### PR TITLE
Make C# first class citizen in CI.

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -26,17 +26,17 @@ jobs:
             tests: false
             sconsflags: arch=arm64 production=yes
 
-          - name: Template arm32 (target=template_release, arch=arm32)
-            cache-name: android-template-arm32
+          - name: Template arm32 w/ Mono (target=template_release, arch=arm32)
+            cache-name: android-template-arm32-mono
             target: template_release
             tests: false
-            sconsflags: arch=arm32
+            sconsflags: arch=arm32 module_mono_enabled=yes
 
-          - name: Template arm64 (target=template_release, arch=arm64)
-            cache-name: android-template-arm64
+          - name: Template arm64 w/ Mono (target=template_release, arch=arm64)
+            cache-name: android-template-arm64-mono
             target: template_release
             tests: false
-            sconsflags: arch=arm64
+            sconsflags: arch=arm64 module_mono_enabled=yes
 
     steps:
       - name: Checkout

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -6,16 +6,16 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
+  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes module_mono_enabled=yes
 
 concurrency:
   group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-ios
   cancel-in-progress: true
 
 jobs:
-  ios-template:
+  ios-template-mono:
     runs-on: macos-latest
-    name: Template (target=template_release)
+    name: Template w/ Mono (target=template_release)
 
     steps:
       - name: Checkout

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,18 +20,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor, tests=yes)
-            cache-name: macos-editor
+          - name: Editor w/ Mono (target=editor)
+            cache-name: macos-editor-mono
             target: editor
-            tests: true
-            bin: ./bin/godot.macos.editor.universal
+            sconsflags: module_mono_enabled=yes
+            bin: ./bin/godot.macos.editor.mono.universal
+            build-mono: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
 
-          - name: Template (target=template_release, tests=yes)
-            cache-name: macos-template
+          - name: Template w/ Mono (target=template_release)
+            cache-name: macos-template-mono
             target: template_release
             tests: true
-            sconsflags: debug_symbols=no
-            bin: ./bin/godot.macos.template_release.universal
+            build-mono: false
+            sconsflags: debug_symbols=no tests=yes module_mono_enabled=yes
+            bin: ./bin/godot.macos.template_release.mono.universal
 
     steps:
       - name: Checkout
@@ -76,10 +79,20 @@ jobs:
 
       - name: Prepare artifact
         run: |
-          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal
+          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.mono.universal
           rm ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64
           strip bin/godot.*
           chmod +x bin/godot.*
+
+      - name: Generate C# glue
+        if: matrix.build-mono
+        run: |
+          ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue
+
+      - name: Build .NET solutions
+        if: matrix.build-mono
+        run: |
+          ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=macos
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -32,19 +32,30 @@ jobs:
             bin: ./bin/godot.windows.editor.x86_64.exe
             artifact: true
 
-          - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
-            cache-name: windows-editor-clang
+          - name: Editor w/ Mono (target=editor)
+            cache-name: windows-editor-mono
             target: editor
-            tests: true
-            sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes
-            bin: ./bin/godot.windows.editor.x86_64.llvm.exe
+            sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console module_mono_enabled=yes
+            bin: ./bin/godot.windows.editor.x86_64.mono.exe
+            build-mono: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            artifact: true
 
-          - name: Template (target=template_release, tests=yes)
-            cache-name: windows-template
+          - name: Editor w/ Mono and clang-cl (target=editor, use_llvm=yes)
+            cache-name: windows-editor-mono-clang
+            target: editor
+            sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes module_mono_enabled=yes
+            bin: ./bin/godot.windows.editor.x86_64.mono.llvm.exe
+            build-mono: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            artifact: true
+
+          - name: Template w/ Mono (target=template_release, tests=yes)
+            cache-name: windows-template-mono
             target: template_release
             tests: true
-            sconsflags: debug_symbols=no
-            bin: ./bin/godot.windows.template_release.x86_64.console.exe
+            sconsflags: debug_symbols=no module_mono_enabled=yes
+            bin: ./bin/godot.windows.template_release.x86_64.mono.console.exe
             artifact: true
 
     steps:
@@ -92,6 +103,16 @@ jobs:
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
+
+      - name: Generate C# glue
+        if: matrix.build-mono
+        run: |
+          ${{ matrix.bin }} --headless --generate-mono-glue ./modules/mono/glue
+
+      - name: Build .NET solutions
+        if: matrix.build-mono
+        run: |
+          python ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
 
       - name: Prepare artifact
         if: ${{ matrix.artifact }}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Make C# first citizen in CI:
Generate editor and export templates other than Linux with Mono enabled