### PR TITLE
Add `wheel_picker_cursor` theme icon to `ColorPicker`

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -207,5 +207,8 @@
 		<theme_item name="shape_rect_wheel" data_type="icon" type="Texture2D">
 			The icon for rectangular wheel picker shapes.
 		</theme_item>
+		<theme_item name="wheel_picker_cursor" data_type="icon" type="Texture2D">
+			The image displayed over the color wheel (depending on the [member picker_shape] being [constant SHAPE_HSV_WHEEL]), marking the currently selected hue.
+		</theme_item>
 	</theme_items>
 </class>

--- a/editor/icons/WheelPickerCursor.svg
+++ b/editor/icons/WheelPickerCursor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="5.5" fill="none" stroke="#fff"/><circle cx="8" cy="8" r="4.5" fill="none" stroke="#000"/></svg>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1771,6 +1771,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_icon("overbright_indicator", "ColorPicker", p_theme->get_icon(SNAME("OverbrightIndicator"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("bar_arrow", "ColorPicker", p_theme->get_icon(SNAME("ColorPickerBarArrow"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("PickerCursor"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("wheel_picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("WheelPickerCursor"), EditorStringName(EditorIcons)));
 
 		// ColorPickerButton.
 		p_theme->set_icon("bg", "ColorPickerButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1217,14 +1217,11 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 
 		col.set_hsv(h, 1, 1);
 		if (actual_shape == SHAPE_HSV_WHEEL) {
-			points.resize(4);
-			double h1 = h - (0.5 / 360);
-			double h2 = h + (0.5 / 360);
-			points.set(0, Point2(center.x + (center.x * Math::cos(h1 * Math_TAU)), center.y + (center.y * Math::sin(h1 * Math_TAU))));
-			points.set(1, Point2(center.x + (center.x * Math::cos(h1 * Math_TAU) * 0.84), center.y + (center.y * Math::sin(h1 * Math_TAU) * 0.84)));
-			points.set(2, Point2(center.x + (center.x * Math::cos(h2 * Math_TAU)), center.y + (center.y * Math::sin(h2 * Math_TAU))));
-			points.set(3, Point2(center.x + (center.x * Math::cos(h2 * Math_TAU) * 0.84), center.y + (center.y * Math::sin(h2 * Math_TAU) * 0.84)));
-			c->draw_multiline(points, col.inverted());
+			const real_t near_wheel_radius_multiplier = 0.84;
+			const real_t wheel_radis_center_multipler = near_wheel_radius_multiplier + (1.0 - near_wheel_radius_multiplier) / 2;
+			real_t wheel_x = center.x + (center.x * Math::cos(h * Math_TAU) * wheel_radis_center_multipler) - (theme_cache.wheel_picker_cursor->get_width() / 2);
+			real_t wheel_y = center.y + (center.y * Math::sin(h * Math_TAU) * wheel_radis_center_multipler) - (theme_cache.wheel_picker_cursor->get_height() / 2);
+			c->draw_texture(theme_cache.wheel_picker_cursor, Point2(wheel_x, wheel_y));
 		}
 
 	} else if (p_which == 1) {
@@ -1819,6 +1816,7 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, sample_revert);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, overbright_indicator);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, picker_cursor);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, wheel_picker_cursor);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_hue);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_okhsl_hue);
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -242,6 +242,7 @@ private:
 		Ref<Texture2D> sample_revert;
 		Ref<Texture2D> overbright_indicator;
 		Ref<Texture2D> picker_cursor;
+		Ref<Texture2D> wheel_picker_cursor;
 		Ref<Texture2D> color_hue;
 		Ref<Texture2D> color_okhsl_hue;
 

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1040,6 +1040,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("overbright_indicator", "ColorPicker", icons["color_picker_overbright"]);
 	theme->set_icon("bar_arrow", "ColorPicker", icons["color_picker_bar_arrow"]);
 	theme->set_icon("picker_cursor", "ColorPicker", icons["color_picker_cursor"]);
+	theme->set_icon("wheel_picker_cursor", "ColorPicker", icons["color_picker_wheel_cursor"]);
 
 	{
 		const int precision = 7;

--- a/scene/theme/icons/color_picker_wheel_cursor.svg
+++ b/scene/theme/icons/color_picker_wheel_cursor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="5.5" fill="none" stroke="#fff"/><circle cx="8" cy="8" r="4.5" fill="none" stroke="#000"/></svg>


### PR DESCRIPTION
Replaces `ColorPicker`'s HSV wheel hue indicator with `wheel_picker_icon` texture which by default is the same as `picker_cursor`

https://github.com/user-attachments/assets/29cbf998-2e7e-4374-ab98-342c2c6b56b6

