### PR TITLE
Add Redot as a project feature to protect Redot projects

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -76,6 +76,7 @@ String ProjectSettings::get_imported_files_path() const {
 const PackedStringArray ProjectSettings::get_required_features() {
 	PackedStringArray features;
 	features.append(REDOT_VERSION_BRANCH);
+	features.append("Redot");
 #ifdef REAL_T_IS_DOUBLE
 	features.append("Double Precision");
 #endif


### PR DESCRIPTION
- Relies on #1020 

This ensures that whenever a Redot project is made, opened, or converted from Godot and saved, Godot will warn if/when you try to bring it back to Godot.