### PR TITLE
Add support for specifying `ImageFormatLoader` Resource import

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -38,7 +38,15 @@ void ImageFormatLoader::_bind_methods() {
 	BIND_BITFIELD_FLAG(FLAG_CONVERT_COLORS);
 }
 
-bool ImageFormatLoader::recognize(const String &p_extension) const {
+bool ImageFormatLoader::should_import(const String &p_resource_type) const {
+	return true;
+}
+
+bool ImageFormatLoader::recognize(const String &p_extension, const String &p_resource_type) const {
+	if (!should_import(p_resource_type)) {
+		return false;
+	}
+
 	List<String> extensions;
 	get_recognized_extensions(&extensions);
 	for (const String &E : extensions) {
@@ -65,6 +73,12 @@ void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_exten
 	}
 }
 
+bool ImageFormatLoaderExtension::should_import(const String &p_resource_type) const {
+	bool should_import = true;
+	GDVIRTUAL_CALL(_should_import, p_resource_type, should_import);
+	return should_import;
+}
+
 void ImageFormatLoaderExtension::add_format_loader() {
 	ImageLoader::add_image_format_loader(this);
 }
@@ -75,6 +89,7 @@ void ImageFormatLoaderExtension::remove_format_loader() {
 
 void ImageFormatLoaderExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions);
+	GDVIRTUAL_BIND(_should_import, "resource_type");
 	GDVIRTUAL_BIND(_load_image, "image", "fileaccess", "flags", "scale");
 	ClassDB::bind_method(D_METHOD("add_format_loader"), &ImageFormatLoaderExtension::add_format_loader);
 	ClassDB::bind_method(D_METHOD("remove_format_loader"), &ImageFormatLoaderExtension::remove_format_loader);
@@ -110,15 +125,18 @@ Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<File
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
+void ImageLoader::get_recognized_extensions(List<String> *p_extensions, const String &p_resource_type) {
 	for (int i = 0; i < loader.size(); i++) {
+		if (!loader[i]->should_import(p_resource_type)) {
+			continue;
+		}
 		loader[i]->get_recognized_extensions(p_extensions);
 	}
 }
 
-Ref<ImageFormatLoader> ImageLoader::recognize(const String &p_extension) {
+Ref<ImageFormatLoader> ImageLoader::recognize(const String &p_extension, const String &p_resource_type) {
 	for (int i = 0; i < loader.size(); i++) {
-		if (loader[i]->recognize(p_extension)) {
+		if (loader[i]->recognize(p_extension, p_resource_type)) {
 			return loader[i];
 		}
 	}
@@ -169,7 +187,7 @@ Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String
 	int idx = -1;
 
 	for (int i = 0; i < ImageLoader::loader.size(); i++) {
-		if (ImageLoader::loader[i]->recognize(extension)) {
+		if (ImageLoader::loader[i]->recognize(extension, "Image")) {
 			idx = i;
 			break;
 		}

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -62,7 +62,8 @@ protected:
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) = 0;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
-	bool recognize(const String &p_extension) const;
+	virtual bool should_import(const String &p_resource_type) const;
+	bool recognize(const String &p_extension, const String &p_resource_type = "") const;
 
 public:
 	virtual ~ImageFormatLoader() {}
@@ -79,11 +80,13 @@ protected:
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual bool should_import(const String &p_resource_type) const override;
 
 	void add_format_loader();
 	void remove_format_loader();
 
 	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions);
+	GDVIRTUAL1RC(bool, _should_import, String);
 	GDVIRTUAL4R(Error, _load_image, Ref<Image>, Ref<FileAccess>, BitField<ImageFormatLoader::LoaderFlags>, float);
 };
 
@@ -94,8 +97,8 @@ class ImageLoader {
 protected:
 public:
 	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
-	static void get_recognized_extensions(List<String> *p_extensions);
-	static Ref<ImageFormatLoader> recognize(const String &p_extension);
+	static void get_recognized_extensions(List<String> *p_extensions, const String &p_resource_type = "");
+	static Ref<ImageFormatLoader> recognize(const String &p_extension, const String &p_resource_type = "");
 
 	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);
 	static void remove_image_format_loader(Ref<ImageFormatLoader> p_loader);

--- a/doc/classes/ImageFormatLoaderExtension.xml
+++ b/doc/classes/ImageFormatLoaderExtension.xml
@@ -26,6 +26,14 @@
 				Loads the content of [param fileaccess] into the provided [param image].
 			</description>
 		</method>
+		<method name="_should_import" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="resource_type" type="String" />
+			<description>
+				[b]Optional.[/b]
+				Returns [code]true[/code] if [param resource_type] should import.
+			</description>
+		</method>
 		<method name="add_format_loader">
 			<return type="void" />
 			<description>

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -46,7 +46,7 @@ String ResourceImporterBitMap::get_visible_name() const {
 }
 
 void ResourceImporterBitMap::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 }
 
 String ResourceImporterBitMap::get_save_extension() const {

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -44,7 +44,7 @@ String ResourceImporterImage::get_visible_name() const {
 }
 
 void ResourceImporterImage::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 }
 
 String ResourceImporterImage::get_save_extension() const {

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -45,7 +45,7 @@ String ResourceImporterImageFont::get_visible_name() const {
 
 void ResourceImporterImageFont::get_recognized_extensions(List<String> *p_extensions) const {
 	if (p_extensions) {
-		ImageLoader::get_recognized_extensions(p_extensions);
+		ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 	}
 }
 

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -80,7 +80,7 @@ String ResourceImporterLayeredTexture::get_visible_name() const {
 }
 
 void ResourceImporterLayeredTexture::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 }
 
 String ResourceImporterLayeredTexture::get_save_extension() const {

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -178,7 +178,7 @@ String ResourceImporterTexture::get_visible_name() const {
 }
 
 void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 }
 
 String ResourceImporterTexture::get_save_extension() const {

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -53,7 +53,7 @@ String ResourceImporterTextureAtlas::get_visible_name() const {
 }
 
 void ResourceImporterTextureAtlas::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_recognized_extensions(p_extensions, get_resource_type());
 }
 
 String ResourceImporterTextureAtlas::get_save_extension() const {


### PR DESCRIPTION
- See #912

---

- Original PR: godotengine/godot#100538

(cherry picked from commit godotengine/godot@93ba41ad40f1cb117d26e482eba6c4fc18344366)

This is a PR necessary to implement DDS runtime loading.