### PR TITLE
[4.3] Add Redot as a project feature to protect Redot projects

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -81,6 +81,7 @@ String ProjectSettings::get_imported_files_path() const {
 const PackedStringArray ProjectSettings::get_required_features() {
 	PackedStringArray features;
 	features.append(VERSION_BRANCH);
+	features.append("Redot");
 #ifdef REAL_T_IS_DOUBLE
 	features.append("Double Precision");
 #endif


### PR DESCRIPTION
- Original PR: #1023 

This ensures that whenever a Redot project is made, opened, or converted from Godot and saved, Godot will warn if/when you try to bring it back to Godot.

(cherry picked from commit 02abb1e8a19b715a1b210fa019a6d8dbe1fd140a)


