### PR TITLE
[4.3] Fix Tilemap release display bug

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2685,9 +2685,9 @@ void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file
 }
 
 void EditorFileSystem::_reimport_thread(uint32_t p_index, ImportThreadData *p_import_data) {
-	int file_idx = p_import_data->reimport_from + int(p_index);
-	_reimport_file(p_import_data->reimport_files[file_idx].path);
-	p_import_data->imported_sem->post();
+	int current_max = p_import_data->reimport_from + int(p_index);
+	p_import_data->max_index.exchange_if_greater(current_max);
+	_reimport_file(p_import_data->reimport_files[current_max].path);
 }
 
 void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
@@ -2766,7 +2766,6 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 #endif
 
 	int from = 0;
-	Semaphore imported_sem;
 	for (int i = 0; i < reimport_files.size(); i++) {
 		if (groups_to_reimport.has(reimport_files[i].path)) {
 			from = i + 1;
@@ -2790,27 +2789,21 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 					importer->import_threaded_begin();
 
 					ImportThreadData tdata;
+					tdata.max_index.set(from);
 					tdata.reimport_from = from;
 					tdata.reimport_files = reimport_files.ptr();
-					tdata.imported_sem = &imported_sem;
 
-					int item_count = i - from + 1;
-					WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &EditorFileSystem::_reimport_thread, &tdata, item_count, -1, false, vformat(TTR("Import resources of type: %s"), reimport_files[from].importer));
-
-					int imported_count = 0;
-					while (true) {
-						ep->step(reimport_files[imported_count].path.get_file(), from + imported_count, false);
-						imported_sem.wait();
-						do {
-							imported_count++;
-						} while (imported_sem.try_wait());
-						if (imported_count == item_count) {
-							break;
+					WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &EditorFileSystem::_reimport_thread, &tdata, i - from + 1, -1, false, vformat(TTR("Import resources of type: %s"), reimport_files[from].importer));
+					int current_index = from - 1;
+					do {
+						if (current_index < tdata.max_index.get()) {
+							current_index = tdata.max_index.get();
+							ep->step(reimport_files[current_index].path.get_file(), current_index, false);
 						}
-					}
+						OS::get_singleton()->delay_usec(1);
+					} while (!WorkerThreadPool::get_singleton()->is_group_task_completed(group_task));
 
 					WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
-					DEV_ASSERT(!imported_sem.try_wait());
 
 					importer->import_threaded_end();
 				}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -311,7 +311,7 @@ class EditorFileSystem : public Node {
 	struct ImportThreadData {
 		const ImportFile *reimport_files;
 		int reimport_from;
-		Semaphore *imported_sem = nullptr;
+		SafeNumeric<int> max_index;
 	};
 
 	void _reimport_thread(uint32_t p_index, ImportThreadData *p_import_data);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -400,7 +400,9 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	if (p_replace_previous) {
 		// Force sync last line update (skip if number of unprocessed log messages is too large to avoid editor lag).
 		if (log->get_pending_paragraphs() < 100) {
-			log->wait_until_finished();
+			while (!log->is_ready()) {
+				::OS::get_singleton()->delay_usec(1);
+			}
 		}
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5525,6 +5525,7 @@ bool EditorNode::immediate_confirmation_dialog(const String &p_text, const Strin
 	cd->popup_centered();
 
 	while (true) {
+		OS::get_singleton()->delay_usec(1);
 		DisplayServer::get_singleton()->process_events();
 		Main::iteration();
 		if (singleton->immediate_dialog_confirmed || !cd->is_visible()) {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -566,6 +566,7 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 	confirmed = false;
 
 	while (true) {
+		OS::get_singleton()->delay_usec(1);
 		DisplayServer::get_singleton()->process_events();
 		Main::iteration();
 		if (!configure_blender_dialog->is_visible() || confirmed) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -77,7 +77,7 @@ void TileMap::_set_tile_map_data_using_compatibility_format(int p_layer, TileMap
 	for (int i = 0; i < c; i += offset) {
 		const uint8_t *ptr = (const uint8_t *)&r[i];
 		uint8_t local[12];
-		const int buffer_size = (format == TILE_MAP_DATA_FORMAT_2) ? 12 : 8;
+		const int buffer_size = (p_format >= TILE_MAP_DATA_FORMAT_2) ? 12 : 8;
 		for (int j = 0; j < buffer_size; j++) {
 			local[j] = ptr[j];
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2795,7 +2795,10 @@ void RichTextLabel::_thread_end() {
 void RichTextLabel::_stop_thread() {
 	if (threaded) {
 		stop_thread.store(true);
-		wait_until_finished();
+		if (task != WorkerThreadPool::INVALID_TASK_ID) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(task);
+			task = WorkerThreadPool::INVALID_TASK_ID;
+		}
 	}
 }
 
@@ -2817,13 +2820,6 @@ bool RichTextLabel::is_ready() const {
 
 bool RichTextLabel::is_updating() const {
 	return updating.load() || validating.load();
-}
-
-void RichTextLabel::wait_until_finished() {
-	if (task != WorkerThreadPool::INVALID_TASK_ID) {
-		WorkerThreadPool::get_singleton()->wait_for_task_completion(task);
-		task = WorkerThreadPool::INVALID_TASK_ID;
-	}
 }
 
 void RichTextLabel::set_threaded(bool p_threaded) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -794,7 +794,6 @@ public:
 	int get_pending_paragraphs() const;
 	bool is_ready() const;
 	bool is_updating() const;
-	void wait_until_finished();
 
 	void set_threaded(bool p_threaded);
 	bool is_threaded() const;


### PR DESCRIPTION
Fix issue with Tilemaps not displaying correctly since redot-4.3.1-alpha.1

- Revert "Rationalize busy waits" (3f4c085593ba6e286db01613f789a8c833e81ec8) from #933
```git revert -m 1 3f4c085593ba6e286db01613f789a8c833e81ec8```

- Cherry -pick "[Fix setting TileMap data compatibility format broken by #98898](https://github.com/Redot-Engine/redot-engine/pull/977/commits/e105e675b937a741c51506453e2639dec04fc4a6)" fix for 22c260477641fac79ef964f1bb5f4198e35d25da (#933)
```git cherry-pick -x 282425eefb9e97ab31ff0f25f3b135ed2e2aca42```