### PR TITLE
Improve GDScript autocompletion for methods

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1141,10 +1141,12 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 							continue;
 						}
 						option = ScriptLanguage::CodeCompletionOption(member.function->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
-						if (member.function->parameters.size() > 0) {
+						if (member.function->parameters.size() > 0 || (member.function->info.flags & METHOD_FLAG_VARARG)) {
 							option.insert_text += "(";
+							option.display += U"(\u2026)";
 						} else {
 							option.insert_text += "()";
+							option.display += "()";
 						}
 						break;
 					case GDScriptParser::ClassNode::Member::SIGNAL:
@@ -1186,6 +1188,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 	if (!p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM) {
 		ScriptLanguage::CodeCompletionOption option("new", ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, ScriptLanguage::LOCATION_LOCAL);
 		option.insert_text += "(";
+		option.display += U"(\u2026)";
 		r_result.insert(option.display, option);
 	}
 
@@ -1243,10 +1246,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							}
 							int location = p_recursion_depth + _get_method_location(scr->get_class_name(), E.name);
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
-							if (E.arguments.size()) {
+							if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 								option.insert_text += "(";
+								option.display += U"(\u2026)";
 							} else {
 								option.insert_text += "()";
+								option.display += "()";
 							}
 							r_result.insert(option.display, option);
 						}
@@ -1329,10 +1334,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					}
 					int location = p_recursion_depth + _get_method_location(type, E.name);
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
-					if (E.arguments.size()) {
+					if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 						option.insert_text += "(";
+						option.display += U"(\u2026)";
 					} else {
 						option.insert_text += "()";
+						option.display += "()";
 					}
 					r_result.insert(option.display, option);
 				}
@@ -1400,10 +1407,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						continue;
 					}
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
-					if (E.arguments.size()) {
+					if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 						option.insert_text += "(";
+						option.display += U"(\u2026)";
 					} else {
 						option.insert_text += "()";
+						option.display += "()";
 					}
 					r_result.insert(option.display, option);
 				}
@@ -1435,8 +1444,10 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		ScriptLanguage::CodeCompletionOption option(String(E), ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (function.arguments.size() || (function.flags & METHOD_FLAG_VARARG)) {
 			option.insert_text += "(";
+			option.display += U"(\u2026)";
 		} else {
 			option.insert_text += "()";
+			option.display += "()";
 		}
 		r_result.insert(option.display, option);
 	}
@@ -1483,6 +1494,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	while (*kwa) {
 		ScriptLanguage::CodeCompletionOption option(*kwa, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		option.insert_text += "(";
+		option.display += U"(\u2026)";
 		r_result.insert(option.display, option);
 		kwa++;
 	}
@@ -1493,6 +1505,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	for (List<StringName>::Element *E = utility_func_names.front(); E; E = E->next()) {
 		ScriptLanguage::CodeCompletionOption option(E->get(), ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		option.insert_text += "(";
+		option.display += U"(\u2026)"; // As all utility functions contain an argument or more, this is hardcoded here.
 		r_result.insert(option.display, option);
 	}
 

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
@@ -1,6 +1,6 @@
 [output]
 include=[
-    {"display": "new"},
+    {"display": "new(…)"},
     {"display": "SIZE_EXPAND"},
     {"display": "SIZE_EXPAND_FILL"},
     {"display": "SIZE_FILL"},

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
@@ -1,6 +1,6 @@
 [output]
 include=[
-    {"display": "new"},
+    {"display": "new(…)"},
     {"display": "SIZE_EXPAND"},
     {"display": "SIZE_EXPAND_FILL"},
     {"display": "SIZE_FILL"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
@@ -2,14 +2,14 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 exclude=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: no_completion_in_string.gd
@@ -17,8 +17,8 @@ exclude=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/self.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/self.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: self.gd
@@ -16,6 +16,6 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal/dollar.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal/dollar.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal/percent.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal/percent.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local/local.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local/local.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered/local_infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered/local_infered.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member/member.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member/member.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered/member_infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered/member_infered.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/class_member_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/class_member_typehint_scene_broad.cfg
@@ -3,7 +3,7 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
@@ -11,6 +11,6 @@ include=[
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/native_member_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/native_member_typehint_scene_broad.cfg
@@ -3,7 +3,7 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
@@ -11,6 +11,6 @@ include=[
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint_broad.cfg
@@ -1,13 +1,13 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]


### PR DESCRIPTION
Tracks: h//ttp//s://githu//b.com/godot//engine/go//dot/pull/99//102 (Remove"//"s as they are used to prevent the original pr from being referenced here)
Adds "()" for methods autocompletion, and if a method contains multiple or variable arguments, a "..." (in one space) will be inserted in the braces.
