### PR TITLE
[4.3] Fix invalid doc references to godot_notifications

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -26,7 +26,7 @@
 	<tutorials>
 		<link title="Object class introduction">$DOCS_URL/contributing/development/core_and_modules/object_class.html</link>
 		<link title="When and how to avoid using nodes for everything">$DOCS_URL/tutorials/best_practices/node_alternatives.html</link>
-		<link title="Object notifications">$DOCS_URL/tutorials/best_practices/godot_notifications.html</link>
+		<link title="Object notifications">$DOCS_URL/tutorials/best_practices/redot_notifications.html</link>
 	</tutorials>
 	<methods>
 		<method name="_get" qualifiers="virtual">

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -156,7 +156,7 @@
 			<param index="0" name="group" type="StringName" />
 			<param index="1" name="notification" type="int" />
 			<description>
-				Calls [method Object.notification] with the given [param notification] to all nodes inside this tree added to the [param group]. See also [url=$DOCS_URL/tutorials/best_practices/godot_notifications.html]Redot notifications[/url] and [method call_group] and [method set_group].
+				Calls [method Object.notification] with the given [param notification] to all nodes inside this tree added to the [param group]. See also [url=$DOCS_URL/tutorials/best_practices/redot_notifications.html]Redot notifications[/url] and [method call_group] and [method set_group].
 				[b]Note:[/b] This method acts immediately on all selected nodes at once, which may cause stuttering in some performance-intensive situations.
 			</description>
 		</method>


### PR DESCRIPTION
Fixes issues with sphinx documentation crashing if it leaves the classes "unmigrated".