### PR TITLE
Tcp issue 31 bugfix proposal

### DIFF
--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -104,6 +104,10 @@ public:
 		return _queued;
 	}
 
+	int space_left() const {
+		return _payload.space_left();
+	}
+
 	void clear() {
 		_payload.resize(0);
 		_packets.resize(0);

--- a/modules/websocket/websocket_peer.cpp
+++ b/modules/websocket/websocket_peer.cpp
@@ -70,6 +70,9 @@ void WebSocketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_max_queued_packets", "buffer_size"), &WebSocketPeer::set_max_queued_packets);
 	ClassDB::bind_method(D_METHOD("get_max_queued_packets"), &WebSocketPeer::get_max_queued_packets);
 
+	ClassDB::bind_method(D_METHOD("set_min_buffer_free_space", "min_buffer_free_space"), &WebSocketPeer::set_min_buffer_free_space);
+	ClassDB::bind_method(D_METHOD("get_min_buffer_free_space"), &WebSocketPeer::get_min_buffer_free_space);
+
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "supported_protocols"), "set_supported_protocols", "get_supported_protocols");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "handshake_headers"), "set_handshake_headers", "get_handshake_headers");
 
@@ -77,6 +80,7 @@ void WebSocketPeer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "outbound_buffer_size"), "set_outbound_buffer_size", "get_outbound_buffer_size");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_queued_packets"), "set_max_queued_packets", "get_max_queued_packets");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "min_buffer_free_space"), "set_min_buffer_free_space", "get_min_buffer_free_space");
 
 	BIND_ENUM_CONSTANT(WRITE_MODE_TEXT);
 	BIND_ENUM_CONSTANT(WRITE_MODE_BINARY);
@@ -150,4 +154,12 @@ void WebSocketPeer::set_max_queued_packets(int p_max_queued_packets) {
 
 int WebSocketPeer::get_max_queued_packets() const {
 	return max_queued_packets;
+}
+
+void WebSocketPeer::set_min_buffer_free_space(int p_min_buffer_free_space) {
+	min_buffer_free_space = p_min_buffer_free_space;
+}
+
+int WebSocketPeer::get_min_buffer_free_space() const {
+	return min_buffer_free_space;
 }

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -72,6 +72,7 @@ protected:
 	int outbound_buffer_size = DEFAULT_BUFFER_SIZE;
 	int inbound_buffer_size = DEFAULT_BUFFER_SIZE;
 	int max_queued_packets = 2048;
+	int min_buffer_free_space = 4096;
 
 public:
 	static WebSocketPeer *create(bool p_notify_postinitialize = true) {
@@ -116,6 +117,9 @@ public:
 
 	void set_max_queued_packets(int p_max_queued_packets);
 	int get_max_queued_packets() const;
+
+	void set_min_buffer_free_space(int p_min_buffer_free_space);
+	int get_min_buffer_free_space() const;
 
 	WebSocketPeer();
 	~WebSocketPeer();

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -563,6 +563,8 @@ Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
 ///
 ssize_t WSLPeer::_wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data) {
 	WSLPeer *peer = (WSLPeer *)user_data;
+	if (peer->in_buffer.space_left() < 4096) // remove majic number and allow user to set value
+		return WSLAY_ERR_NOMEM;
 	Ref<StreamPeer> conn = peer->connection;
 	if (conn.is_null()) {
 		wslay_event_set_error(ctx, WSLAY_ERR_CALLBACK_FAILURE);

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -563,7 +563,7 @@ Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
 ///
 ssize_t WSLPeer::_wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data) {
 	WSLPeer *peer = (WSLPeer *)user_data;
-	if (peer->in_buffer.space_left() < 4096) // remove majic number and allow user to set value
+	if (peer->in_buffer.space_left() < peer->min_buffer_free_space)
 		return WSLAY_ERR_NOMEM;
 	Ref<StreamPeer> conn = peer->connection;
 	if (conn.is_null()) {


### PR DESCRIPTION
Added a fix to #31 

Using the MRP provided on the linked godot issue all messages now come through without issue.

32bit and 64bit test suits have been run locally as passing.

Issue stemmed from the implementation around Wslay not interrupting the reciving of packets when the in_buffer was nearly full. 


![image](https://github.com/user-attachments/assets/458fec2b-2818-43bc-ac38-df4e4729916c)


![image](https://github.com/user-attachments/assets/0e28d961-3d1c-415e-8c36-db7a780ebbe6)


![image](https://github.com/user-attachments/assets/a9ec9947-074d-42c5-a498-093132eebce0)
