### PR TITLE
Add alternative name styles for signals and resource names

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -420,6 +420,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Editor
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localize_settings", true, "")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/coding_language_style", 0, "_snake_case,snake_case,PascalCase,camelCase")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/ui_layout_direction", 0, "Based on Application Locale,Left-to-Right,Right-to-Left,Based on System Locale", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Display what the Auto display scale setting effectively corresponds to.

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -105,6 +105,13 @@ public:
 		AUTOWRAP_WORD_SMART
 	};
 
+	enum CodingLanguageStyle {
+		SNAKE_CASE_LEADING_UNDERSCORE,
+		SNAKE_CASE,
+		PASCAL_CASE,
+		CAMEL_CASE
+	};
+
 	enum LineBreakFlag {
 		BREAK_NONE = 0,
 		BREAK_MANDATORY = 1 << 0,


### PR DESCRIPTION
## What does this PR do?
Redot defaults to using `_snake_case` for signal / script names with no alternatives. 

This PR provides alternatives such as `_snake_case`, `snake_case`, `camelCase`, `PascalCase` that can be set in the editor settings.

![image](https://github.com/user-attachments/assets/f5df01ed-9a43-4398-b210-7e8cb689320e)

This PR changes names for
- [x] Signal Names
- [ ] Resource Names (scripts / scenes / shaders)

## Todo
- Separate `coding_language_style` into 2 or more options for setting signal names and resource names separately
- Maybe edit `register_editor_types.cpp` around lines `280 - 283` to account for these new PR changes

There could be a new option "Naming Style" that adds the options "_camel_case, camel_case, PascalCase, snakeCase" OR this could be defined in the editor settings.
![image](https://github.com/user-attachments/assets/b7891fcc-4402-4391-a103-0efd2935cab5)

Should a new "Naming Style" dropdown be added here as well or stay in editor settings?
![image](https://github.com/user-attachments/assets/972c1ab8-f33f-43a4-8cfd-04b09a0c9443)

Should a new "Naming Style" dropdown be added here or be in editor settings?
![image](https://github.com/user-attachments/assets/90821cd2-cf62-4656-aa94-cb17dd80c937)

## Known Issues
- Camel case does not camel the last word in signal names

## Note
This PR description originally talked about automatically changing the signal names so their PascalCase for mono projects and _snake_case for GDScript projects but as @Spartan322 pointed out this is not the correct way to do this. So now this PR lets the user choose what styles they want.