### PR TITLE
[4.3] Corrected manpage

### DIFF
--- a/misc/dist/linux/redot.6
+++ b/misc/dist/linux/redot.6
@@ -1,4 +1,4 @@
-.TH GODOT "6" "January 2020" "redot 4.0" "Games"
+.TH REDOT "6" "November 2024" "redot 4.0" "Games"
 .SH NAME
 redot \- multi\-platform 2D and 3D game engine with a feature\-rich editor
 .SH SYNOPSIS
@@ -171,23 +171,23 @@ Generate JSON dump of the Redot API for GDExtension bindings named 'extension_ap
 \fB\-\-test\fR <test>
 Run a unit test ('string', 'math', 'physics', 'physics_2d', 'render', 'oa_hash_map', 'gui', 'shaderlang', 'gd_tokenizer', 'gd_parser', 'gd_compiler', 'gd_bytecode', 'ordered_hash_map', 'astar').
 .SH FILES
-XDG_DATA_CONFIG/godot/ or ~/.config/godot/
+XDG_DATA_CONFIG/redot/ or ~/.config/redot/
 .RS
 User\-specific configuration folder, contains persistent editor settings, script and text editor templates and projects metadata.
 .RE
-XDG_DATA_HOME/godot/ or ~/.local/share/godot/
+XDG_DATA_HOME/redot/ or ~/.local/share/redot/
 .RS
 Contains the default configuration and user data folders for Redot\-made games (\fIuser://\fR path), as well as export templates.
 .RE
-XDG_DATA_CACHE/godot/ or ~/.cache/godot/
+XDG_DATA_CACHE/redot/ or ~/.cache/redot/
 .RS
 Cache folder for generated thumbnails and scene previews, as well as temporary location for downloads.
 .RE
-/usr/share/doc/godot/
+/usr/share/doc/redot/
 .RS
 Additional documentation files.
 .RE
-/usr/share/licenses/godot/
+/usr/share/licenses/redot/
 .RS
 Detailed licensing information.
 .RE


### PR DESCRIPTION
I don't know how I missed this, but right now accessing man page requires `man godot` rather than `man redot` -- This solves that.