### PR TITLE
Update logo license and copyright file

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -48,12 +48,15 @@ Copyright: 2024-present, Redot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat
 
-Files: ./icon.png
- ./icon.svg
- ./logo.png
+Files: ./logo.png
  ./logo.svg
-Comment: Redot Engine logo
-Copyright: 2024, dev_airsyad (on X/Twitter)
+ ./logo_outlined.png
+ ./logo_outlined.svg
+ ./editor/icons/TitleBarLogo.svg
+ ./icon.png
+ ./icon.svg
+Comment: Redot Engine Logos and Icons
+Copyright: 2024, Asrorul Irsyad
 License: CC-BY-4.0
 
 Files: ./core/math/convex_hull.cpp

--- a/LOGO_LICENSE.txt
+++ b/LOGO_LICENSE.txt
@@ -1,5 +1,5 @@
-Godot Engine Logo
-Copyright (c) 2017 Andrea Calabró
+Redot Engine Logo
+Copyright (c) 2024 Asrorul Irsyad
 
 This work is licensed under the Creative Commons Attribution 4.0 International
 license (CC BY 4.0 International): https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Updated logo copyright info in COPYRIGHT.txt
Updated LOGO_LICENSE.txt to reflect current copyright info

supersedes #737 