### PR TITLE
Node3D editor: Added tooltips for Grid Snap and Local Space transform toggles

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8699,6 +8699,7 @@ Node3DEditor::Node3DEditor() {
 
 	tool_option_button[TOOL_OPT_LOCAL_COORDS] = memnew(Button);
 	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_LOCAL_COORDS]);
+	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_tooltip_text(TTR("Toggles whether gizmo transformations are applied relative to the selected node."));
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_theme_type_variation("FlatButton");
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_LOCAL_COORDS));
@@ -8707,6 +8708,7 @@ Node3DEditor::Node3DEditor() {
 
 	tool_option_button[TOOL_OPT_USE_SNAP] = memnew(Button);
 	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_USE_SNAP]);
+	tool_option_button[TOOL_OPT_USE_SNAP]->set_tooltip_text(TTR("Toggles whether nodes will snap to the editor grid."));
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_theme_type_variation("FlatButton");
 	tool_option_button[TOOL_OPT_USE_SNAP]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_USE_SNAP));


### PR DESCRIPTION
A very small PR to fix a lingering inconsistency with the buttons in the Node3D editor view, in that the Use Local and Grid Snap toggles didn't have tooltips when hovered.

The results:
![image](https://github.com/user-attachments/assets/07d4b7be-78fd-4a5a-af81-c67d563bf9d5)
![image](https://github.com/user-attachments/assets/c7edbe10-3dd4-4538-8e3a-46e62b687457)
