### PR TITLE
add nix flake + package definitions for editor & export templates

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,8 @@ $RECYCLE.BIN/
 *.msp
 *.lnk
 *.generated.props
+
+# Nix
+.direnv/
+/result
+/result-*

--- a/SConstruct
+++ b/SConstruct
@@ -297,6 +297,9 @@ opts.Add("asflags", "Custom flags for the assembler")
 opts.Add("arflags", "Custom flags for the archive tool")
 opts.Add("rcflags", "Custom flags for Windows resource compiler")
 
+# Nix
+opts.Add(BoolVariable("nix", "Whether the project is built using Nix.", False))
+
 # Update the environment to have all above options defined
 # in following code (especially platform and custom_modules).
 opts.Update(env)

--- a/export-template-package.nix
+++ b/export-template-package.nix
@@ -1,0 +1,117 @@
+{
+
+  pkgsCross,
+  symlinkJoin,
+  lib,
+  redot,
+}:
+{
+  templateType ? "release",
+  platform ? "linuxbsd",
+}:
+let
+  exportPlatformNames = {
+    linuxbsd = "linux";
+    windows = "windows";
+  };
+
+  mkTemplate =
+    {
+      pkg,
+      templateType ? "release",
+      platform ? "linuxbsd",
+      arch ? "x86_64",
+    }:
+    let
+      basePkg =
+        (pkg.override {
+          withTarget = "template_${templateType}";
+          withPlatform = platform;
+        }).overrideAttrs
+          (old: {
+            pname = "redot4-export-templates-${platform}-${templateType}";
+
+            outputs = [ "out" ];
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p "$out/share/redot/export_templates/${old.redotVersion}"
+
+              cp bin/redot.* "$out/share/redot/export_templates/${old.redotVersion}/${
+                exportPlatformNames.${platform}
+              }_${templateType}_${arch}"
+
+              runHook postInstall
+            '';
+          });
+    in
+    (
+      if platform == "windows" then
+        mkWindowsTemplate {
+          inherit templateType;
+          pkg = basePkg;
+        }
+      else
+        basePkg
+    );
+
+  mkWindowsTemplate =
+    {
+      pkg,
+      templateType ? "release",
+    }:
+    let
+      arch = "x86_64";
+    in
+    (pkg.override {
+      withPlatform = "windows";
+      inherit arch;
+      importEnvVars = [
+        "CPLUS_INCLUDE_PATH"
+      ];
+    }).overrideAttrs
+      (
+        old:
+        let
+          buildInputs = (old.buildInputs or [ ]) ++ [
+            pkgsCross.mingwW64.windows.mingw_w64_pthreads
+            pkgsCross.mingwW64.windows.mcfgthreads
+            pkgsCross.mingw32.windows.mcfgthreads
+          ];
+
+          libs = symlinkJoin {
+            name = "redot-export-templates-windows-libpath";
+            paths = buildInputs;
+          };
+        in
+        {
+          nativeBuildInputs = old.nativeBuildInputs ++ [
+            pkgsCross.mingwW64.buildPackages.gcc
+            pkgsCross.mingw32.buildPackages.gcc
+          ];
+
+          inherit buildInputs;
+
+          env = (old.env or { }) // {
+            CPLUS_INCLUDE_PATH = lib.makeIncludePath buildInputs;
+            NIX_LIBS = "${libs}/lib";
+          };
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out/share/redot/export_templates/${old.redotVersion}"
+
+            cp bin/redot.*.console.exe "$out/share/redot/export_templates/${old.redotVersion}/windows_${templateType}_${arch}_console.exe"
+            cp bin/redot.*.${arch}.exe "$out/share/redot/export_templates/${old.redotVersion}/windows_${templateType}_${arch}.exe"
+
+            runHook postInstall
+          '';
+        }
+      );
+in
+mkTemplate {
+  inherit platform templateType;
+  pkg = redot;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738546358,
+        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  description = "Redot Game Engine";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        pkgsCross = import nixpkgs {
+          config = {
+            crossSystem = "x86_64-w64-mingw32";
+          };
+
+          inherit system;
+        };
+
+        mkExportTemplate = pkgs.callPackage (import ./export-template-package.nix) {
+          inherit (self.packages.${system}) redot;
+        };
+      in
+      {
+        packages = {
+          default = self.packages.${system}.redot;
+
+          redot = pkgs.callPackage (import ./package.nix) {
+            src = self;
+            commitHash = if self ? rev then self.rev else "devel";
+          };
+
+          export-templates-linux-release = mkExportTemplate {
+            templateType = "release";
+            platform = "linuxbsd";
+          };
+
+          export-templates-linux-debug = mkExportTemplate {
+            templateType = "debug";
+            platform = "linuxbsd";
+          };
+
+          export-templates-windows-release = mkExportTemplate {
+            templateType = "release";
+            platform = "windows";
+          };
+
+          export-templates-windows-debug = mkExportTemplate {
+            templateType = "debug";
+            platform = "windows";
+          };
+
+          export-templates = pkgs.symlinkJoin {
+            name = "redot-export-templates";
+            paths = builtins.attrValues {
+              inherit (self.packages.${system})
+                export-templates-linux-release
+                export-templates-linux-debug
+                export-templates-windows-release
+                export-templates-windows-debug
+                ;
+            };
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit (self.packages.${system}.redot) nativeBuildInputs;
+
+          buildInputs =
+            self.packages.${system}.redot.buildInputs ++ self.packages.${system}.redot.runtimeDependencies;
+        };
+      }
+    );
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,233 @@
+# Based on https://github.com/NixOS/nixpkgs/blob/6d5b297bc68f021d5fe9d43a3d1ba35a3b6d0663/pkgs/by-name/go/godot_4/package.nix
+
+{
+  alsa-lib,
+  autoPatchelfHook,
+  buildPackages,
+  dbus,
+  fontconfig,
+  installShellFiles,
+  lib,
+  libdecor,
+  libGL,
+  libpulseaudio,
+  libX11,
+  libXcursor,
+  libXext,
+  libXfixes,
+  libXi,
+  libXinerama,
+  libxkbcommon,
+  libXrandr,
+  libXrender,
+  pkg-config,
+  scons,
+  speechd-minimal,
+  stdenv,
+  testers,
+  udev,
+  vulkan-loader,
+  wayland,
+  wayland-scanner,
+  withDbus ? true,
+  withFontconfig ? true,
+  withPlatform ? "linuxbsd",
+  withPrecision ? "single",
+  withPulseaudio ? true,
+  withSpeechd ? true,
+  withTarget ? "editor",
+  withTouch ? true,
+  withUdev ? true,
+  # Wayland in Redot requires X11 until upstream fix is merged
+  # https://github.com/godotengine/godot/pull/73504
+  withWayland ? true,
+  withX11 ? true,
+  src,
+  commitHash,
+  arch ? stdenv.hostPlatform.linuxArch,
+  importEnvVars ? [ ],
+}:
+assert lib.asserts.assertOneOf "withPrecision" withPrecision [
+  "single"
+  "double"
+];
+let
+  mkSconsFlagsFromAttrSet = lib.mapAttrsToList (
+    k: v: if builtins.isString v then "${k}=${v}" else "${k}=${builtins.toJSON v}"
+  );
+
+  versionInfo = builtins.listToAttrs (
+    map (
+      e:
+      let
+        valuePair = lib.splitString " = " e;
+      in
+      {
+        name = builtins.elemAt valuePair 0;
+        value = lib.replaceStrings [ "\"" ] [ "" ] (builtins.elemAt valuePair 1);
+      }
+    ) (lib.splitString "\n" (builtins.readFile ./version.py))
+  );
+
+  version = "${versionInfo.major}.${versionInfo.minor}${
+    lib.optionalString (versionInfo.patch != "0") ".${versionInfo.patch}"
+  }-${versionInfo.status}";
+
+  redotVersion = lib.replaceStrings [ "-" ] [ "." ] version;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "redot4";
+
+  inherit src version redotVersion;
+
+  outputs = [
+    "out"
+    "man"
+  ];
+  separateDebugInfo = true;
+
+  # Set the build name which is part of the version. In official downloads, this
+  # is set to 'official'. When not specified explicitly, it is set to
+  # 'custom_build'. Other platforms packaging Redot (Gentoo, Arch, Flatpak
+  # etc.) usually set this to their name as well.
+  #
+  # See also 'methods.py' in the Redot repo and 'build' in
+  # https://docs.redotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+  BUILD_NAME = "nixpkgs";
+
+  # Required for the commit hash to be included in the version number.
+  #
+  # `methods.py` reads the commit hash from `.git/HEAD` and manually follows
+  # refs. Since we just write the hash directly, there is no need to emulate any
+  # other parts of the .git directory.
+  #
+  # See also 'hash' in
+  # https://docs.redotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+  preConfigure = ''
+    mkdir -p .git
+    echo ${commitHash} > .git/HEAD
+  '';
+
+  # From: https://github.com/Redot-Engine/redot-engine/blob/redot-4.3-stable/SConstruct
+  sconsFlags = mkSconsFlagsFromAttrSet (
+    {
+      # Options from 'SConstruct'
+      precision = withPrecision; # Floating-point precision level
+      production = true; # Set defaults to build Redot for use in production
+      platform = withPlatform;
+      target = withTarget;
+      import_env_vars = lib.foldl (a: b: "${a},${b}") "" importEnvVars;
+      nix = true;
+
+      inherit arch;
+    }
+    // (lib.optionalAttrs (withTarget == "editor") {
+      # Options from 'platform/linuxbsd/detect.py'
+      dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
+      fontconfig = withFontconfig; # Use fontconfig for system fonts support
+      pulseaudio = withPulseaudio; # Use PulseAudio
+      speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
+      touch = withTouch; # Enable touch events
+      udev = withUdev; # Use udev for gamepad connection callbacks
+      wayland = withWayland; # Compile with Wayland support
+      x11 = withX11; # Compile with X11 support
+      module_mono_enabled = false;
+
+      linkflags = "-Wl,--build-id";
+
+      debug_symbols = true;
+    })
+  );
+
+  enableParallelBuilding = true;
+
+  strictDeps = true;
+
+  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    buildPackages.stdenv.cc
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    installShellFiles
+    pkg-config
+    scons
+  ] ++ lib.optionals withWayland [ wayland-scanner ];
+
+  runtimeDependencies =
+    [
+      alsa-lib
+      libGL
+      vulkan-loader
+    ]
+    ++ lib.optionals withX11 [
+      libX11
+      libXcursor
+      libXext
+      libXfixes
+      libXi
+      libXinerama
+      libxkbcommon
+      libXrandr
+      libXrender
+    ]
+    ++ lib.optionals withWayland [
+      libdecor
+      wayland
+    ]
+    ++ lib.optionals withDbus [
+      dbus
+      dbus.lib
+    ]
+    ++ lib.optionals withFontconfig [
+      fontconfig
+      fontconfig.lib
+    ]
+    ++ lib.optionals withPulseaudio [ libpulseaudio ]
+    ++ lib.optionals withSpeechd [ speechd-minimal ]
+    ++ lib.optionals withUdev [ udev ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp bin/redot.* $out/bin/redot4
+
+    installManPage misc/dist/linux/redot.6
+
+    mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps}
+    cp misc/dist/linux/org.redotengine.Redot.desktop "$out/share/applications/org.redotengine.Redot4.desktop"
+    substituteInPlace "$out/share/applications/org.redotengine.Redot4.desktop" \
+      --replace "Exec=redot" "Exec=$out/bin/redot4" \
+      --replace "Redot Engine" "Redot Engine 4"
+    cp icon.svg "$out/share/icons/hicolor/scalable/apps/redot.svg"
+    cp icon.png "$out/share/icons/redot.png"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = redotVersion;
+    };
+  };
+
+  requiredSystemFeatures = [
+    # fixes: No space left on device
+    "big-parallel"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Redot-Engine/redot-engine/releases/tag/${version}";
+    description = "Free and Open Source 2D and 3D game engine";
+    homepage = "https://redotengine.org";
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "redot4";
+  };
+})

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -696,6 +696,10 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Build type
 
+    # Need this under Nix to find libraries like mcfgthread
+    if env["nix"]:
+        env.Append(LIBPATH=[os.environ.get("NIX_LIBS")])
+
     if not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = True
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

## Description

This PR adds a Nix package definition for the Redot editor, as well as the export templates for `linuxbsd` and `windows`.

Once merged, it will be possible to build / install the editor and export templates locally using the Nix package manager. The Nix package manager itself is distro-agnostic, and can be downloaded for Linux as well as MacOS here: https://nixos.org/

To test this PR, it is possible to run the following command to build the editor locally using Nix:

```shell
nix build github:Naxdy/redot-engine#redot
```

Then run `./result/bin/redot4` to run the editor. For the export templates, you can run the following:

```shell
# all export templates
nix build github:Naxdy/redot-engine#export-templates

# specific export template (see `nix flake show github:Naxdy/redot-engine` for a comprehensive list)
nix build github:Naxdy/redot-engine#export-templates-linux-release
```

The export templates will be symlinked under `./result/share/redot/export_templates/[engine-version]`

> [!NOTE]
> The nix build script retrieves the version info from `version.py` and assumes that variables and values are delimited by " = " (space-equalsign-space).

## Dev Shell

A rudimentary dev shell that provides all packages used by the nix derivation is also provided via `devShells.default`, including an `.envrc` file for use with `direnv`.

The `.gitignore` file has been updated to exclude Nix-specific directories (outputs & direnv cache).  

## Caveats

- MacOS export templates are not packaged, since I don't have a machine to test with. I also don't know if cross-compilation of the Windows export templates will function on Darwin with the derivations provided (I'd assume not?)
- The Redot editor will be built _without_ Mono support, since enabling it would require tracking a separate lockfile for all .NET packages (example: https://github.com/NixOS/nixpkgs/blob/6d5b297bc68f021d5fe9d43a3d1ba35a3b6d0663/pkgs/by-name/go/godot_4/deps.json ), which is a burden I did not want to push upon Redot maintainers. If desired, I (or someone else) can add in Mono support after the fact though.

-----

Closes #247
Closes #154