### PR TITLE
Fix BoneAttachment3d not updating warning on external skeleton change.

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -62,6 +62,8 @@ bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 		set_external_skeleton(p_value);
 	}
 
+	update_configuration_warnings();
+
 	return true;
 }
 


### PR DESCRIPTION
This patches an issue where the bone attachment 3d would not update its warning after a change in its target skeleton until the project was reloaded or the tree was updated. Now it updates the moment the user changes the external skeleton property. (sorry for tag, not sure how else to send in a patch)
