### PR TITLE
Branding change on About->Third-party Licenses widget

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -270,7 +270,7 @@ EditorAbout::EditorAbout() {
 	Label *tpl_label = memnew(Label);
 	tpl_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tpl_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-	tpl_label->set_text(TTR("Godot Engine relies on a number of third-party free and open source libraries, all compatible with the terms of its MIT license. The following is an exhaustive list of all such third-party components with their respective copyright statements and license terms."));
+	tpl_label->set_text(TTR("Redot Engine relies on a number of third-party free and open source libraries, all compatible with the terms of its MIT license. The following is an exhaustive list of all such third-party components with their respective copyright statements and license terms."));
 	tpl_label->set_size(Size2(630, 1) * EDSCALE);
 	license_thirdparty->add_child(tpl_label);
 


### PR DESCRIPTION
Branding change.  This is unrelated to the COPYRIGHT.txt which feeds the lists below it.

![image](https://github.com/user-attachments/assets/39ed1cab-155f-4804-851e-80c3e0bc9c84)
