### PR TITLE
[4.3] Presized vectors, write to elements directly. 

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -785,9 +785,13 @@ TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vec
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < decomp.size(); ++i) {
-		ret.push_back(decomp[i]);
+	size_t decomp_size = decomp.size() + 1;
+	ret.resize(decomp_size);
+
+	for (size_t i = 0; i < decomp_size; ++i) {
+		ret[i] = decomp[i];
 	}
+
 	return ret;
 }
 
@@ -796,8 +800,11 @@ TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -807,8 +814,11 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -818,8 +828,11 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vecto
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -829,8 +842,11 @@ TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -840,8 +856,11 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vect
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -851,8 +870,11 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -862,8 +884,11 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polygon(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -873,8 +898,11 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polyline(const Vector<Vector2>
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -883,8 +911,11 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
 	Vector<Size2i> rects;
-	for (int i = 0; i < p_rects.size(); i++) {
-		rects.push_back(p_rects[i]);
+	size_t p_rects_size = p_rects.size() + 1;
+	rects.resize(p_rects_size);
+
+	for (size_t i = 0; i < p_rects_size; i++) {
+		rects.write[i] = Size2i(int(p_rects[i].x), int(p_rects[i].y));
 	}
 
 	Vector<Point2i> result;
@@ -893,8 +924,11 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	::Geometry2D::make_atlas(rects, result, size);
 
 	Vector<Point2> r_result;
-	for (int i = 0; i < result.size(); i++) {
-		r_result.push_back(result[i]);
+	size_t result_size = result.size() + 1;
+	r_result.resize(result_size);
+
+	for (size_t i = 0; i < result_size; i++) {
+		r_result.write[i] = Size2i(int(result[i].x), int(result[i].y));
 	}
 
 	ret["points"] = r_result;

--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -102,23 +102,28 @@ bool DebuggerMarshalls::ScriptStackVariable::deserialize(const Array &p_arr) {
 
 Array DebuggerMarshalls::OutputError::serialize() {
 	Array arr;
-	arr.push_back(hr);
-	arr.push_back(min);
-	arr.push_back(sec);
-	arr.push_back(msec);
-	arr.push_back(source_file);
-	arr.push_back(source_func);
-	arr.push_back(source_line);
-	arr.push_back(error);
-	arr.push_back(error_descr);
-	arr.push_back(warning);
-	unsigned int size = callstack.size();
 	const ScriptLanguage::StackInfo *r = callstack.ptr();
-	arr.push_back(size * 3);
-	for (int i = 0; i < callstack.size(); i++) {
-		arr.push_back(r[i].file);
-		arr.push_back(r[i].func);
-		arr.push_back(r[i].line);
+
+	unsigned int callstack_size = callstack.size();
+	unsigned int w_index = 11; // A friendly write index.
+	arr.resize(callstack_size + w_index); // callstack.size() + the next 11 headers.
+
+	arr[0] = hr;
+	arr[1] = min;
+	arr[2] = sec;
+	arr[3] = msec;
+	arr[4] = source_file;
+	arr[5] = source_func;
+	arr[6] = source_line;
+	arr[7] = error;
+	arr[8] = error_descr;
+	arr[9] = warning;
+	arr[10] = callstack_size * 3;
+
+	for (unsigned int i = 0; i < callstack_size; i++) {
+		arr[w_index++] = (r[i].file);
+		arr[w_index++] = (r[i].func);
+		arr[w_index++] = (r[i].line);
 	}
 	return arr;
 }

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -199,17 +199,21 @@ public:
 			Array arguments;
 			if (p_dict.has("arguments")) {
 				arguments = p_dict["arguments"];
-			}
-			for (int i = 0; i < arguments.size(); i++) {
-				doc.arguments.push_back(ArgumentDoc::from_dict(arguments[i]));
+				size_t arguments_size = arguments.size();
+				doc.arguments.resize(arguments_size);
+				for (size_t i = 0; i < arguments_size; i++) {
+					doc.arguments.write[i] = ArgumentDoc::from_dict(arguments[i]);
+				}
 			}
 
 			Array errors_returned;
 			if (p_dict.has("errors_returned")) {
 				errors_returned = p_dict["errors_returned"];
-			}
-			for (int i = 0; i < errors_returned.size(); i++) {
-				doc.errors_returned.push_back(errors_returned[i]);
+				size_t errors_returned_size = errors_returned.size();
+				doc.errors_returned.resize(errors_returned_size);
+				for (size_t i = 0; i < errors_returned_size; i++) {
+					doc.errors_returned.write[i] = errors_returned[i];
+				}
 			}
 
 			if (p_dict.has("keywords")) {
@@ -256,16 +260,20 @@ public:
 
 			if (!p_doc.arguments.is_empty()) {
 				Array arguments;
-				for (int i = 0; i < p_doc.arguments.size(); i++) {
-					arguments.push_back(ArgumentDoc::to_dict(p_doc.arguments[i]));
+				size_t p_doc_arguments_size = p_doc.arguments.size();
+				arguments.resize(p_doc_arguments_size);
+				for (size_t i = 0; i < p_doc_arguments_size; i++) {
+					arguments[i] = ArgumentDoc::to_dict(p_doc.arguments[i]);
 				}
 				dict["arguments"] = arguments;
 			}
 
 			if (!p_doc.errors_returned.is_empty()) {
 				Array errors_returned;
-				for (int i = 0; i < p_doc.errors_returned.size(); i++) {
-					errors_returned.push_back(p_doc.errors_returned[i]);
+				size_t p_doc_errors_returned_size = p_doc.errors_returned.size();
+				errors_returned.resize(p_doc_errors_returned_size);
+				for (size_t i = 0; i < p_doc_errors_returned_size; i++) {
+					errors_returned[i] = p_doc.errors_returned[i];
 				}
 				dict["errors_returned"] = errors_returned;
 			}
@@ -729,81 +737,99 @@ public:
 			Array tutorials;
 			if (p_dict.has("tutorials")) {
 				tutorials = p_dict["tutorials"];
-			}
-			for (int i = 0; i < tutorials.size(); i++) {
-				doc.tutorials.push_back(TutorialDoc::from_dict(tutorials[i]));
+				size_t tutorials_size = tutorials.size();
+				doc.tutorials.resize(tutorials_size);
+				for (size_t i = 0; i < tutorials_size; i++) {
+					doc.tutorials.write[i] = TutorialDoc::from_dict(tutorials[i]);
+				}
 			}
 
 			Array constructors;
 			if (p_dict.has("constructors")) {
 				constructors = p_dict["constructors"];
-			}
-			for (int i = 0; i < constructors.size(); i++) {
-				doc.constructors.push_back(MethodDoc::from_dict(constructors[i]));
+				size_t constructors_size = constructors.size();
+				doc.constructors.resize(constructors_size);
+				for (size_t i = 0; i < constructors_size; i++) {
+					doc.constructors.write[i] = MethodDoc::from_dict(constructors[i]);
+				}
 			}
 
 			Array methods;
 			if (p_dict.has("methods")) {
 				methods = p_dict["methods"];
-			}
-			for (int i = 0; i < methods.size(); i++) {
-				doc.methods.push_back(MethodDoc::from_dict(methods[i]));
+				size_t methods_size = methods.size();
+				doc.methods.resize(methods_size);
+				for (size_t i = 0; i < methods_size; i++) {
+					doc.methods.write[i] = MethodDoc::from_dict(methods[i]);
+				}
 			}
 
 			Array operators;
 			if (p_dict.has("operators")) {
 				operators = p_dict["operators"];
-			}
-			for (int i = 0; i < operators.size(); i++) {
-				doc.operators.push_back(MethodDoc::from_dict(operators[i]));
+				size_t operators_size = operators.size();
+				doc.operators.resize(operators_size);
+				for (size_t i = 0; i < operators_size; i++) {
+					doc.operators.write[i] = MethodDoc::from_dict(operators[i]);
+				}
 			}
 
 			Array signals;
 			if (p_dict.has("signals")) {
 				signals = p_dict["signals"];
-			}
-			for (int i = 0; i < signals.size(); i++) {
-				doc.signals.push_back(MethodDoc::from_dict(signals[i]));
+				size_t signals_size = signals.size();
+				doc.signals.resize(signals_size);
+				for (size_t i = 0; i < signals_size; i++) {
+					doc.signals.write[i] = MethodDoc::from_dict(signals[i]);
+				}
 			}
 
 			Array constants;
 			if (p_dict.has("constants")) {
 				constants = p_dict["constants"];
-			}
-			for (int i = 0; i < constants.size(); i++) {
-				doc.constants.push_back(ConstantDoc::from_dict(constants[i]));
+				size_t constants_size = constants.size();
+				doc.constants.resize(constants_size);
+				for (size_t i = 0; i < constants_size; i++) {
+					doc.constants.write[i] = ConstantDoc::from_dict(constants[i]);
+				}
 			}
 
 			Dictionary enums;
 			if (p_dict.has("enums")) {
 				enums = p_dict["enums"];
-			}
-			for (int i = 0; i < enums.size(); i++) {
-				doc.enums[enums.get_key_at_index(i)] = EnumDoc::from_dict(enums.get_value_at_index(i));
+				for (int i = 0; i < enums.size(); i++) {
+					doc.enums[enums.get_key_at_index(i)] = EnumDoc::from_dict(enums.get_value_at_index(i));
+				}
 			}
 
 			Array properties;
 			if (p_dict.has("properties")) {
 				properties = p_dict["properties"];
-			}
-			for (int i = 0; i < properties.size(); i++) {
-				doc.properties.push_back(PropertyDoc::from_dict(properties[i]));
+				size_t properties_size = properties.size();
+				doc.properties.resize(properties_size);
+				for (size_t i = 0; i < properties_size; i++) {
+					doc.properties.write[i] = PropertyDoc::from_dict(properties[i]);
+				}
 			}
 
 			Array annotations;
 			if (p_dict.has("annotations")) {
 				annotations = p_dict["annotations"];
-			}
-			for (int i = 0; i < annotations.size(); i++) {
-				doc.annotations.push_back(MethodDoc::from_dict(annotations[i]));
+				size_t annotations_size = annotations.size();
+				doc.annotations.resize(annotations_size);
+				for (size_t i = 0; i < annotations_size; i++) {
+					doc.annotations.write[i] = MethodDoc::from_dict(annotations[i]);
+				}
 			}
 
 			Array theme_properties;
 			if (p_dict.has("theme_properties")) {
 				theme_properties = p_dict["theme_properties"];
-			}
-			for (int i = 0; i < theme_properties.size(); i++) {
-				doc.theme_properties.push_back(ThemeItemDoc::from_dict(theme_properties[i]));
+				size_t theme_properties_size = theme_properties.size();
+				doc.theme_properties.resize(theme_properties_size);
+				for (size_t i = 0; i < theme_properties_size; i++) {
+					doc.theme_properties.write[i] = ThemeItemDoc::from_dict(theme_properties[i]);
+				}
 			}
 
 #ifndef DISABLE_DEPRECATED
@@ -857,48 +883,60 @@ public:
 
 			if (!p_doc.tutorials.is_empty()) {
 				Array tutorials;
-				for (int i = 0; i < p_doc.tutorials.size(); i++) {
-					tutorials.push_back(TutorialDoc::to_dict(p_doc.tutorials[i]));
+				size_t p_doc_tutorials_size = p_doc.tutorials.size();
+				tutorials.resize(p_doc_tutorials_size);
+				for (size_t i = 0; i < p_doc_tutorials_size; i++) {
+					tutorials[i] = TutorialDoc::to_dict(p_doc.tutorials[i]);
 				}
 				dict["tutorials"] = tutorials;
 			}
 
 			if (!p_doc.constructors.is_empty()) {
 				Array constructors;
-				for (int i = 0; i < p_doc.constructors.size(); i++) {
-					constructors.push_back(MethodDoc::to_dict(p_doc.constructors[i]));
+				size_t p_doc_constructors_size = p_doc.constructors.size();
+				constructors.resize(p_doc_constructors_size);
+				for (size_t i = 0; i < p_doc_constructors_size; i++) {
+					constructors[i] = MethodDoc::to_dict(p_doc.constructors[i]);
 				}
 				dict["constructors"] = constructors;
 			}
 
 			if (!p_doc.methods.is_empty()) {
 				Array methods;
-				for (int i = 0; i < p_doc.methods.size(); i++) {
-					methods.push_back(MethodDoc::to_dict(p_doc.methods[i]));
+				size_t p_doc_methods_size = p_doc.methods.size();
+				methods.resize(p_doc_methods_size);
+				for (size_t i = 0; i < p_doc_methods_size; i++) {
+					methods[i] = MethodDoc::to_dict(p_doc.methods[i]);
 				}
 				dict["methods"] = methods;
 			}
 
 			if (!p_doc.operators.is_empty()) {
 				Array operators;
-				for (int i = 0; i < p_doc.operators.size(); i++) {
-					operators.push_back(MethodDoc::to_dict(p_doc.operators[i]));
+				size_t p_doc_operators_size = p_doc.operators.size();
+				operators.resize(p_doc_operators_size);
+				for (size_t i = 0; i < p_doc_operators_size; i++) {
+					operators[i] = MethodDoc::to_dict(p_doc.operators[i]);
 				}
 				dict["operators"] = operators;
 			}
 
 			if (!p_doc.signals.is_empty()) {
 				Array signals;
-				for (int i = 0; i < p_doc.signals.size(); i++) {
-					signals.push_back(MethodDoc::to_dict(p_doc.signals[i]));
+				size_t p_doc_signals_size = p_doc.signals.size();
+				signals.resize(p_doc_signals_size);
+				for (size_t i = 0; i < p_doc_signals_size; i++) {
+					signals[i] = MethodDoc::to_dict(p_doc.signals[i]);
 				}
 				dict["signals"] = signals;
 			}
 
 			if (!p_doc.constants.is_empty()) {
 				Array constants;
-				for (int i = 0; i < p_doc.constants.size(); i++) {
-					constants.push_back(ConstantDoc::to_dict(p_doc.constants[i]));
+				size_t p_doc_constants_size = p_doc.constants.size();
+				constants.resize(p_doc_constants_size);
+				for (size_t i = 0; i < p_doc_constants_size; i++) {
+					constants[i] = ConstantDoc::to_dict(p_doc.constants[i]);
 				}
 				dict["constants"] = constants;
 			}
@@ -913,24 +951,30 @@ public:
 
 			if (!p_doc.properties.is_empty()) {
 				Array properties;
-				for (int i = 0; i < p_doc.properties.size(); i++) {
-					properties.push_back(PropertyDoc::to_dict(p_doc.properties[i]));
+				size_t p_doc_properties_size = p_doc.properties.size();
+				properties.resize(p_doc_properties_size);
+				for (size_t i = 0; i < p_doc_properties_size; i++) {
+					properties[i] = PropertyDoc::to_dict(p_doc.properties[i]);
 				}
 				dict["properties"] = properties;
 			}
 
 			if (!p_doc.annotations.is_empty()) {
 				Array annotations;
-				for (int i = 0; i < p_doc.annotations.size(); i++) {
-					annotations.push_back(MethodDoc::to_dict(p_doc.annotations[i]));
+				size_t p_doc_annotations_size = p_doc.annotations.size();
+				annotations.resize(p_doc_annotations_size);
+				for (size_t i = 0; i < p_doc_annotations_size; i++) {
+					annotations[i] = MethodDoc::to_dict(p_doc.annotations[i]);
 				}
 				dict["annotations"] = annotations;
 			}
 
 			if (!p_doc.theme_properties.is_empty()) {
 				Array theme_properties;
-				for (int i = 0; i < p_doc.theme_properties.size(); i++) {
-					theme_properties.push_back(ThemeItemDoc::to_dict(p_doc.theme_properties[i]));
+				size_t p_doc_theme_properties_size = p_doc.theme_properties.size();
+				theme_properties.resize(p_doc_theme_properties_size);
+				for (size_t i = 0; i < p_doc_theme_properties_size; i++) {
+					theme_properties[i] = ThemeItemDoc::to_dict(p_doc.theme_properties[i]);
 				}
 				dict["theme_properties"] = theme_properties;
 			}

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1103,9 +1103,11 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 						Vector<uint32_t> compat_hashes = ClassDB::get_method_compatibility_hashes(class_name, method_name);
 						Array compatibility;
-						if (compat_hashes.size()) {
-							for (int i = 0; i < compat_hashes.size(); i++) {
-								compatibility.push_back(compat_hashes[i]);
+						size_t compat_hashes_size = compat_hashes.size();
+						if (compat_hashes_size) {
+							compatibility.resize(compat_hashes_size);
+							for (size_t i = 0; i < compat_hashes_size; i++) {
+								compatibility[i] = compat_hashes[i];
 							}
 						}
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -432,8 +432,9 @@ public:
 				option.location = op["location"];
 				if (op.has("matches")) {
 					PackedInt32Array matches = op["matches"];
-					ERR_CONTINUE(matches.size() & 1);
-					for (int j = 0; j < matches.size(); j += 2) {
+					size_t matches_size = matches.size();
+					ERR_CONTINUE(matches_size & 1);
+					for (size_t j = 0; j < matches_size; j += 2) {
 						option.matches.push_back(Pair<int, int>(matches[j], matches[j + 1]));
 					}
 				}

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -390,11 +390,15 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E, bool p_execu
 					} else {
 						args.clear();
 
-						for (int i = 0; i < binds.size(); i++) {
-							args.push_back(&binds[i]);
+						size_t binds_size = binds.size();
+
+						args.resize(binds_size);
+
+						for (size_t i = 0; i < binds_size; i++) {
+							args[i] = &binds[i];
 						}
 
-						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds.size());
+						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds_size);
 					}
 				}
 			} break;


### PR DESCRIPTION
I did a test with a blank project. Before the changes
```
$ ps -p `pgrep redot` -o vsz,rss,pmem                                                                         
   VSZ   RSS %MEM
4121136 791364  1.2
```

After the changes:
```
$ ps -p `pgrep redot` -o vsz,rss,pmem                                                                         
   VSZ   RSS %MEM
2300024 689524  1.0
```

I think this is an unrealistic, but it was consistently less resource intensive for both the CPU and for the RAM after repeated tests.

We can do better with memory management and I think this is a good starting point. I meant to pull these changes in from ReX before, but I must have forgot to. That's not an intentional pun.