### PR TITLE
Remove unnecessary operations for set_rotation and rectangle collision

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -93,7 +93,8 @@ void Transform2D::set_rotation(real_t p_rot) {
 	columns[0][1] = sr;
 	columns[1][0] = -sr;
 	columns[1][1] = cr;
-	set_scale(scale);
+	columns[0] *= scale.x;
+	columns[1] *= scale.y;
 }
 
 Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {

--- a/modules/godot_physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/modules/godot_physics_2d/godot_collision_solver_2d_sat.cpp
@@ -479,11 +479,15 @@ static void _collision_segment_rectangle(const GodotShape2D *p_a, const Transfor
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_b.columns[0].normalized())) {
+	const Vector2 rect_fn = p_transform_b.columns[0].normalized();
+
+	if (!separator.test_axis(rect_fn)) {
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_b.columns[1].normalized())) {
+	const Vector2 nd_rect_fn = Vector2(-rect_fn[1], rect_fn[0]);
+
+	if (!separator.test_axis(nd_rect_fn)) {
 		return;
 	}
 
@@ -652,11 +656,14 @@ static void _collision_circle_rectangle(const GodotShape2D *p_a, const Transform
 	const Vector2 *axis = &p_transform_b.columns[0];
 	//const Vector2& half_extents = rectangle_B->get_half_extents();
 
-	if (!separator.test_axis(axis[0].normalized())) {
+	const Vector2 rect_fn = axis[0].normalized();
+	if (!separator.test_axis(rect_fn)) {
 		return;
 	}
 
-	if (!separator.test_axis(axis[1].normalized())) {
+	const Vector2 nd_rect_fn = Vector2(-rect_fn[1], rect_fn[0]);
+
+	if (!separator.test_axis(nd_rect_fn)) {
 		return;
 	}
 
@@ -770,21 +777,31 @@ static void _collision_rectangle_rectangle(const GodotShape2D *p_a, const Transf
 		return;
 	}
 
+	//It's the same normal for both axis tests,
+	//but the second one is just inverted and has the x as inverse.
+	const Vector2 rect_fn = p_transform_a.columns[0].normalized();
+
 	//box faces A
-	if (!separator.test_axis(p_transform_a.columns[0].normalized())) {
+	if (!separator.test_axis(rect_fn)) {
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_a.columns[1].normalized())) {
+	const Vector2 nd_rect_fn = Vector2(-rect_fn[1], rect_fn[0]);
+
+	if (!separator.test_axis(nd_rect_fn)) {
 		return;
 	}
+
+	const Vector2 rect_fn2 = p_transform_b.columns[0].normalized();
 
 	//box faces B
-	if (!separator.test_axis(p_transform_b.columns[0].normalized())) {
+	if (!separator.test_axis(rect_fn2)) {
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_b.columns[1].normalized())) {
+	const Vector2 nd_rect_fn2 = Vector2(-rect_fn2[1], rect_fn2[0]);
+
+	if (!separator.test_axis(nd_rect_fn2)) {
 		return;
 	}
 
@@ -844,12 +861,18 @@ static void _collision_rectangle_capsule(const GodotShape2D *p_a, const Transfor
 		return;
 	}
 
+	//It's the same normal for both axis tests,
+	//but the second one is just inverted and has the x as inverse.
+	const Vector2 rect_fn = p_transform_a.columns[0].normalized();
+
 	//box faces
-	if (!separator.test_axis(p_transform_a.columns[0].normalized())) {
+	if (!separator.test_axis(rect_fn)) {
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_a.columns[1].normalized())) {
+	const Vector2 nd_rect_fn = Vector2(-rect_fn[1], rect_fn[0]);
+
+	if (!separator.test_axis(nd_rect_fn)) {
 		return;
 	}
 
@@ -922,12 +945,18 @@ static void _collision_rectangle_convex_polygon(const GodotShape2D *p_a, const T
 		return;
 	}
 
+	//It's the same normal for both axis tests,
+	//but the second one is just inverted and has the x as inverse.
+	const Vector2 rect_fn = p_transform_a.columns[0].normalized();
+
 	//box faces
-	if (!separator.test_axis(p_transform_a.columns[0].normalized())) {
+	if (!separator.test_axis(rect_fn)) {
 		return;
 	}
 
-	if (!separator.test_axis(p_transform_a.columns[1].normalized())) {
+	const Vector2 nd_rect_fn = Vector2(-rect_fn[1], rect_fn[0]);
+
+	if (!separator.test_axis(nd_rect_fn)) {
 		return;
 	}
 

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -112,6 +112,23 @@ TEST_CASE("[Transform2D] Affine inverse") {
 	CHECK(affine_inverted_again == orig);
 }
 
+TEST_CASE("[Transform2D] Set rotation") {
+	const real_t rot = 1.8;
+	const Vector2 scale = Vector2(2.5, 5);
+	const Vector2 useless_pos = Vector2();
+	Transform2D subject = Transform2D(0.2, scale, 0.0, useless_pos);
+
+	subject.set_rotation(rot);
+
+	const real_t res_rot = subject.get_rotation();
+	const Vector2 res_scale = subject.get_scale();
+	const real_t tol = 0.001;
+
+	CHECK(Math::is_equal_approx(rot, res_rot, tol));
+	CHECK(Math::is_equal_approx(scale.x, res_scale.x, tol));
+	CHECK(Math::is_equal_approx(scale.y, res_scale.y, tol));
+}
+
 TEST_CASE("[Transform2D] Orthonormalized") {
 	const Transform2D T = create_dummy_transform();
 	const Transform2D orthonormalized_T = T.orthonormalized();


### PR DESCRIPTION
This pr is just 2 simple performance optimizations.

- set_rotation now doesn't re-normalized the normals produced by sin and cos.

- Rectangle collision doesn't normalize the 2nd pillar of transform anymore. Instead it picks the 1st already normalized pillar and simply does {x2 = -y1; y2 = x1} which gives the same result and is less costly.