### PR TITLE
Changing the default color theme to a red base tone.

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -317,8 +317,8 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_contrast = 0.0;
 				preset_draw_extra_borders = true;
 			} else { // Default
-				preset_accent_color = Color(0.44, 0.73, 0.98);
-				preset_base_color = Color(0.21, 0.24, 0.29);
+				preset_accent_color = Color(0.23, 0.11, 0.16);
+				preset_base_color = Color(0.14, 0.12, 0.12);
 				preset_contrast = config.default_contrast;
 			}
 


### PR DESCRIPTION
Changes the base tone to red, to match reddot theme. It's a grayish red with accessibility in mind.