### PR TITLE
Fix multiple `<h1>` in `classes/index.html` documentation

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1768,7 +1768,7 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
 
         for group_name in CLASS_GROUPS:
             if group_name in grouped_classes:
-                f.write(make_heading(CLASS_GROUPS[group_name], "="))
+                f.write(make_heading(CLASS_GROUPS[group_name], "-"))
 
                 f.write(".. toctree::\n")
                 f.write("    :maxdepth: 1\n")


### PR DESCRIPTION
You might find multiple `<h1>` in `https://docs.godotengine.org/zh-cn/4.x/classes/index.html`.

Fix by passing `------` instead of `======` to heading, so the subtitle in `index.rst` generate correctly.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
