### PR TITLE
[4.3] Remove `ColorModeOKHSL.get_shape_override`

### DIFF
--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -146,7 +146,6 @@ public:
 	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }
 
 	ColorModeOKHSL(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker){};


### PR DESCRIPTION
It seems to be vestigial inherited from the ColorPicker refactor

(cherry picked from commit blazium-engine/blazium@f7c6762df94867d93465612ec6be86b28593dc47)
