### PR TITLE
User viewable msgs changed for rebrand on HTML export dists

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
-		<meta name="author" content="Godot Engine">
+		<meta name="author" content="Redot Engine">
 		<meta name="description" content="Use the Redot Engine editor directly in your web browser, without having to install anything.">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-capable" content="yes">
@@ -243,7 +243,7 @@ a:active {
 				<h2 id="welcome-modal-title" class="welcome-modal-title">Important - Please read before continuing</h2>
 				<div id="welcome-modal-description">
 					<p>
-						The Godot Web Editor has some limitations compared to the native version.
+						The Redot Web Editor has some limitations compared to the native version.
 						Its main focus is education and experimentation;
 						<strong>it is not recommended for production</strong>.
 					</p>
@@ -258,7 +258,7 @@ a:active {
 				</div>
 				<div id="welcome-modal-missing-description" style="display: none">
 					<p>
-						<strong>The following features required by the Godot Web Editor are missing:</strong>
+						<strong>The following features required by the Redot Web Editor are missing:</strong>
 					</p>
 					<ul id="welcome-modal-missing-list">
 					</ul>
@@ -291,7 +291,7 @@ a:active {
 			<div id="tab-loader">
 				<div style="color: #e0e0e0;" id="persistence">
 					<br >
-					<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px">
+					<img src="logo.svg" alt="Redot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px">
 					<br >
 					___GODOT_VERSION___
 					<br >

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
-		<meta name="author" content="Redot Engine"> 
+		<meta name="author" content="Redot Engine">
 		<meta name="description" content="Use the Redot Engine editor directly in your web browser, without having to install anything.">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-capable" content="yes">

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
-		<meta name="author" content="Redot Engine">
+		<meta name="author" content="Redot Engine"> 
 		<meta name="description" content="Use the Redot Engine editor directly in your web browser, without having to install anything.">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-capable" content="yes">

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -172,7 +172,7 @@ const engine = new Engine(GODOT_CONFIG);
 			});
 		} else {
 			// Display the message as usual
-			const missingMsg = 'Error\nThe following features required to run Godot projects on the Web are missing:\n';
+			const missingMsg = 'Error\nThe following features required to run Redot projects on the Web are missing:\n';
 			displayFailureNotice(missingMsg + missing.join('\n'));
 		}
 	} else {


### PR DESCRIPTION
User viewable messages altered to replace branding.  Some URLs error messages point to will need to be changed in the future when redot-docs is publicly available and hosted via URL, but that can wait.