### PR TITLE
Use "Redot Red" for accent color in Light theme.

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -303,7 +303,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_base_color = Color(0.24, 0.24, 0.24);
 				preset_contrast = config.default_contrast;
 			} else if (config.preset == "Light") {
-				preset_accent_color = Color(0.18, 0.50, 1.00);
+				preset_accent_color = Color(0.87, 0.22, 0.29);
 				preset_base_color = Color(0.9, 0.9, 0.9);
 				// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
 				preset_contrast = -0.06;


### PR DESCRIPTION
This update changes the "Light" theme in the editor to use red rather than blue for its primary accent color to stay "on-brand."

The desired effect of this change is that users who prefer light themes over dark themes will still have an experience that feels like Redot rather than Godot, so that Redot can have its trademark dark mode theme and an accompanying light mode.

![screenshot 1, showing the theme selector on the project list](https://github.com/user-attachments/assets/79583bbb-2830-4314-a5c1-77868bd005ac)
![screenshot 2, showing the editor in use with a script open](https://github.com/user-attachments/assets/133b0b16-e475-4f82-bee4-a84f3163a9b3)
