### PR TITLE
[4.3] Fixed occlusion culling buffer getting overwritten in larger scenes

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -385,7 +385,7 @@ void RaycastOcclusionCull::Scenario::_transform_vertices_thread(uint32_t p_threa
 }
 
 void RaycastOcclusionCull::Scenario::_transform_vertices_range(const Vector3 *p_read, float *p_write, const Transform3D &p_xform, int p_from, int p_to) {
-	float *floats_w = p_write;
+	float *floats_w = p_write + 3 * p_from;
 	for (int i = p_from; i < p_to; i++) {
 		const Vector3 p = p_xform.xform(p_read[i]);
 		floats_w[0] = p.x;


### PR DESCRIPTION
- Original PR:  godotengine/godot#100060
- Fixes #972

(cherry picked from commit 329d25b1fafccf5e8059c494b6210f1805b0b4bb)

---
- Related godotengine/godot#100032

On subsequent calls to `_transform_vertices_range()` (where `p_from` would have been adjusted) it would still start writing to the same index in of `xformed_vertices` effectively overwriting and corrupting vertex data previously written.
 
The correct implementation is to offset `p_write` with 3*`p_from`.
 
I tested using [occlusion_culling_mesh_lod](https://github.com/godotengine/godot-demo-projects/tree/master/3d/occlusion_culling_mesh_lod) for both double and float builds.
 
Before:
![image](https://github.com/user-attachments/assets/ffd770f7-5c37-4576-9ea8-638920598345)
 
After:
![image](https://github.com/user-attachments/assets/01325bbb-0728-4c1f-a932-98dde604e53c)

