### PR TITLE
Correct macOS Free and Available Memory

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -428,14 +428,24 @@ Dictionary OS_Unix::get_memory_info() const {
 		ERR_PRINT(vformat("Could not get vm.swapusage, error code: %d - %s", errno, strerror(errno)));
 	}
 
+	// used memory: https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433
+	int64_t total_used_count = vmstat.wire_count + vmstat.inactive_count + vmstat.active_count + vmstat.compressor_page_count;
+	int64_t total_used = total_used_count * (int64_t)pagesize;
 	if (phy_mem != 0) {
 		meminfo["physical"] = phy_mem;
-	}
-	if (vmstat.free_count * (int64_t)pagesize != 0) {
-		meminfo["free"] = vmstat.free_count * (int64_t)pagesize;
-	}
-	if (swap_used.xsu_avail + vmstat.free_count * (int64_t)pagesize != 0) {
-		meminfo["available"] = swap_used.xsu_avail + vmstat.free_count * (int64_t)pagesize;
+		int64_t total_free = phy_mem - total_used;
+		if (total_free != 0) {
+			/*
+			 ** subtract used memory from total memory != vmstat.free_count: this can be observed from manual testing...
+			 ** correct value matches code from running macOS's open source top(1) utility; vmstat.free_count doesn't...
+			 ** https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433
+			 ** printf("incorrect value: %lld\ncorrect value: %lld\n", vmstat.free_count * pagesize, total_free); // try
+			 */
+			meminfo["free"] = total_free;
+			if (swap_used.xsu_avail + total_free != 0) {
+				meminfo["available"] = swap_used.xsu_avail + total_free;
+			}
+		}
 	}
 #elif defined(__FreeBSD__)
 	int pagesize = 0;


### PR DESCRIPTION
> Based on my Godot pull request: https://github.com/godotengine/godot/pull/100788

Code used is taken right out of Apple's official [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433) utility for macOS. Observing Apple's code at a first glance, it makes no sense why `vmstat.free_count * pagesize` would not be correct as that appears to be exactly what they are using to calculate free memory. However, I must be missing something, because `vmstat.free_count * pagesize` does not match the "unused memory" value shown when running [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433). It shows *way* less than that...

Instead, the correct value shown in [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433) corresponds to the value provided from how [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433) calculates used memory, while subtracting that from total memory. Makes no sense, I know. But this code is correct now and actually matches what is shown in [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433), which can be verified easily from testing if you like.

Edit:

I forgot how to squash commits, so please be patient with me while I try to figure that one out.

Edit 2:

I also have a system information utility I wrote which uses the same code underneath for RAM usage stats, as the code used in this pull request, in case you wanted something quick and easy to test and compare with [top(1)](https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433):

```
git clone https://github.com/time-killer-games/sysinfo $HOME/sysinfo && $HOME/sysinfo/build.sh
```

In this outdated screenshot you can see what free RAM used to look like back when I based it on `vmstat.free_count * pagesize` like you guys currently do:

![macos](https://github.com/user-attachments/assets/a3dc259a-c01c-4dd0-b38a-c0211a4f0be8)

As you can see `vmstat.free_count * pagesize` is a lot smaller than what the actual free memory should reasonably be with only one app opened in the entire desktop. I highly doubt 260.39 MB free out of 8 GB of memory total is accurate given how little resources it takes to run that app.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
