### PR TITLE
fix: uses the exposed Redot global instead of the no longer existing Godot

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -59,7 +59,7 @@ for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 
 build = []
-build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm", "#bin/godot${PROGSUFFIX}.worker.js"]
+build_targets = ["#bin/redot${PROGSUFFIX}.js", "#bin/redot${PROGSUFFIX}.wasm", "#bin/redot${PROGSUFFIX}.worker.js"]
 if env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
@@ -97,14 +97,14 @@ engine = [
     "js/engine/engine.js",
 ]
 externs = [env.File("#platform/web/js/engine/engine.externs.js")]
-js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
+js_engine = env.CreateEngineFile("#bin/redot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
 env.Depends(js_engine, externs)
 
 wrap_list = [
     build[0],
     js_engine,
 ]
-js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+js_wrapped = env.Textfile("#bin/redot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
 
 # 0 - unwrapped js file (use wrapped one instead)
 # 1 - wasm file

--- a/platform/web/eslint.config.cjs
+++ b/platform/web/eslint.config.cjs
@@ -130,6 +130,7 @@ module.exports = [
 				...globals.browser,
 				'Features': true,
 				'Godot': true,
+				'Redot': true,
 				'InternalConfig': true,
 				'Preloader': true,
 			},

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -293,7 +293,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 				return {};
 			},
 			'locateFile': function (path) {
-				if (!path.startsWith('godot.')) {
+				if (!path.startsWith('godot.') && !path.startsWith('redot.')) {
 					return path;
 				} else if (path.endsWith('.worker.js')) {
 					return `${loadPath}.worker.js`;

--- a/platform/web/js/engine/engine.externs.js
+++ b/platform/web/js/engine/engine.externs.js
@@ -1,4 +1,4 @@
-var Godot;
+var Redot;
 var WebAssembly = {};
 WebAssembly.instantiate = function(buffer, imports) {};
 WebAssembly.instantiateStreaming = function(response, imports) {};

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -93,7 +93,7 @@ const Engine = (function () {
 					return new Promise(function (resolve, reject) {
 						promise.then(function (response) {
 							const cloned = new Response(response.clone().body, { 'headers': [['content-type', 'application/wasm']] });
-							Godot(me.config.getModuleConfig(loadPath, cloned)).then(function (module) {
+							Redot(me.config.getModuleConfig(loadPath, cloned)).then(function (module) {
 								const paths = me.config.persistentPaths;
 								module['initFS'](paths).then(function (err) {
 									me.rtenv = module;


### PR DESCRIPTION
The error this fixes can be reproduced by setting up export templates then clicking 
![image](https://github.com/user-attachments/assets/3822c30f-ca74-4c25-9f30-66d9c12c439d)

![image](https://github.com/user-attachments/assets/4ab19552-f558-44c5-91d9-791fde529d28)

![image](https://github.com/user-attachments/assets/0ded6226-abcb-4b97-94d5-3a2edaeea861)

here's my GMTK 2024 game running on a web export for REDOT

![image](https://github.com/user-attachments/assets/bbdda0e9-0319-42f4-98a7-4cee70d3ded4)

