### PR TITLE
Added a Nix flake containing everything needed to build, dev and run …

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "revCount": 655136,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.655136%2Brev-1d9c2c9b3e71b9ee663d11c5d298727dace8d374/0190cd4f-c0eb-72cb-834b-ac854aa282dc/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "A Nix-flake-based C/C++ development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        f rec {
+          pkgs = import nixpkgs {inherit system;};
+          deps = with pkgs; [
+            pkg-config
+            autoPatchelfHook
+            installShellFiles
+            python3
+            speechd
+            wayland-scanner
+            makeWrapper
+            mono
+            dotnet-sdk_8
+            dotnet-runtime_8
+            vulkan-loader
+            libGL
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXinerama
+            xorg.libXext
+            xorg.libXrandr
+            xorg.libXrender
+            xorg.libXi
+            xorg.libXfixes
+            libxkbcommon
+            alsa-lib
+            mono
+            wayland-scanner
+            wayland
+            libdecor
+            libpulseaudio
+            dbus
+            dbus.lib
+            speechd
+            fontconfig
+            fontconfig.lib
+            udev
+            dotnet-sdk_8
+            dotnet-runtime_8
+            scons
+          ];
+        });
+  in {
+    devShells = forEachSupportedSystem ({
+      pkgs,
+      deps,
+    }: {
+      default =
+        pkgs.mkShell.override
+        {
+          # Override stdenv in order to change compiler:
+          # stdenv = pkgs.clangStdenv;
+        }
+        {
+          packages = deps;
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath deps;
+        };
+    });
+  };
+}


### PR DESCRIPTION
This is a Nix Flake for NixOS and anyone with nix package manager installed on their system.

It allow people to enter into the flake dev shell as followed:
`nix develop` and it will install all the listed dependencies to build and run redot avoiding the pain of having to workout what dependencies you need to install and what missing.