### PR TITLE
[4.3] Fix Godot Reference for update URL

### DIFF
--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -297,7 +297,7 @@ void EngineUpdateLabel::pressed() {
 		} break;
 
 		case UpdateStatus::UPDATE_AVAILABLE: {
-			OS::get_singleton()->shell_open("https://godotengine.org/download/archive/" + available_newer_version);
+			OS::get_singleton()->shell_open("https://redotengine.org/download/archive/" + available_newer_version);
 		} break;
 
 		default: {


### PR DESCRIPTION
This fix de-references godotengine from the update URL.  
