### PR TITLE
[4.3] Fix 32-bit Windows build

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -864,7 +864,7 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 	pi.si.StartupInfo.hStdOutput = pipe_out[1];
 	pi.si.StartupInfo.hStdError = pipe_err[1];
 
-	size_t attr_list_size = 0;
+	SIZE_T attr_list_size = 0;
 	InitializeProcThreadAttributeList(nullptr, 1, 0, &attr_list_size);
 	pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)alloca(attr_list_size);
 	if (!InitializeProcThreadAttributeList(pi.si.lpAttributeList, 1, 0, &attr_list_size)) {
@@ -948,7 +948,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 			pi.si.StartupInfo.hStdError = pipe[1];
 		}
 
-		size_t attr_list_size = 0;
+		SIZE_T attr_list_size = 0;
 		InitializeProcThreadAttributeList(nullptr, 1, 0, &attr_list_size);
 		pi.si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)alloca(attr_list_size);
 		if (!InitializeProcThreadAttributeList(pi.si.lpAttributeList, 1, 0, &attr_list_size)) {


### PR DESCRIPTION
Causes godotengine/godot#99108 conversion errors on 32-bit Windows because size_t on 32-bit is unsigned int whereas on 32-bit Windows' SIZE_T is unsigned long. This is how it was solved for godotengine/godot#99107 with godotengine/godot#99280.