### PR TITLE
Fix godot references in the issue & PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
         - Write a descriptive issue title above.
         - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
         - Search [open](https://github.com/Redot-Engine/redot-engine/issues) and [closed](https://github.com/Redot-Engine/redot-engine/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-        - Verify that you are using a [supported Godot version](https://docs.redotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
+        - Verify that you are using a [supported Redot version](https://docs.redotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
         - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ Please target the `master` branch in priority.
 Relevant fixes are cherry-picked for stable branches as needed by maintainers.
 
 To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
-https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
+https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
 -->


### PR DESCRIPTION
Fixing godot reference in the issue & pr template

leaving the .godot project folder because currently we are still using it for compatibility reasons. 