### PR TITLE
[4.3] Enable `ColorPicker` RGB+RAW modes to have overbright values

### DIFF
--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -48,6 +48,7 @@ public:
 	virtual float get_spinbox_arrow_step() const { return get_slider_step(); };
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
+	virtual bool can_allow_greater() const { return false; };
 	virtual float get_slider_value(int idx) const = 0;
 
 	virtual Color get_color() const = 0;
@@ -95,6 +96,7 @@ public:
 	virtual float get_slider_step() const override { return 1; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; };
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
@@ -116,6 +118,7 @@ public:
 	virtual float get_spinbox_arrow_step() const override { return 0.01; }
 	virtual String get_slider_label(int idx) const override;
 	virtual float get_slider_max(int idx) const override;
+	virtual bool can_allow_greater() const override { return true; };
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -633,6 +633,7 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 		float spinbox_arrow_step = modes[current_mode]->get_spinbox_arrow_step();
 		for (int i = 0; i < current_slider_count; i++) {
 			sliders[i]->set_max(modes[current_mode]->get_slider_max(i));
+			sliders[i]->set_allow_greater(modes[current_mode]->can_allow_greater());
 			sliders[i]->set_step(step);
 			values[i]->set_custom_arrow_step(spinbox_arrow_step);
 			sliders[i]->set_value(modes[current_mode]->get_slider_value(i));


### PR DESCRIPTION


(cherry picked from commit blazium-engine/blazium@f7c6762df94867d93465612ec6be86b28593dc47)