### PR TITLE
[4.4] Updated CONTRIBUTING.md w/ PR Guideline and Redot Docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This document summarizes the most important points for people interested in
 contributing to Redot, especially via bug reports or pull requests.
 
-The [Redot Discord](https://discord.gg/redot) documentation has a dedicated Contributing section
+The [Redot Documentation](https://docs-stable.redotengine.org/contributing/development) has a dedicated Contributing section
 which details these points and more, and is a recommended read.
 
 ## Table of contents
@@ -11,10 +11,15 @@ which details these points and more, and is a recommended read.
 - [Reporting bugs](#reporting-bugs)
 - [Proposing features or improvements](#proposing-features-or-improvements)
 - [Contributing pull requests](#contributing-pull-requests)
-- [Contributing to Godot translations](#contributing-to-godot-translations)
+- [Contributing to Redot translations](#contributing-to-redot-translations)
 - [Communicating with developers](#communicating-with-developers)
 
 ## Reporting bugs
+
+If you are reporting a bug with an unstable development build, it helps us greatly
+if you open your project in Godot's current dev builds to ensure that it is not
+a bug we've inherited from their upstream work process, as we must let them
+work on those bugs to minimize merge conflicts on our end.
 
 Report bugs [here](https://github.com/Redot-Engine/redot-engine/issues/new?assignees=&labels=&template=bug_report.yml).
 Please follow the instructions in the template when you do.
@@ -25,7 +30,8 @@ Be sure to not include the `.godot` folder in the archive to save space.
 
 Make sure that the bug you are experiencing is reproducible in the latest Redot
 releases. It's worth testing against both the latest stable release and the
-latest dev snapshot for the next Redot release.
+latest dev snapshot for the next Redot release, as well as the latest Godot
+dev snapshot.
 
 If you run into a bug which wasn't present in an earlier Redot version (what we
 call a _regression_), please mention it and clarify which versions you tested
@@ -35,9 +41,20 @@ call a _regression_), please mention it and clarify which versions you tested
 
 **The main issue tracker is for bug reports and does not accept feature proposals.**
 
-Instead, head to the [Redot Discord](https://discord.gg/redot).
+Visit the [Redot Proposals Repo](https://github.com/Redot-Engine/redot-proposals)
+to suggest features or improvements to the engine.
 
 ## Contributing pull requests
+
+Please refer to these links for detailed guides on workflow:
+(credit to Godot for these fantastic workflow guides)
+-	[Code Style](https://docs.redotengine.org/en/stable/contributing/development/code_style_guidelines.html)
+-	[PR Workflow](https://docs.redotengine.org/en/latest/contributing/workflow/pr_workflow.html)
+-	[PR Review](https://docs.redotengine.org/en/latest/contributing/workflow/pr_review_guidelines.html)
+
+Additionally, we expect all PR contributors to be using [Pre-Commit](https://pre-commit.com/) to
+speed up PR workflow. See the Code Style doc above for more information.
+
 
 If you want to add new engine features, please make sure that:
 
@@ -52,7 +69,8 @@ Similar rules can be applied when contributing bug fixes - it's always best to
 discuss the implementation in the bug report first if you are not 100% about
 what would be the best fix.
 
-Visit the [Redot Discord](https://discord.gg/redot) for information and guides related to contribution and pull requests.
+Read the [Redot Documentation](https://docs-stable.redotengine.org/contributing/development)
+for information and guides related to contribution and pull requests.
 
 ### Be mindful of your commits
 
@@ -128,10 +146,10 @@ scripting APIs, you **must** update the class reference to document those.
 This is to ensure the documentation coverage doesn't decrease as contributions
 are merged.
 
-[Update documentation XML files](https://docs.godotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
+[Update documentation XML files](https://docs.redotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
 using your compiled binary, then fill in the descriptions.
 Follow the style guide described in the
-[Documentation writing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html).
+[Documentation writing guidelines](https://docs.redotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html).
 
 If your pull request modifies parts of the code in a non-obvious way, make sure
 to add comments in the code as well. This helps other people understand the
@@ -157,15 +175,15 @@ applicable.
 Feel free to contribute standalone pull requests to add new tests or improve
 existing tests as well.
 
-See [Unit testing](https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/unit_testing.html)
-for information on writing tests in Godot's C++ codebase.
+See [Unit testing](https://docs.redotengine.org/en/latest/contributing/development/core_and_modules/unit_testing.html)
+for information on writing tests in Redot's C++ codebase.
 
-## Contributing to Godot translations
+## Contributing to Redot translations
 
-You can contribute to Godot translations on [Hosted Weblate](https://hosted.weblate.org/projects/godot-engine/),
-an open source and web-based translation platform.
+You can contribute to Redot translations by leaving a volunteer application
+on the [Redot Discord](https://discord.gg/redot) for us to review.
 
-Please refer to Godot's [editor and documentation localization guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
+Please refer to Redot's [editor and documentation localization guidelines](https://docs.redotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
 for an overview of the translation resources and what they correspond to.
 
 ## Communicating with developers
@@ -180,7 +198,8 @@ or a bug you want to fix), the following channels can be used:
   existing issue about a topic you want to discuss, you can participate directly.
   If not, you can open a new issue. Please mind the guidelines outlined above
   for bug reporting.
-- Feature Proposals should be made on the [Redot Discord](https://discord.gg/redot) for now.
+- [Redot Proposals Repo](https://github.com/Redot-Engine/redot-proposals): Feature
+or improvement proposals.
 - [Redot](https://x.com/redotengine) on Twitter
 
 Thanks for your interest in contributing!


### PR DESCRIPTION
PR Guidelines added
Pre-Commit link added
Updated old Godot doc links to the new Redot website doc links
Changed links to the Discord for contribution info to more appropriate ones now that the Proposals repo is ready to go

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
