### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "revCount": 688563,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.688563%2Brev-bc947f541ae55e999ffdb4013441347d83b00feb/01925b66-3b70-71bd-b277-924a6c208ba7/source.tar.gz?rev=bc947f541ae55e999ffdb4013441347d83b00feb&revCount=688563"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "A Nix-flake-based C/C++ development environment";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+    }:
+    let
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs (import systems) (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      packages = forEachSupportedSystem (
+        {
+          pkgs,
+        }:
+        {
+          default =
+            pkgs.callPackage ./package.nix
+              {
+              };
+        }
+      );
+      devShells = forEachSupportedSystem (
+        {
+          pkgs,
+        }:
+        {
+          default =
+            pkgs.mkShell.override
+              {
+                # Override stdenv in order to change compiler:
+                # stdenv = pkgs.clangStdenv;
+              }
+              rec {
+                packages =
+                  with pkgs;
+                  [
+                    pkgconf
+                    autoPatchelfHook
+                    installShellFiles
+                    python3
+                    makeWrapper
+                    dotnet-sdk_8
+                    dotnet-runtime_8
+                    vulkan-loader
+                    vulkan-headers
+                    fontconfig
+                    fontconfig.lib
+                    scons
+                  ]
+                  ++ pkgs.lib.optionals pkgs.stdenv.targetPlatform.isLinux [
+                    speechd
+                    alsa-lib
+                    xorg.libX11
+                    xorg.libXcursor
+                    xorg.libXinerama
+                    xorg.libXext
+                    xorg.libXrandr
+                    xorg.libXrender
+                    xorg.libXi
+                    xorg.libXfixes
+                    libxkbcommon
+                    dbus
+                    dbus.lib
+                    udev
+                    wayland-scanner
+                    wayland
+                    libdecor
+                    libpulseaudio
+                  ];
+                LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath packages;
+              };
+        }
+      );
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  lib,
+  enableWayland ? stdenv.targetPlatform.isLinux,
+  enablePulseAudio ? stdenv.targetPlatform.isLinux,
+  enableX11 ? stdenv.targetPlatform.isLinux,
+  enableAlsa ? stdenv.targetPlatform.isLinux,
+  enableSpeechd ? stdenv.targetPlatform.isLinux,
+  enableVulkan ? true,
+  pkgconf,
+  autoPatchelfHook,
+  installShellFiles,
+  python3,
+  scons,
+  makeWrapper,
+  vulkan-loader,
+  vulkan-headers,
+  speechd,
+  fontconfig,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+  libdecor,
+  libxkbcommon,
+  libpulseaudio,
+  xorg,
+  udev,
+  alsa-lib,
+  dbus,
+  xcbuild,
+  darwin,
+}:
+
+stdenv.mkDerivation {
+  name = "redot-engine";
+  src = ./.;
+
+  buildInputs =
+    [
+      pkgconf
+      autoPatchelfHook
+      installShellFiles
+      python3
+      makeWrapper
+      scons
+      fontconfig
+    ]
+    ++ lib.optionals enableSpeechd [ speechd ]
+    ++ lib.optionals enableVulkan [
+      vulkan-loader
+      vulkan-headers
+    ]
+    ++ lib.optionals enableWayland [
+      wayland
+      wayland-scanner
+      wayland-protocols
+      libdecor
+      libxkbcommon
+    ]
+    ++ lib.optionals enablePulseAudio [ libpulseaudio ]
+    ++ lib.optionals enableX11 [
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXinerama
+      xorg.libXext
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXi
+      xorg.libXfixes
+    ]
+    ++ lib.optionals enableAlsa [ alsa-lib ]
+    ++ lib.optionals stdenv.targetPlatform.isLinux [
+      udev
+      dbus
+    ]
+    ++ lib.optionals stdenv.targetPlatform.isDarwin [
+      xcbuild
+      darwin.moltenvk
+    ]
+    ++ lib.optionals stdenv.targetPlatform.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AppKit
+      ]
+    );
+
+  sconsFlags = lib.optionals stdenv.targetPlatform.isDarwin [
+    "vulkan_sdk_path=${darwin.moltenvk}"
+  ];
+}

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -137,7 +137,11 @@ def detect_mvk(env, osname):
         )
 
     for mvk_path in mvk_list:
+        # FIXME: Iterate over all files in the sdk path
         if mvk_path and os.path.isfile(os.path.join(mvk_path, f"{osname}/libMoltenVK.a")):
+            print(f"MoltenVK found at: {mvk_path}")
+            return mvk_path
+        elif mvk_path and os.path.isfile(os.path.join(mvk_path, f"lib/libMoltenVK.dylib")):
             print(f"MoltenVK found at: {mvk_path}")
             return mvk_path
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Based on #154, this PR adds a nix flake.
The changes I've made compared to #154 are:
- Added a Nix derivation
- Added support for other systems (e.g. riscv64) via nix-systems
- Used nixfmt (nixfmt-rfc-style package) for formatting

Darwin support is still WIP which is why I made this a draft. It seems like AppKit/AppKit.h is not being found despite it being present in buildInputs. 
Additionally, I had to temporarily modify platform_methods.py to allow finding moltenVK in `${darwin.moltenvk}/lib/libMoltenVK.dylib`. This could probably be improved with a proper lookup of the entire sdk directory instead of looking in lib or other hard coded paths 🤔 