### PR TITLE
Binary name generator update.  MUST BE DONE TO EVERY SCsub

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -56,7 +56,7 @@ env.Depends(res_obj, "#core/version_generated.gen.h")
 env.add_source_files(sources, common_win)
 sources += res_obj
 
-prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+prog = env.add_program("#bin/redot", sources, PROGSUFFIX=env["PROGSUFFIX"])
 arrange_program_clean(prog)
 
 # Build console wrapper app.
@@ -74,7 +74,7 @@ if env["windows_subsystem"] == "gui":
         env_wrap.Append(LINKFLAGS=["-Wl,--subsystem,console"])
         env_wrap.Append(LIBS=["version"])
 
-    prog_wrap = env_wrap.add_program("#bin/godot", common_win_wrap + res_wrap_obj, PROGSUFFIX=env["PROGSUFFIX_WRAP"])
+    prog_wrap = env_wrap.add_program("#bin/redot", common_win_wrap + res_wrap_obj, PROGSUFFIX=env["PROGSUFFIX_WRAP"])
     arrange_program_clean(prog_wrap)
     env_wrap.Depends(prog_wrap, prog)
     sources += common_win_wrap + res_wrap_obj


### PR DESCRIPTION
updated the SCsub so that generated binary will have "redot." in the name instead of "godot." in the name. should be done to every SCsub in platform/. 
this PR will be updated.