### PR TITLE
Fix parsing preview MSBuild versions

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -825,7 +825,16 @@ def get_compiler_version(env):
             for line in version.splitlines():
                 split = line.split(":", 1)
                 if split[0] == "catalog_productDisplayVersion":
-                    sem_ver = split[1].split(".")
+                    # When Visual Studio Preview is installed, the display string
+                    # contains a space followed by the preview version.
+                    # Example: "xx.xx.xx Preview x.x"
+                    catalog_version = split[1].strip()
+                    space = catalog_version.find(" ")
+
+                    if space != -1:
+                        catalog_version = catalog_version[:space]
+
+                    sem_ver = catalog_version.split(".")
                     ret["major"] = int(sem_ver[0])
                     ret["minor"] = int(sem_ver[1])
                     ret["patch"] = int(sem_ver[2])


### PR DESCRIPTION
Running `scons` while having a preview version of MSBuild installed (with Visual Studio Preview) will result in the following error:

```
$ scons
scons: Reading SConscript files ...
Automatically detected platform: windows
Auto-detected 24 CPU cores available for build parallelism. Using 23 cores by default. You can override it with the `-j` or `num_jobs` arguments.
Using SCons-detected MSVC version 14.3, arch x86_64
Building for platform "windows", architecture "x86_64", target "editor".
ValueError: invalid literal for int() with base 10: '0 Preview 2':
  File "C:\Sources\redot-engine\SConstruct", line 642:
    cc_version = methods.get_compiler_version(env)
  File "C:\Sources\redot-engine\methods.py", line 831:
    ret["patch"] = int(sem_ver[2])
```

The Visual Studio Preview that I have installed is: 17.12.0 Preview 2.1

After checking, in methods.py the catalog version is being split by the '.' character, which results in the following array:
```
["17", "12", "0 Preview 2", "1"]
 ^^^   ^^^^  ^^^^^^^^^^^^^  ^^^
  |     |         |          |
  |     |         |          +--- Unused/invalid
  |     |         +--- Patch
  |     +--- Minor
  +--- Major
```
Then the patch version is being converted to an integer, which fails because it contains non-numeric characters.

This PR checks if the version has a space in it and trims everything after the space; causing the conversion to succeed.

<details>
  <summary>Screenshot of Visual Studio Installer</summary>
    
  ![image](https://github.com/user-attachments/assets/f85321e7-f525-47ae-ada3-dd69ab51c84c)
  
</details>


