### PR TITLE
[4.3] GDScript: Fix SceneTreeTimer leaked when awaiting it while quitting

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -289,5 +289,10 @@ GDScriptFunctionState::~GDScriptFunctionState() {
 		MutexLock lock(GDScriptLanguage::singleton->mutex);
 		scripts_list.remove_from_list();
 		instances_list.remove_from_list();
+
+		_clear_connections();
+		if (ObjectDB::get_instance(get_instance_id())) {
+			_clear_stack();
+		}
 	}
 }


### PR DESCRIPTION
- See godotengine/godot#96441

(cherry picked from commit godotengine/godot@e45eb85563c7b98cbb71f0a15123e5cc37523f19)
