### PR TITLE
[4.3] Fix `EditorSpinSlider` grabber doesn't follow parent when scrolling

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -446,7 +446,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 				Vector2 scale = get_global_transform_with_canvas().get_scale();
 				grabber->set_scale(scale);
 				grabber->reset_size();
-				grabber->set_position(get_global_position() + (grabber_rect.get_center() - grabber->get_size() * 0.5) * scale);
+				grabber->set_position((grabber_rect.get_center() - grabber->get_size() * 0.5) * scale);
 
 				if (mousewheel_over_grabber) {
 					Input::get_singleton()->warp_mouse(grabber->get_position() + grabber_rect.size);
@@ -737,7 +737,7 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabber = memnew(TextureRect);
 	add_child(grabber);
 	grabber->hide();
-	grabber->set_as_top_level(true);
+	grabber->set_z_index(1);
 	grabber->set_mouse_filter(MOUSE_FILTER_STOP);
 	grabber->connect(SceneStringName(mouse_entered), callable_mp(this, &EditorSpinSlider::_grabber_mouse_entered));
 	grabber->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorSpinSlider::_grabber_mouse_exited));


### PR DESCRIPTION
(cherry picked from commit blazium-engine/blazium@a501d9f81282ad6030f5395fc86e8c15ded7116b)
