### PR TITLE
Fix Project Manager listing incorrect info

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,9 +1,9 @@
-# Exhaustive licensing information for files in the Godot Engine repository
+# Exhaustive licensing information for files in the Redot Engine repository
 # =========================================================================
 #
 # This file aims at documenting the copyright and license for every source
-# file in the Godot Engine repository, and especially outline the files
-# whose license differs from the MIT/Expat license used by Godot Engine.
+# file in the Redot Engine repository, and especially outline the files
+# whose license differs from the MIT/Expat license used by Redot Engine.
 #
 # It is written as a machine-readable format following the debian/copyright
 # specification. Globbing patterns (e.g. "Files: *") mean that they affect
@@ -27,23 +27,24 @@
 #   License: Zlib
 # The exact copyright for each file in that library *may* differ, and some
 # files or code snippets might be distributed under other compatible licenses
-# (e.g. a public domain dedication), but as far as Godot Engine is concerned
+# (e.g. a public domain dedication), but as far as Redot Engine is concerned
 # the library is considered as a whole under the Zlib license.
 #
 # Note: When linking dynamically against thirdparty libraries instead of
-# building them into the Godot binary, you may remove the corresponding
+# building them into the Redot binary, you may remove the corresponding
 # license details from this file.
 
 -----------------------------------------------------------------------
 
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Godot Engine
-Upstream-Contact: Rémi Verschelde <contact@godotengine.org>
-Source: https://github.com/godotengine/godot
+Upstream-Name: Redot Engine
+Upstream-Contact: Andevrs <redotengine@gmail.com>
+Source: https://github.com/Redot-Engine/redot-engine
 
 Files: *
-Comment: Godot Engine
-Copyright: 2014-present, Godot Engine contributors
+Comment: Redot Engine
+Copyright: 2024-present, Redot Engine contributors
+ 2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat
 
@@ -51,14 +52,15 @@ Files: ./icon.png
  ./icon.svg
  ./logo.png
  ./logo.svg
-Comment: Godot Engine logo
-Copyright: 2017, Andrea Calabró
+Comment: Redot Engine logo
+Copyright: 2024, dev_airsyad (on X/Twitter)
 License: CC-BY-4.0
 
 Files: ./core/math/convex_hull.cpp
  ./core/math/convex_hull.h
 Comment: Bullet Continuous Collision Detection and Physics Library
 Copyright: 2011, Ole Kniemeyer, MAXON, www.maxon.net
+ 2024-present, Redot Engine contributors
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat and Zlib
@@ -84,6 +86,7 @@ Files: ./modules/godot_physics_3d/gjk_epa.cpp
  ./modules/godot_physics_3d/godot_shape_3d.h
 Comment: Bullet Continuous Collision Detection and Physics Library
 Copyright: 2003-2008, Erwin Coumans
+ 2024-present, Redot Engine contributors
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat and Zlib
@@ -97,6 +100,7 @@ Files: ./modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
  ./modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.h
 Comment: Bullet Continuous Collision Detection and Physics Library
 Copyright: 2007, Starbreeze Studios
+ 2024-present, Redot Engine contributors
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat and Zlib
@@ -104,6 +108,7 @@ License: Expat and Zlib
 Files: ./modules/lightmapper_rd/lm_compute.glsl
 Comment: Joint Non-Local Means (JNLM) denoiser
 Copyright: 2020, Manuel Prandini
+ 2024-present, Redot Engine contributors
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat
@@ -127,6 +132,7 @@ License: Apache-2.0
 Files: ./scene/animation/easing_equations.h
 Comment: Robert Penner's Easing Functions
 Copyright: 2001, Robert Penner
+ 2024-present, Redot Engine contributors
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat

--- a/REDOT_AUTHORS.md
+++ b/REDOT_AUTHORS.md
@@ -27,6 +27,10 @@ name is available.
 
 
 
+## Project Manager
+
+
+
 ## Developers
 
     Adam Vondersaar (trashguy)

--- a/core/SCsub
+++ b/core/SCsub
@@ -191,6 +191,10 @@ def version_info_builder(target, source, env):
 #define VERSION_WEBSITE "{website}"
 #define VERSION_DOCS_BRANCH "{docs_branch}"
 #define VERSION_DOCS_URL "https://docs.redotengine.org/en/" VERSION_DOCS_BRANCH
+#define GODOT_VERSION_MAJOR {godot_major}
+#define GODOT_VERSION_MINOR {godot_minor}
+#define GODOT_VERSION_PATCH {godot_patch}
+#define GODOT_VERSION_STATUS "{godot_status}"
 """.format(**env.version_info)
         )
 
@@ -258,6 +262,10 @@ env.CommandNoCache(
     "#thirdparty/certs/ca-certificates.crt",
     env.Run(core_builders.make_certs_header),
 )
+
+# Authors
+env.Depends("#core/redot_authors.gen.h", "../REDOT_AUTHORS.md")
+env.CommandNoCache("#core/redot_authors.gen.h", "../REDOT_AUTHORS.md", env.Run(core_builders.make_redot_authors_header))
 
 # Authors
 env.Depends("#core/authors.gen.h", "../AUTHORS.md")

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -36,8 +36,10 @@
 #include "core/config/project_settings.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
+#include "core/redot_authors.gen.h"
 #include "core/variant/typed_array.h"
 #include "core/version.h"
+#include "core/version_generated.gen.h"
 
 void Engine::set_physics_ticks_per_second(int p_ips) {
 	ERR_FAIL_COND_MSG(p_ips <= 0, "Engine iterations per second must be greater than 0.");
@@ -139,6 +141,25 @@ Dictionary Engine::get_version_info() const {
 	return dict;
 }
 
+Dictionary Engine::get_godot_compatible_version_info() const {
+	Dictionary dict;
+	dict["major"] = GODOT_VERSION_MAJOR;
+	dict["minor"] = GODOT_VERSION_MINOR;
+	dict["patch"] = GODOT_VERSION_PATCH;
+	dict["hex"] = GODOT_VERSION_HEX;
+	dict["status"] = GODOT_VERSION_STATUS;
+
+	String stringver = String(dict["major"]) + "." + String(dict["minor"]);
+	if ((int)dict["patch"] != 0) {
+		stringver += "." + String(dict["patch"]);
+	}
+	// stringver += "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")"; TODO: add godot automated build identification?
+	stringver += "-" + String(dict["status"]);
+	dict["string"] = stringver;
+
+	return dict;
+}
+
 static Array array_from_info(const char *const *info_list) {
 	Array arr;
 	for (int i = 0; info_list[i] != nullptr; i++) {
@@ -156,6 +177,17 @@ static Array array_from_info_count(const char *const *info_list, int info_count)
 }
 
 Dictionary Engine::get_author_info() const {
+	Dictionary dict;
+
+	dict["lead_developers"] = array_from_info(REDOT_AUTHORS_LEAD_DEVELOPERS);
+	dict["project_managers"] = array_from_info(REDOT_AUTHORS_PROJECT_MANAGERS);
+	dict["founders"] = array_from_info(REDOT_AUTHORS_FOUNDERS);
+	dict["developers"] = array_from_info(REDOT_AUTHORS_DEVELOPERS);
+
+	return dict;
+}
+
+Dictionary Engine::get_godot_author_info() const {
 	Dictionary dict;
 
 	dict["lead_developers"] = array_from_info(AUTHORS_LEAD_DEVELOPERS);
@@ -189,6 +221,19 @@ TypedArray<Dictionary> Engine::get_copyright_info() const {
 }
 
 Dictionary Engine::get_donor_info() const {
+	Dictionary donors;
+	donors["patrons"] = Array();
+	donors["platinum_sponsors"] = Array();
+	donors["gold_sponsors"] = Array();
+	donors["silver_sponsors"] = Array();
+	donors["diamond_members"] = Array();
+	donors["titanium_members"] = Array();
+	donors["platinum_members"] = Array();
+	donors["gold_members"] = Array();
+	return donors;
+}
+
+Dictionary Engine::get_godot_donor_info() const {
 	Dictionary donors;
 	donors["patrons"] = array_from_info(DONORS_PATRONS);
 	donors["platinum_sponsors"] = array_from_info(DONORS_SPONSORS_PLATINUM);

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -170,9 +170,12 @@ public:
 #endif
 
 	Dictionary get_version_info() const;
+	Dictionary get_godot_compatible_version_info() const;
 	Dictionary get_author_info() const;
+	Dictionary get_godot_author_info() const;
 	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;
+	Dictionary get_godot_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1764,8 +1764,16 @@ Dictionary Engine::get_version_info() const {
 	return ::Engine::get_singleton()->get_version_info();
 }
 
+Dictionary Engine::get_godot_compatible_version_info() const {
+	return ::Engine::get_singleton()->get_godot_compatible_version_info();
+}
+
 Dictionary Engine::get_author_info() const {
 	return ::Engine::get_singleton()->get_author_info();
+}
+
+Dictionary Engine::get_godot_author_info() const {
+	return ::Engine::get_singleton()->get_godot_author_info();
 }
 
 TypedArray<Dictionary> Engine::get_copyright_info() const {
@@ -1774,6 +1782,10 @@ TypedArray<Dictionary> Engine::get_copyright_info() const {
 
 Dictionary Engine::get_donor_info() const {
 	return ::Engine::get_singleton()->get_donor_info();
+}
+
+Dictionary Engine::get_godot_donor_info() const {
+	return ::Engine::get_singleton()->get_godot_donor_info();
 }
 
 Dictionary Engine::get_license_info() const {
@@ -1905,9 +1917,12 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_main_loop"), &Engine::get_main_loop);
 
 	ClassDB::bind_method(D_METHOD("get_version_info"), &Engine::get_version_info);
+	ClassDB::bind_method(D_METHOD("get_godot_compatible_version_info"), &Engine::get_godot_compatible_version_info);
 	ClassDB::bind_method(D_METHOD("get_author_info"), &Engine::get_author_info);
+	ClassDB::bind_method(D_METHOD("get_godot_author_info"), &Engine::get_godot_author_info);
 	ClassDB::bind_method(D_METHOD("get_copyright_info"), &Engine::get_copyright_info);
 	ClassDB::bind_method(D_METHOD("get_donor_info"), &Engine::get_donor_info);
+	ClassDB::bind_method(D_METHOD("get_godot_donor_info"), &Engine::get_godot_donor_info);
 	ClassDB::bind_method(D_METHOD("get_license_info"), &Engine::get_license_info);
 	ClassDB::bind_method(D_METHOD("get_license_text"), &Engine::get_license_text);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -544,9 +544,12 @@ public:
 	MainLoop *get_main_loop() const;
 
 	Dictionary get_version_info() const;
+	Dictionary get_godot_compatible_version_info() const;
 	Dictionary get_author_info() const;
+	Dictionary get_godot_author_info() const;
 	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;
+	Dictionary get_godot_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;
 

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -53,6 +53,55 @@ def make_certs_header(target, source, env):
         g.write("#endif // CERTS_COMPRESSED_GEN_H")
 
 
+def make_redot_authors_header(target, source, env):
+    sections = [
+        "Project Founders",
+        "Lead Developer",
+        "Project Manager",
+        "Developers",
+    ]
+    sections_id = [
+        "REDOT_AUTHORS_FOUNDERS",
+        "REDOT_AUTHORS_LEAD_DEVELOPERS",
+        "REDOT_AUTHORS_PROJECT_MANAGERS",
+        "REDOT_AUTHORS_DEVELOPERS",
+    ]
+
+    src = str(source[0])
+    dst = str(target[0])
+    with open(src, "r", encoding="utf-8") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
+        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+        g.write("#ifndef REDOT_AUTHORS_GEN_H\n")
+        g.write("#define REDOT_AUTHORS_GEN_H\n")
+
+        reading = False
+
+        def close_section():
+            g.write("\t0\n")
+            g.write("};\n")
+
+        for line in f:
+            if reading:
+                if line.startswith("    "):
+                    g.write('\t"' + escape_string(line.strip()) + '",\n')
+                    continue
+            if line.startswith("## "):
+                if reading:
+                    close_section()
+                    reading = False
+                for section, section_id in zip(sections, sections_id):
+                    if line.strip().endswith(section):
+                        current_section = escape_string(section_id)
+                        reading = True
+                        g.write("const char *const " + current_section + "[] = {\n")
+                        break
+
+        if reading:
+            close_section()
+
+        g.write("#endif // REDOT_AUTHORS_GEN_H\n")
+
+
 def make_authors_header(target, source, env):
     sections = [
         "Project Founders",

--- a/core/version.h
+++ b/core/version.h
@@ -85,4 +85,44 @@ extern const char *const VERSION_HASH;
 // Set to 0 if unknown.
 extern const uint64_t VERSION_TIMESTAMP;
 
+// Defines the main "branch" version. Patch versions in this branch should be
+// forward-compatible.
+// Example: "3.1"
+#define GODOT_VERSION_BRANCH _MKSTR(GODOT_VERSION_MAJOR) "." _MKSTR(GODOT_VERSION_MINOR)
+#if GODOT_VERSION_PATCH
+// Example: "3.1.4"
+#define GODOT_VERSION_NUMBER GODOT_VERSION_BRANCH "." _MKSTR(GODOT_VERSION_PATCH)
+#else // patch is 0, we don't include it in the "pretty" version number.
+// Example: "3.1" instead of "3.1.0"
+#define GODOT_VERSION_NUMBER GODOT_VERSION_BRANCH
+#endif // GODOT_VERSION_PATCH
+
+// Version number encoded as hexadecimal int with one byte for each number,
+// for easy comparison from code.
+// Example: 3.1.4 will be 0x030104, making comparison easy from script.
+#define GODOT_VERSION_HEX 0x10000 * GODOT_VERSION_MAJOR + 0x100 * GODOT_VERSION_MINOR + GODOT_VERSION_PATCH
+
+// TODO: determine how to deal with godot compatible versioning behavior
+
+// Describes the full configuration of that Redot version, including the version number,
+// the status (beta, stable, etc.) and potential module-specific features (e.g. mono).
+// Example: "3.1.4.stable.mono"
+// #define GODOT_VERSION_FULL_CONFIG VERSION_NUMBER "." GODOT_VERSION_STATUS VERSION_MODULE_CONFIG
+
+// Similar to GODOT_VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
+// description (e.g. official, custom_build, etc.).
+// Example: "3.1.4.stable.mono.official"
+// #define GODOT_VERSION_FULL_BUILD GODOT_VERSION_FULL_CONFIG "." GODOT_VERSION_BUILD
+
+// Same as above, but prepended with Redot's name and a cosmetic "v" for "version".
+// Example: "Godot v3.1.4.stable.official.mono"
+// #define GODOT_VERSION_FULL_NAME GODOT_VERSION_NAME " v" GODOT_VERSION_FULL_BUILD
+
+// Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
+// extern const char *const GODOT_VERSION_HASH;
+
+// Git commit date UNIX timestamp (in seconds), generated at build time in `core/version_hash.gen.cpp`.
+// Set to 0 if unknown.
+// extern const uint64_t GODOT_VERSION_TIMESTAMP;
+
 #endif // VERSION_H

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -34,7 +34,8 @@
 		<method name="get_author_info" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
-				Returns the engine author information as a [Dictionary], where each entry is an [Array] of strings with the names of notable contributors to the Godot Engine: [code]lead_developers[/code], [code]founders[/code], [code]project_managers[/code], and [code]developers[/code].
+				Returns the engine author information as a [Dictionary], where each entry is an [Array] of strings with the names of notable contributors to the Redot Engine: [code]lead_developers[/code], [code]founders[/code], [code]project_managers[/code], and [code]developers[/code].
+				See also [method get_godot_author_info] for Godot's author info.
 			</description>
 		</method>
 		<method name="get_copyright_info" qualifiers="const">
@@ -52,6 +53,8 @@
 			<description>
 				Returns a [Dictionary] of categorized donor names. Each entry is an [Array] of strings:
 				{[code]platinum_sponsors[/code], [code]gold_sponsors[/code], [code]silver_sponsors[/code], [code]bronze_sponsors[/code], [code]mini_sponsors[/code], [code]gold_donors[/code], [code]silver_donors[/code], [code]bronze_donors[/code]}
+				See also [method get_godot_donor_info] for Godot's donor info.
+				[b]Warning:[/b] All donor names are empty. This currently maintained for compatibility with Godot.
 			</description>
 		</method>
 		<method name="get_frames_drawn">
@@ -65,6 +68,54 @@
 			<return type="float" />
 			<description>
 				Returns the average frames rendered every second (FPS), also known as the framerate.
+			</description>
+		</method>
+		<method name="get_godot_author_info" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns the engine author information for Godot as a [Dictionary], where each entry is an [Array] of strings with the names of notable contributors to the Godot Engine: [code]lead_developers[/code], [code]founders[/code], [code]project_managers[/code], and [code]developers[/code].
+				See also [method get_author_info] for Redot's author info.
+			</description>
+		</method>
+		<method name="get_godot_compatible_version_info" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns the current engine minimal version compatibility info in relation to Godot as a [Dictionary] containing the following entries:
+				- [code]major[/code] - Major version number as an int;
+				- [code]minor[/code] - Minor version number as an int;
+				- [code]patch[/code] - Patch version number as an int;
+				- [code]hex[/code] - Full version encoded as a hexadecimal int with one byte (2 hex digits) per number (see example below);
+				- [code]status[/code] - Status (such as "beta", "rc1", "rc2", "stable", etc.) as a String;
+				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], and [code]status[/code] in a single String.
+				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].
+				[b]Note:[/b] The [code]hex[/code] value is still an [int] internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for quick version comparisons from code:
+				[codeblocks]
+				[gdscript]
+				if Engine.get_version_info().hex &gt;= 0x040100:
+				    pass # Do things specific to version 4.1 or later.
+				else:
+				    pass # Do things specific to versions before 4.1.
+				[/gdscript]
+				[csharp]
+				if ((int)Engine.GetVersionInfo()["hex"] &gt;= 0x040100)
+				{
+				    // Do things specific to version 4.1 or later.
+				}
+				else
+				{
+				    // Do things specific to versions before 4.1.
+				}
+				[/csharp]
+				[/codeblocks]
+				See also [method get_version_info] for Redot's version info.
+			</description>
+		</method>
+		<method name="get_godot_donor_info" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns a [Dictionary] of categorized donor names for Godot. Each entry is an [Array] of strings:
+				{[code]platinum_sponsors[/code], [code]gold_sponsors[/code], [code]silver_sponsors[/code], [code]bronze_sponsors[/code], [code]mini_sponsors[/code], [code]gold_donors[/code], [code]silver_donors[/code], [code]bronze_donors[/code]}
+				See also [method get_donor_info] for Redot's donor info.
 			</description>
 		</method>
 		<method name="get_license_info" qualifiers="const">
@@ -202,6 +253,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
+				See also [method get_godot_compatible_version_info] for Redot's minimal compatibility version info.
 			</description>
 		</method>
 		<method name="get_write_movie_path" qualifiers="const">

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -35,6 +35,7 @@
 #include "core/authors.gen.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
+#include "core/redot_authors.gen.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_version_button.h"
 #include "editor/themes/editor_scale.h"
@@ -220,14 +221,30 @@ EditorAbout::EditorAbout() {
 	dev_sections.push_back(TTR("Project Manager", "Job Title"));
 	dev_sections.push_back(TTR("Developers"));
 	const char *const *dev_src[] = {
+		REDOT_AUTHORS_FOUNDERS,
+		REDOT_AUTHORS_LEAD_DEVELOPERS,
+		REDOT_AUTHORS_PROJECT_MANAGERS,
+		REDOT_AUTHORS_DEVELOPERS,
+	};
+	tc->add_child(_populate_list(TTR("Authors"), dev_sections, dev_src, 0b1)); // First section (Project Founders) is always one column.
+
+	// Godot Authors.
+
+	List<String> godot_dev_sections;
+	godot_dev_sections.push_back(TTR("Project Founders"));
+	godot_dev_sections.push_back(TTR("Lead Developer"));
+	// TRANSLATORS: This refers to a job title.
+	godot_dev_sections.push_back(TTR("Project Manager", "Job Title"));
+	godot_dev_sections.push_back(TTR("Developers"));
+	const char *const *godot_dev_src[] = {
 		AUTHORS_FOUNDERS,
 		AUTHORS_LEAD_DEVELOPERS,
 		AUTHORS_PROJECT_MANAGERS,
 		AUTHORS_DEVELOPERS,
 	};
-	tc->add_child(_populate_list(TTR("Authors"), dev_sections, dev_src, 0b1)); // First section (Project Founders) is always one column.
+	tc->add_child(_populate_list(TTR("Godot Authors"), godot_dev_sections, godot_dev_src, 0b1)); // First section (Project Founders) is always one column.
 
-	// Donors.
+	// Godot Donors.
 
 	List<String> donor_sections;
 	donor_sections.push_back(TTR("Patrons"));
@@ -248,7 +265,7 @@ EditorAbout::EditorAbout() {
 		DONORS_MEMBERS_PLATINUM,
 		DONORS_MEMBERS_GOLD,
 	};
-	tc->add_child(_populate_list(TTR("Donors"), donor_sections, donor_src, 0b1, true)); // First section (Patron) is one column.
+	tc->add_child(_populate_list(TTR("Godot Donors"), donor_sections, donor_src, 0b1, true)); // First section (Patron) is one column.
 
 	// License.
 

--- a/methods.py
+++ b/methods.py
@@ -214,6 +214,10 @@ def get_version_info(module_version_string="", silent=False):
         "module_config": str(version.module_config) + module_version_string,
         "website": str(version.website),
         "docs_branch": str(version.docs),
+        "godot_major": str(version.godot_major),
+        "godot_minor": str(version.godot_minor),
+        "godot_patch": str(version.godot_patch),
+        "godot_status": str(version.godot_status),
     }
 
     # For dev snapshots (alpha, beta, RC, etc.) we do not commit status change to Git,

--- a/version.py
+++ b/version.py
@@ -7,3 +7,7 @@ status = "dev"
 module_config = ""
 website = "https://redotengine.org"
 docs = "latest"
+godot_major = 4
+godot_minor = 4
+godot_patch = 0
+godot_status = "dev"


### PR DESCRIPTION
Fix author info referring to Godot authors, now refers to REDOT_AUTHORS.md
Fix donor info referring to Godot donors, now empty
Correct COPYRIGHT.txt to properly refer to reflect Redot rebrand
Add Godot author info
Add Godot version compatibility info
Add Godot donor info
