### PR TITLE
Fix Snap icon removal introduced in e8e8a88

### DIFF
--- a/editor/icons/Snap.svg
+++ b/editor/icons/Snap.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M3 3v2h2V3zm6 0v2h2V3zM3 9v2h2V9zm4 4v2h2v-2zm6 0v2h2v-2z"/><path fill="#fff" fill-opacity=".686" d="M7 13h2v-2a2 2 0 0 1 4 0v2h2v-2a4 4 0 0 0-8 0z"/></svg>


### PR DESCRIPTION
Icon bug introduced in #726
The snap icon in the editor will error our without `Snap.svg`