### PR TITLE
Remove CI jobs that do not match Godot

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -23,17 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor tests=yes)
-            cache-name: linux-editor
-            target: editor
-            bin: ./bin/redot.linuxbsd.editor.x86_64
-            build-mono: false
-            tests: true
-            doc-test: true
-            proj-conv: true
-            api-compat: true
-            artifact: true
-
           - name: Editor w/ Mono (target=editor)
             cache-name: linux-editor-mono
             target: editor

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -32,18 +32,6 @@ jobs:
             bin: ./bin/redot.windows.editor.x86_64.exe
             compiler: msvc
 
-          - name: Editor w/ Mono (target=editor)
-            cache-name: windows-editor-mono
-            target: editor
-            sconsflags: module_mono_enabled=yes
-            bin: ./bin/redot.windows.editor.x86_64.mono.exe
-            build-mono: true
-            tests: false # Disabled due freeze caused by mix Mono build and CI
-            doc-test: true
-            proj-conv: true
-            api-compat: true
-            compiler: msvc
-
           - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
             cache-name: windows-editor-clang
             target: editor


### PR DESCRIPTION
These have a tendency to consume a more notable amount of GH Action resources by their mere existence so they are being removed to free up time, GHA run slots, and cache for future workflow runs.
