### PR TITLE
[4.3] Unify `CanvasItemEditor` duplicate hovering behavior

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -469,6 +469,7 @@ private:
 
 	void _draw_viewport();
 
+	void _is_hovering_guide(Point2 p_pos, bool p_is_pressed = false);
 	bool _gui_input_anchors(const Ref<InputEvent> &p_event);
 	bool _gui_input_move(const Ref<InputEvent> &p_event);
 	bool _gui_input_open_scene_on_double_click(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
(cherry picked from commit blazium-engine/blazium@5ca9caa0f88c7ee4c9cad38decf0a064eb126bab)
