### PR TITLE
Various editor strings (rebranding)

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -1105,7 +1105,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	install_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	install_file_dialog->set_current_dir(EDITOR_DEF("_export_template_download_directory", ""));
-	install_file_dialog->add_filter("*.tpz", TTR("Godot Export Templates"));
+	install_file_dialog->add_filter("*.tpz", TTR("Redot Export Templates"));
 	install_file_dialog->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_file_selected).bind(false));
 	add_child(install_file_dialog);
 

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -266,7 +266,7 @@ void ExportTemplateManager::_refresh_mirrors() {
 	is_refreshing_mirrors = true;
 
 	String current_version = VERSION_FULL_CONFIG;
-	const String mirrors_metadata_url = "https://godotengine.org/mirrorlist/" + current_version + ".json";
+	const String mirrors_metadata_url = "https://redotengine.org/mirrorlist/" + current_version + ".json";
 	request_mirrors->request(mirrors_metadata_url);
 }
 
@@ -1105,7 +1105,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	install_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	install_file_dialog->set_current_dir(EDITOR_DEF("_export_template_download_directory", ""));
-	install_file_dialog->add_filter("*.tpz", TTR("Redot Export Templates"));
+	install_file_dialog->add_filter("*.tpz", TTR("Godot Export Templates"));
 	install_file_dialog->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_file_selected).bind(false));
 	add_child(install_file_dialog);
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -221,7 +221,7 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 
 	String proj_name = GLOBAL_GET("application/config/name");
 	if (proj_name.is_empty()) {
-		proj_name = "Godot Game";
+		proj_name = "Redot Game";
 	}
 
 	// Service worker

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1409,7 +1409,7 @@ void DisplayServerWindows::screen_set_keep_on(bool p_enable) {
 	}
 
 	if (p_enable) {
-		const String reason = "Godot Engine running with display/window/energy_saving/keep_screen_on = true";
+		const String reason = "Redot Engine running with display/window/energy_saving/keep_screen_on = true";
 		Char16String reason_utf16 = reason.utf16();
 
 		REASON_CONTEXT context;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -441,13 +441,13 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 						"$trigger = New-ScheduledTaskTrigger -Once -At 00:00\n"
 						"$settings = New-ScheduledTaskSettingsSet\n"
 						"$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings\n"
-						"Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true\n"
-						"Start-ScheduledTask -TaskName godot_remote_debug\n"
-						"while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }\n"
-						"Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue";
+						"Register-ScheduledTask redot_remote_debug -InputObject $task -Force:$true\n"
+						"Start-ScheduledTask -TaskName redot_remote_debug\n"
+						"while (Get-ScheduledTask -TaskName redot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }\n"
+						"Unregister-ScheduledTask -TaskName redot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue";
 
-	String cleanup_script = "Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue\n"
-							"Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue\n"
+	String cleanup_script = "Stop-ScheduledTask -TaskName redot_remote_debug -ErrorAction:SilentlyContinue\n"
+							"Unregister-ScheduledTask -TaskName redot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue\n"
 							"Remove-Item -Recurse -Force '{temp_dir}'";
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ssh_remote_deploy/enabled"), false, true));


### PR DESCRIPTION
- Rebrand scheduled task for runnable deploy ssh option
- Export template manager string update
- web export proj name altered if no proj name set
- string change in display_server_windows.cpp

Just a few string replacements and an update to the remote SSH options that changed the scheduled task name on the remote Windows target device