### PR TITLE
[4.3] Fix `GDExtensionAPIDump` lacking status_version header

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -114,6 +114,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 		header["version_patch"] = 0;
 #endif
 		header["version_status"] = VERSION_STATUS;
+		header["version_status_version"] = VERSION_STATUS_VERSION;
 		header["version_build"] = VERSION_BUILD;
 		header["version_full_name"] = VERSION_FULL_NAME;
 


### PR DESCRIPTION
(cherry picked from commit 5fb6d30604b392776265052c621eef0470d8fadb)
