### PR TITLE
[4.3] CI: Install apt dependencies directly, works around issue with `awalsh128/cache-apt-pkgs-action`

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -17,9 +17,8 @@ jobs:
           fetch-depth: 2
 
       - name: Install APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libxml2-utils
+        run: |
+          sudo apt install -y libxml2-utils
 
       - name: Install Python dependencies and general setup
         run: |


### PR DESCRIPTION
Original PR: godotengine/godot#101363

(cherry picked from commit 829ad307f8c06134229256d0fc564fabd4e8826b)

---

Works around [awalsh128/cache-apt-pkgs-action#141](https://github.com/awalsh128/cache-apt-pkgs-action/issues/141), this shouldn't add too much to the build iteration time as it's a single package (it used to be several when we added this back then).
