### PR TITLE
[4.3] Expose GDScript syntax highlighter to editor plugins

### DIFF
--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -11,6 +11,7 @@ def get_doc_classes():
     return [
         "@GDScript",
         "GDScript",
+        "GDScriptSyntaxHighlighter",
     ]
 
 

--- a/modules/gdscript/doc_classes/GDScriptSyntaxHighlighter.xml
+++ b/modules/gdscript/doc_classes/GDScriptSyntaxHighlighter.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptSyntaxHighlighter" inherits="EditorSyntaxHighlighter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A GDScript syntax highlighter that can be used with [TextEdit] and [CodeEdit] nodes.
+	</brief_description>
+	<description>
+		[b]Note:[/b] This class can only be used for editor plugins because it relies on editor settings.
+		[codeblocks]
+		[gdscript]
+		var code_preview = TextEdit.new()
+		var highlighter = GDScriptSyntaxHighlighter.new()
+		code_preview.syntax_highlighter = highlighter
+		[/gdscript]
+		[csharp]
+		var codePreview = new TextEdit();
+		var highlighter = new GDScriptSyntaxHighlighter();
+		codePreview.SyntaxHighlighter = highlighter;
+		[/csharp]
+		[/codeblocks]
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -167,6 +167,13 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 
 		gdscript_translation_parser_plugin.instantiate();
 		EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
+	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		ClassDB::APIType prev_api = ClassDB::get_current_api();
+		ClassDB::set_current_api(ClassDB::API_EDITOR);
+
+		GDREGISTER_CLASS(GDScriptSyntaxHighlighter);
+
+		ClassDB::set_current_api(prev_api);
 	}
 #endif // TOOLS_ENABLED
 }


### PR DESCRIPTION
- Original PR godotengine/godot#95764

(cherry picked from commit 3fe644de86b6a9fa96bbbbaa7746c52005848d96)

---

- Related godotengine/godot-proposals#10374

|Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/96cfb154-2bc0-419b-8465-63c31aebaa60) | ![after](https://github.com/user-attachments/assets/97a9fc39-82ff-4da0-969a-144126ec830b) |

