### PR TITLE
CI: Add redot-cpp testing action

### DIFF
--- a/.github/actions/redot-cpp-build/action.yml
+++ b/.github/actions/redot-cpp-build/action.yml
@@ -1,0 +1,39 @@
+name: Build redot-cpp
+description: Build redot-cpp with the provided options.
+
+env:
+  REDOT_CPP_BRANCH: 4.3
+
+inputs:
+  bin:
+    description: Path to the Redot binary.
+    required: true
+    type: string
+  scons-flags:
+    description: Additional SCons flags.
+    type: string
+  scons-cache:
+    description: The SCons cache path.
+    default: ${{ github.workspace }}/.scons_cache/
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        repository: Redot-Engine/redot-cpp
+        ref: ${{ env.REDOT_CPP_BRANCH }}
+        path: redot-cpp
+
+    - name: Extract API
+      shell: sh
+      run: ${{ inputs.bin }} --headless --dump-gdextension-interface --dump-extension-api
+
+    - name: SCons Build
+      shell: sh
+      env:
+        SCONS_CACHE: ${{ inputs.scons-cache }}
+      run: scons --directory=./redot-cpp/test "gdextension_dir=${{ github.workspace }}" ${{ inputs.scons-flags }}

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -35,6 +35,8 @@ jobs:
             artifact: true
             # Validate godot-cpp compatibility on one arbitrary editor build.
             godot-cpp: true
+            # Validate redot-cpp compatibility on one arbitrary editor build.
+            redot-cpp: true
             cache-limit: 2
 
           - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
@@ -171,6 +173,13 @@ jobs:
       - name: Compilation (godot-cpp)
         uses: ./.github/actions/godot-cpp-build
         if: matrix.godot-cpp
+        with:
+          bin: ${{ matrix.bin }}
+          scons-flags: target=template_debug dev_build=yes verbose=yes
+
+      - name: Compilation (redot-cpp)
+        uses: ./.github/actions/redot-cpp-build
+        if: matrix.redot-cpp
         with:
           bin: ${{ matrix.bin }}
           scons-flags: target=template_debug dev_build=yes verbose=yes


### PR DESCRIPTION
- master version of #981

Ensures that we are testing [redot-cpp](https://github.com/Redot-Engine/redot-cpp) alongside godot-cpp in our CI, this ensures we'll actually address issues related to redot-cpp when we merge PRs.