### PR TITLE
[4.3] Remove hide on `ColorPicker` color picking

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1542,7 +1542,6 @@ void ColorPicker::_pick_finished() {
 	}
 	is_picking_color = false;
 	set_process_internal(false);
-	picker_window->hide();
 }
 
 void ColorPicker::_pick_button_pressed_legacy() {


### PR DESCRIPTION
(cherry picked from commit blazium-engine/blazium@f7c6762df94867d93465612ec6be86b28593dc47)
