### PR TITLE
[4.3] Calculate pixel snap in canvas space instead of world space

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -262,14 +262,14 @@ void main() {
 
 	color_interp = color;
 
+	vertex = (canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
+
 	if (use_pixel_snap) {
 		vertex = floor(vertex + 0.5);
 		// precision issue on some hardware creates artifacts within texture
 		// offset uv by a small amount to avoid
 		uv += 1e-5;
 	}
-
-	vertex = (canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;
 	uv_interp = uv;

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -214,14 +214,14 @@ void main() {
 
 	color_interp = color;
 
+	vertex = (canvas_data.canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
+
 	if (canvas_data.use_pixel_snap) {
 		vertex = floor(vertex + 0.5);
 		// precision issue on some hardware creates artifacts within texture
 		// offset uv by a small amount to avoid
 		uv += 1e-5;
 	}
-
-	vertex = (canvas_data.canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;
 	uv_interp = uv;


### PR DESCRIPTION
Cherry-picked from godotengine/godot#97260
Supersedes #744

This ensures that you are actually snapping to pixels in the viewport and not an arbitrary amount

(cherry picked from commit godotengine/godot@e75900e1ad1a2c699829335ad3be27b4e01afec1)
