### PR TITLE
Change Godot Linux appdata urls to Redot

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.appdata.xml
+++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml
@@ -27,8 +27,8 @@
   </screenshots>
   <url type="homepage">https://redotengine.org</url>
   <url type="bugtracker">https://github.com/Redot-Engine/redot-engine/issues</url>
-  <url type="faq">https://docs.godotengine.org/en/latest/about/faq.html</url>
-  <url type="help">https://docs.godotengine.org</url>
+  <url type="faq">https://docs.redotengine.org/about/faq</url>
+  <url type="help">https://docs.redotengine.org/</url>
   <url type="donation">https://www.savethechildren.org</url>
   <url type="translate">https://hosted.weblate.org/projects/godot-engine/godot</url>
   <developer_name>The Redot Engine Community</developer_name>


### PR DESCRIPTION
Referencing Redot documentation instead of Godot.
