### PR TITLE
Implement basic C# translation parser plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a bug in Godot
+description: Report a bug in Redot
 
 body:
   - type: markdown
@@ -8,8 +8,8 @@ body:
         When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
         - Write a descriptive issue title above.
         - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
-        - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-        - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
+        - Search [open](https://github.com/Redot-Engine/redot-engine/issues) and [closed](https://github.com/Redot-Engine/redot-engine/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
+        - Verify that you are using a [supported Godot version](https://docs.redotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
         - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
 
   - type: textarea
@@ -17,8 +17,8 @@ body:
       label: Tested versions
       description: |
         To properly fix a bug, we need to identify if the bug was recently introduced in the engine, or if it was always present.
-        - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
-        - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
+        - Please specify the Redot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Redot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
+        - If you can, **please test earlier Redot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Redot releases in our [download archive](https://redotengine.org/download/archive/).
         - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
       placeholder: |
 
@@ -35,8 +35,8 @@ body:
         - For issues that are likely OS-specific and/or graphics-related, please specify the CPU model and architecture.
         - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
         - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
-        - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
-      placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
+        - **Starting from Redot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
+      placeholder: Windows 10 - Redot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
     validations:
       required: true
 
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Minimal reproduction project (MRP)
       description: |
-        - A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
+        - A small Redot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
         - Having an MRP is very important for contributors to be able to reproduce the bug in the same way that you are experiencing it. When testing a potential fix for the issue, contributors will use the MRP to validate that the fix is working as intended.
         - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
         - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: Godot proposals
-    url: https://github.com/godotengine/godot-proposals
-    about: Please submit feature proposals on the Godot proposals repository, not here.
+  - name: Redot proposals
+    url: https://github.com/Redot-Engine/redot-proposals
+    about: Please submit feature proposals on the Redot proposals repository, not here.
 
-  - name: Godot documentation repository
-    url: https://github.com/godotengine/godot-docs
-    about: Please report issues with documentation on the Godot documentation repository, not here.
+  - name: Redot documentation repository
+    url: https://github.com/Redot-Engine/redot-docs
+    about: Please report issues with documentation on the Redot documentation repository, not here.
 
-  - name: Godot community channels
-    url: https://godotengine.org/community
+  - name: Redot community channels
+    url: https://redotengine.org/community
     about: Please ask for technical support on one of the other community channels, not here.

--- a/modules/mono/editor/csharp_translation_parser_plugin.cpp
+++ b/modules/mono/editor/csharp_translation_parser_plugin.cpp
@@ -2,11 +2,10 @@
 /*  csharp_translation_parser_plugin.cpp                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
-/*                             GODOT ENGINE                               */
-/*                        https://godotengine.org                         */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
 /**************************************************************************/
-/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
-/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/* Copyright (c) 2024-present Redot Engine contributors (see AUTHORS.md). */
 /*                                                                        */
 /* Permission is hereby granted, free of charge, to any person obtaining  */
 /* a copy of this software and associated documentation files (the        */

--- a/modules/mono/editor/csharp_translation_parser_plugin.cpp
+++ b/modules/mono/editor/csharp_translation_parser_plugin.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************/
+/*  csharp_translation_parser_plugin.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "csharp_translation_parser_plugin.h"
+#include "../csharp_script.h"
+
+#include "core/io/resource_loader.h"
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/io/resource.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/templates/list.h"
+#include "core/templates/vector.h"
+
+
+void CSharpEditorTranslationParserPlugin::get_recognized_extensions(List<String>* r_extensions) const {
+	r_extensions->push_back("cs");
+}
+
+Error CSharpEditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) {
+	Error err;
+	Ref<Resource> loaded_res = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+	ERR_FAIL_COND_V_MSG(err, err, "Failed to load " + p_path);
+
+	ids = r_ids;
+	ids_ctx_plural = r_ids_ctx_plural;
+	Ref<CSharpScript> csharp = loaded_res;
+	String source_code = csharp->get_source_code();
+
+	// Iterate through all matches.
+	_find_translation_ids(source_code);
+
+	return OK;
+}
+
+void CSharpEditorTranslationParserPlugin::_find_translation_ids(const String &source_code) {
+	// Extract translation ids from Tr calls.
+	int i = 0;
+	Vector<Vector<String>> args = _find_method_args(source_code, tr_func);
+	for (Vector<Vector<String>>::Iterator itr = args.begin(); itr != args.end(); ++itr, ++i) {
+		_parse_tr_atr_args(&args[i]);
+	}
+
+	// Extract translation ids from TrN calls.
+	i = 0;
+	args = _find_method_args(source_code, trn_func);
+	for (Vector<Vector<String>>::Iterator itr = args.begin(); itr != args.end(); ++itr, ++i) {
+		_parse_trn_atrn_args(&args[i]);
+	}
+
+	// Extract translation ids from Atr calls.
+	i = 0;
+	args = _find_method_args(source_code, atr_func);
+	for (Vector<Vector<String>>::Iterator itr = args.begin(); itr != args.end(); ++itr, ++i) {
+		_parse_tr_atr_args(&args[i]);
+	}
+
+	// Extract translation ids from AtrN calls.
+	i = 0;
+	args = _find_method_args(source_code, atrn_func);
+	for (Vector<Vector<String>>::Iterator itr = args.begin(); itr != args.end(); ++itr, ++i) {
+		_parse_trn_atrn_args(&args[i]);
+	}
+}
+
+Vector<Vector<String>> CSharpEditorTranslationParserPlugin::_find_method_args(const String &source_code, const String method_name) {
+	Vector<Vector<String>> all_args;
+	int start = 0;
+	while ((start = source_code.find(method_name + "(", start)) != -1) {
+		// Locate the opening and closing parentheses.
+		int open_paren = source_code.find("(", start);
+		int close_paren = source_code.find(")", open_paren);
+
+		if (open_paren == -1 || close_paren == -1) {
+			break;
+		}
+
+		// Extract arguments between the parentheses.
+		Vector<String> args = source_code.substr(open_paren + 1, close_paren - open_paren - 1).split(",");
+
+		if (args.size() == 0) {
+			continue;
+		}
+
+		all_args.push_back(args);
+
+		// Move past this method call for the next iteration.
+		start = close_paren + 1;
+	}
+
+	return all_args;
+}
+
+void CSharpEditorTranslationParserPlugin::_parse_tr_atr_args(const Vector<String> *args) {
+	if (args->size() < 1) {
+		return;
+	}
+
+	String msg_id_arg = args->get(0);
+	Vector<String> id_ctx;
+	id_ctx.resize(3);
+
+	// Skip non string literals.
+	if (!_is_string_literal(msg_id_arg)) {
+		return;
+	}
+
+	// Extract message id.
+	String msg_id = msg_id_arg.strip_edges().substr(1, msg_id_arg.length() - 2);
+	id_ctx.set(0, msg_id);
+
+	// Extract context.
+	if (args->size() == 2) {
+		String ctx_arg = args->get(1);
+
+		if (_is_string_literal(ctx_arg)) {
+			String ctx = ctx_arg.strip_edges().substr(1, ctx_arg.length() - 2);
+			id_ctx.set(1, ctx);
+		}
+	}
+
+	ids_ctx_plural->push_back(id_ctx);
+}
+
+void CSharpEditorTranslationParserPlugin::_parse_trn_atrn_args(const Vector<String> *args) {
+	if (args->size() < 3) {
+		return;
+	}
+
+	String msg_id_singular_arg = args->get(0);
+	String msg_id_plural_arg = args->get(1);
+	Vector<String> id_ctx_plural;
+	id_ctx_plural.resize(3);
+
+	// Skip non string literals.
+	if (!_is_string_literal(msg_id_singular_arg) || !_is_string_literal(msg_id_plural_arg)) {
+		return;
+	}
+
+	// Extract singular message id.
+	String msg_id_singular = msg_id_singular_arg.strip_edges().substr(1, msg_id_singular_arg.length() - 2);
+	id_ctx_plural.set(0, msg_id_singular);
+
+	// Extract plural message id.
+	String msg_id_plural = msg_id_plural_arg.strip_edges().substr(1, msg_id_plural_arg.length() - 2);
+	id_ctx_plural.set(2, msg_id_singular);
+
+	bool extract_ctx = false;
+
+	// Extract context.
+	if (args->size() == 4) {
+		String ctx_arg = args->get(3);
+
+		if (_is_string_literal(ctx_arg)) {
+			String ctx = ctx_arg.strip_edges().substr(1, ctx_arg.length() - 2);
+			id_ctx_plural.set(1, ctx);
+		}
+	}
+
+	ids_ctx_plural->push_back(id_ctx_plural);
+}
+
+bool CSharpEditorTranslationParserPlugin::_is_string_literal(const String code) {
+	return code.begins_with("\"") || code.ends_with("\"");
+}
+
+CSharpEditorTranslationParserPlugin::CSharpEditorTranslationParserPlugin() {}

--- a/modules/mono/editor/csharp_translation_parser_plugin.h
+++ b/modules/mono/editor/csharp_translation_parser_plugin.h
@@ -2,11 +2,10 @@
 /*  csharp_translation_parser_plugin.h                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
-/*                             GODOT ENGINE                               */
-/*                        https://godotengine.org                         */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
 /**************************************************************************/
-/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
-/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/* Copyright (c) 2024-present Redot Engine contributors (see AUTHORS.md). */
 /*                                                                        */
 /* Permission is hereby granted, free of charge, to any person obtaining  */
 /* a copy of this software and associated documentation files (the        */


### PR DESCRIPTION
This PR implements a basic C# translation parser plugin. It extracts `Tr`, `TrN`, `Atr` and `AtrN` calls from C# scripts and generates entries for the POT file generator. The implementation is very basic compared to the GDScript translation parser because we can't properly parse C# source code for obvious reasons.

I have no prior C++ experience at all. I only implemented this because I needed it for my project.