### PR TITLE
Change the default theme to dark scheme from minimal-theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -327,9 +327,9 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_base_color = Color(0.17, 0.17, 0.20);
 				preset_contrast = 0.4;
 			} else { // Default
-				preset_accent_color = Color(0.87, 0.22, 0.29);
-				preset_base_color = Color(0.14, 0.12, 0.12);
-				preset_contrast = config.default_contrast;
+				preset_accent_color = Color(0.99, 0.77, 0.76);
+				preset_base_color = Color(0.13, 0.13, 0.13);
+				preset_contrast = 0.3;
 			}
 
 			config.accent_color = preset_accent_color;


### PR DESCRIPTION
#### Color scheme change

We want to change the color scheme to something more subtle the red has long received a lot of hate.  

Initially we wanted to switch to the [godot-minimal-theme ](https://github.com/passivestar/godot-minimal-theme) but that turned out more complicated than not as it has a 700 line GDScript file that changes a lot of nuances like spacing and margin.   

So we decided we could just use the color values from it for now.   Feel free to review my values but i belive they are correct. 