### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,40 @@
-# Godot Engine
+# Redot Engine
 
 <p align="center">
-  <a href="https://godotengine.org">
-    <img src="logo_outlined.svg" width="400" alt="Godot Engine logo">
-  </a>
+    <img src="https://private-user-images.githubusercontent.com/12012300/372159356-e24da59f-5104-498b-8716-115ab4802ec0.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjc3MjExNDcsIm5iZiI6MTcyNzcyMDg0NywicGF0aCI6Ii8xMjAxMjMwMC8zNzIxNTkzNTYtZTI0ZGE1OWYtNTEwNC00OThiLTg3MTYtMTE1YWI0ODAyZWMwLnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA5MzAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwOTMwVDE4MjcyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTgzOTY5OWUyZWY5NTc1MjJjYTliYzNjODZiNDBjZjRkZGRmMjZlNjgyNGViNWQ1NzIzZDEwODU0YmFhYTIzMjMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.6c1RHqt81UogWs_Y_27ro-Pg27NY_bohPF-hzMEEMUY" width="400" alt="Redot Engine logo">
 </p>
 
 ## 2D and 3D cross-platform game engine
 
-**[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform
-game engine to create 2D and 3D games from a unified interface.** It provides a
-comprehensive set of [common tools](https://godotengine.org/features), so that
+**[Redot Engine](https://www.redotengine.org) is a feature-packed, cross-platform
+game engine to create 2D and 3D games from a unified interface, based on Godot Engine.** It provides a
+comprehensive set of common tools, so that
 users can focus on making games without having to reinvent the wheel. Games can
 be exported with one click to a number of platforms, including the major desktop
 platforms (Linux, macOS, Windows), mobile platforms (Android, iOS), as well as
-Web-based platforms and [consoles](https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html).
-
-## Free, open source and community-driven
-
-Godot is completely free and open source under the very permissive [MIT license](https://godotengine.org/license).
-No strings attached, no royalties, nothing. The users' games are theirs, down
-to the last line of engine code. Godot's development is fully independent and
-community-driven, empowering users to help shape their engine to match their
-expectations. It is supported by the [Godot Foundation](https://godot.foundation/)
-not-for-profit.
-
-Before being open sourced in [February 2014](https://github.com/godotengine/godot/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
-Godot had been developed by [Juan Linietsky](https://github.com/reduz) and
-[Ariel Manzur](https://github.com/punto-) (both still maintaining the project)
-for several years as an in-house engine, used to publish several work-for-hire
-titles.
-
-![Screenshot of a 3D scene in the Godot Engine editor](https://raw.githubusercontent.com/godotengine/godot-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
+Web-based platforms and consoles.
 
 ## Getting the engine
 
-### Binary downloads
-
-Official binaries for the Godot editor and the export templates can be found
-[on the Godot website](https://godotengine.org/download).
-
 ### Compiling from source
 
-[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
+[See the official docs for Godot](https://docs.godotengine.org/en/latest/contributing/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing
 
-Godot is not only an engine but an ever-growing community of users and engine
-developers. The main community channels are listed [on the homepage](https://godotengine.org/community).
-
-The best way to get in touch with the core engine developers is to join the
-[Godot Contributors Chat](https://chat.godotengine.org).
+Redot is not only an engine but an ever-growing community of users and engine
+developers. The main community is located in the [Discord](https://discord.gg/eWFDjKtd6G).
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 This document also includes guidelines for reporting bugs.
 
 ## Documentation and demos
 
-The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).
-It is maintained by the Godot community in its own [GitHub repository](https://github.com/godotengine/godot-docs).
+The official documentation is not yet hosted.
+It is maintained by the Redot community in its own [GitHub repository](https://github.com/Redot-Engine/redot-docs).
 
-The [class reference](https://docs.godotengine.org/en/latest/classes/)
-is also accessible from the Godot editor.
+The class reference is also accessible from the Redot editor.
 
-We also maintain official demos in their own [GitHub repository](https://github.com/godotengine/godot-demo-projects)
-as well as a list of [awesome Godot community resources](https://github.com/godotengine/awesome-godot).
-
-There are also a number of other
-[learning resources](https://docs.godotengine.org/en/latest/community/tutorials.html)
-provided by the community, such as text and video tutorials, demos, etc.
-Consult the [community channels](https://godotengine.org/community)
-for more information.
-
-[![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
-[![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)
-[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/godotengine/godot)](https://www.tickgit.com/browse?repo=github.com/godotengine/godot)
+We also maintain official demos in their own [GitHub repository](https://github.com/Redot-Engine/redot-demo-projects)
+as well as a list of [awesome Redot community resources](https://github.com/Redot-Engine/redot-awesome).


### PR DESCRIPTION
Removes most references to Godot in the Readme except where required, rebrand to Redot.

Inspired by other PR's with the same intent, this should be superior.