### PR TITLE
[4.3] CI: Add redot-cpp testing

### DIFF
--- a/.github/workflows/redot_cpp_test.yml
+++ b/.github/workflows/redot_cpp_test.yml
@@ -1,0 +1,58 @@
+name: 🪲 Redot CPP
+on:
+  workflow_call:
+
+# Global Settings
+env:
+  # Used for the cache key. Add version suffix to force clean build.
+  REDOT_BASE_BRANCH: 4.3
+  # Used for the godot-cpp checkout.
+  REDOT_CPP_BRANCH: '4.3'
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests
+  cancel-in-progress: true
+
+jobs:
+  redot-cpp-tests:
+    runs-on: ubuntu-24.04
+    name: Build and test Redot CPP
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
+      # Checkout godot-cpp
+      - name: Checkout godot-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: Redot-Engine/redot-cpp
+          ref: ${{ env.REDOT_CPP_BRANCH }}
+          submodules: 'recursive'
+          path: 'redot-cpp'
+
+      # Download generated API dump
+      - name: Download GDExtension interface and API dump
+        uses: ./.github/actions/download-artifact
+        with:
+          name: 'godot-api-dump'
+          path: './redot-api'
+
+      # Extract and override existing files with generated files
+      - name: Extract GDExtension interface and API dump
+        run: |
+          cp -f redot-api/gdextension_interface.h redot-cpp/gdextension/
+          cp -f redot-api/extension_api.json redot-cpp/gdextension/
+
+      # TODO: Add caching to the SCons build and store it for CI via the godot-cache
+      # action.
+
+      # Build redot-cpp test extension
+      - name: Build redot-cpp test extension
+        run: |
+          cd redot-cpp/test
+          scons target=template_debug dev_build=yes
+          cd ../..

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -63,3 +63,12 @@ jobs:
     # appropriately.
     needs: linux-build
     uses: ./.github/workflows/godot_cpp_test.yml
+
+  redot-cpp-test:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
+    name: 🪲 Redot CPP
+    # This can be changed to depend on another platform, if we decide to use it for
+    # redot-cpp instead. Make sure to move the .github/actions/redot-api-dump step
+    # appropriately.
+    needs: linux-build
+    uses: ./.github/workflows/redot_cpp_test.yml


### PR DESCRIPTION
- 4.3 version of #982

Ensures that we are testing [redot-cpp](https://github.com/Redot-Engine/redot-cpp) alongside godot-cpp in our CI, this ensures we'll actually address issues related to redot-cpp when we merge PRs.