### PR TITLE
Add `get_redot_version` to GDExtension interface

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -164,13 +164,13 @@ Dictionary Engine::get_godot_compatible_version_info() const {
 	dict["patch"] = GODOT_VERSION_PATCH;
 	dict["hex"] = GODOT_VERSION_HEX;
 	dict["status"] = GODOT_VERSION_STATUS;
+	dict["build"] = GODOT_VERSION_BUILD;
 
 	String stringver = String(dict["major"]) + "." + String(dict["minor"]);
 	if ((int)dict["patch"] != 0) {
 		stringver += "." + String(dict["patch"]);
 	}
-	// stringver += "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")"; TODO: add godot automated build identification?
-	stringver += "-" + String(dict["status"]);
+	stringver += "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")";
 	dict["string"] = stringver;
 
 	return dict;

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -244,10 +244,23 @@ GDExtensionInterfaceFunctionPtr gdextension_get_proc_address(const char *p_name)
 }
 
 static void gdextension_get_godot_version(GDExtensionGodotVersion *r_godot_version) {
-	r_godot_version->major = VERSION_MAJOR;
-	r_godot_version->minor = VERSION_MINOR;
-	r_godot_version->patch = VERSION_PATCH;
-	r_godot_version->string = VERSION_FULL_NAME;
+	r_godot_version->major = GODOT_VERSION_MAJOR;
+	r_godot_version->minor = GODOT_VERSION_MINOR;
+	r_godot_version->patch = GODOT_VERSION_PATCH;
+	r_godot_version->string = GODOT_VERSION_FULL_NAME;
+}
+
+static void gdextension_get_redot_version(GDExtensionRedotVersion *r_redot_version) {
+	r_redot_version->major = VERSION_MAJOR;
+	r_redot_version->minor = VERSION_MINOR;
+	r_redot_version->patch = VERSION_PATCH;
+	r_redot_version->hex = VERSION_HEX;
+	r_redot_version->status = VERSION_STATUS;
+	r_redot_version->status_version = VERSION_STATUS_VERSION;
+	r_redot_version->build = VERSION_BUILD;
+	r_redot_version->hash = VERSION_HASH;
+	r_redot_version->timestamp = VERSION_TIMESTAMP;
+	r_redot_version->string = VERSION_FULL_NAME;
 }
 
 // Memory Functions
@@ -1669,6 +1682,7 @@ static void gdextension_editor_help_load_xml_from_utf8_chars(const char *p_data)
 
 void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(get_godot_version);
+	REGISTER_INTERFACE_FUNC(get_redot_version);
 	REGISTER_INTERFACE_FUNC(mem_alloc);
 	REGISTER_INTERFACE_FUNC(mem_realloc);
 	REGISTER_INTERFACE_FUNC(mem_free);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -792,6 +792,19 @@ typedef struct {
 	const char *string;
 } GDExtensionGodotVersion;
 
+typedef struct {
+	uint32_t major;
+	uint32_t minor;
+	uint32_t patch;
+	uint32_t hex; // Full version encoded as hexadecimal with one byte (2 hex digits) per number (e.g. for "3.1.12" it would be 0x03010C)
+	const char *status; // (e.g. "stable", "beta", "rc")
+	uint32_t status_version;
+	const char *build; // (e.g. "custom_build")
+	const char *hash; // Full Git commit hash.
+	uint64_t timestamp; // Git commit date UNIX timestamp in seconds, or 0 if unavailable.
+	const char *string; // (e.g. "Redot v3.1.4.stable.official.mono")
+} GDExtensionRedotVersion;
+
 /**
  * @name get_godot_version
  * @since 4.1
@@ -801,6 +814,16 @@ typedef struct {
  * @param r_godot_version A pointer to the structure to write the version information into.
  */
 typedef void (*GDExtensionInterfaceGetGodotVersion)(GDExtensionGodotVersion *r_godot_version);
+
+/**
+ * @name get_redot_version
+ * @since 4.3
+ *
+ * Gets the Redot version that the GDExtension was loaded into.
+ *
+ * @param r_redot_version A pointer to the structure to write the version information into.
+ */
+typedef void (*GDExtensionInterfaceGetRedotVersion)(GDExtensionRedotVersion *r_redot_version);
 
 /* INTERFACE: Memory */
 

--- a/core/version.h
+++ b/core/version.h
@@ -59,6 +59,14 @@
 #define VERSION_NUMBER VERSION_BRANCH
 #endif // VERSION_PATCH
 
+#define GODOT_VERSION_BRANCH _MKSTR(GODOT_VERSION_MAJOR) "." _MKSTR(GODOT_VERSION_MINOR)
+#if GODOT_VERSION_PATCH
+// Example: "3.1.4"
+#define GODOT_VERSION_NUMBER GODOT_VERSION_BRANCH "." _MKSTR(GODOT_VERSION_PATCH)
+#else // patch is 0, we don't include it in the "pretty" version number.
+#define GODOT_VERSION_NUMBER GODOT_VERSION_BRANCH
+#endif // GODOT_VERSION_PATCH
+
 // Version number encoded as hexadecimal int with one byte for each number,
 // for easy comparison from code.
 // Example: 3.1.4 will be 0x030104, making comparison easy from script.
@@ -73,14 +81,22 @@
 #define VERSION_FULL_CONFIG VERSION_NUMBER "." VERSION_STATUS "." _MKSTR(VERSION_STATUS_VERSION) VERSION_MODULE_CONFIG
 #endif
 
+#define GODOT_VERSION_FULL_CONFIG GODOT_VERSION_NUMBER "." GODOT_VERSION_STATUS VERSION_MODULE_CONFIG
+
 // Similar to VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
 // description (e.g. official, custom_build, etc.).
 // Example: "3.1.4.stable.mono.official"
 #define VERSION_FULL_BUILD VERSION_FULL_CONFIG "." VERSION_BUILD
 
+#define GODOT_VERSION_BUILD "redot." VERSION_BUILD
+#define GODOT_VERSION_FULL_BUILD GODOT_VERSION_FULL_CONFIG "." GODOT_VERSION_BUILD
+
 // Same as above, but prepended with Redot's name and a cosmetic "v" for "version".
 // Example: "Redot v3.1.4.stable.official.mono"
 #define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL_BUILD
+
+#define GODOT_VERSION_NAME "Godot Engine"
+#define GODOT_VERSION_FULL_NAME GODOT_VERSION_NAME " v" GODOT_VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
 extern const char *const VERSION_HASH;
@@ -107,20 +123,6 @@ extern const uint64_t VERSION_TIMESTAMP;
 #define GODOT_VERSION_HEX 0x10000 * GODOT_VERSION_MAJOR + 0x100 * GODOT_VERSION_MINOR + GODOT_VERSION_PATCH
 
 // TODO: determine how to deal with godot compatible versioning behavior
-
-// Describes the full configuration of that Redot version, including the version number,
-// the status (beta, stable, etc.) and potential module-specific features (e.g. mono).
-// Example: "3.1.4.stable.mono"
-// #define GODOT_VERSION_FULL_CONFIG VERSION_NUMBER "." GODOT_VERSION_STATUS VERSION_MODULE_CONFIG
-
-// Similar to GODOT_VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
-// description (e.g. official, custom_build, etc.).
-// Example: "3.1.4.stable.mono.official"
-// #define GODOT_VERSION_FULL_BUILD GODOT_VERSION_FULL_CONFIG "." GODOT_VERSION_BUILD
-
-// Same as above, but prepended with Redot's name and a cosmetic "v" for "version".
-// Example: "Godot v3.1.4.stable.official.mono"
-// #define GODOT_VERSION_FULL_NAME GODOT_VERSION_NAME " v" GODOT_VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
 // extern const char *const GODOT_VERSION_HASH;

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -72,7 +72,8 @@
 				- [code]patch[/code] - Patch version number as an int;
 				- [code]hex[/code] - Full version encoded as a hexadecimal int with one byte (2 hex digits) per number (see example below);
 				- [code]status[/code] - Status (such as "beta", "rc1", "rc2", "stable", etc.) as a String;
-				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], and [code]status[/code] in a single String.
+				- [code]build[/code] - Build name prefixed with "redot." (e.g. "redot.custom_build") as a String;
+				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code], and [code]build[/code] in a single String.
 				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].
 				[b]Note:[/b] The [code]hex[/code] value is still an [int] internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for quick version comparisons from code:
 				[codeblocks]
@@ -219,7 +220,7 @@
 				- [code]build[/code] - Build name (e.g. "custom_build") as a String;
 				- [code]hash[/code] - Full Git commit hash as a String;
 				- [code]timestamp[/code] - Holds the Git commit date UNIX timestamp in seconds as an int, or [code]0[/code] if unavailable;
-				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code], and [code]build[/code] in a single String.
+				- [code]string[/code] - [code]major[/code], [code]minor[/code], [code]patch[/code], [code]status[/code] (with [code]status_version[/code] if not [code]0[/code]), and [code]build[/code] in a single String.
 				The [code]hex[/code] value is encoded as follows, from left to right: one byte for the major, one byte for the minor, one byte for the patch version. For example, "3.1.12" would be [code]0x03010C[/code].
 				[b]Note:[/b] The [code]hex[/code] value is still an [int] internally, and printing it will give you its decimal representation, which is not particularly meaningful. Use hexadecimal literals for quick version comparisons from code:
 				[codeblocks]


### PR DESCRIPTION
- Original PR: #979

Add more godot compatible version macros
Add `build` to `Engine::get_godot_compatible_version_info`
Update `Engine.get_godot_compatible_version_info` documentation
Fix `Engine.get_version_info` documentation for `string`

(cherry picked from commit 2ccf5447ba499f3876aae39c366dbdc4a854990b)
