### PR TITLE
Fix redot-cpp-build CI action

### DIFF
--- a/.github/actions/redot-cpp-build/action.yml
+++ b/.github/actions/redot-cpp-build/action.yml
@@ -1,9 +1,6 @@
 name: Build redot-cpp
 description: Build redot-cpp with the provided options.
 
-env:
-  REDOT_CPP_BRANCH: 4.3
-
 inputs:
   bin:
     description: Path to the Redot binary.
@@ -16,6 +13,10 @@ inputs:
     description: The SCons cache path.
     default: ${{ github.workspace }}/.scons_cache/
     type: string
+  redot-cpp-branch:
+    description: The redot-cpp branch.
+    default: master
+    type: string
 
 runs:
   using: composite
@@ -25,7 +26,7 @@ runs:
       with:
         submodules: recursive
         repository: Redot-Engine/redot-cpp
-        ref: ${{ env.REDOT_CPP_BRANCH }}
+        ref: ${{ inputs.redot-cpp-branch }}
         path: redot-cpp
 
     - name: Extract API

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -187,6 +187,7 @@ jobs:
         with:
           bin: ${{ matrix.bin }}
           scons-flags: target=template_debug dev_build=yes verbose=yes
+          redot-cpp-branch: ${{ env.GODOT_CPP_BRANCH }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save


### PR DESCRIPTION
- Cherry-picked from #1009

(cherry picked from commit 4eee6655318609595dbc453811e00fed676c1704)
