### PR TITLE
Preallocate vectors with known size

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -947,8 +947,11 @@ TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vec
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < decomp.size(); ++i) {
-		ret.push_back(decomp[i]);
+	size_t decomp_size = decomp.size() + 1;
+	ret.resize(decomp_size);
+
+	for (size_t i = 0; i < decomp_size; ++i) {
+		ret[i] = decomp[i];
 	}
 	return ret;
 }
@@ -958,8 +961,11 @@ TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -969,8 +975,11 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -980,8 +989,11 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vecto
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -991,8 +1003,11 @@ TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -1002,8 +1017,11 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vect
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -1013,8 +1031,11 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -1024,8 +1045,11 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polygon(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -1035,8 +1059,11 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polyline(const Vector<Vector2>
 
 	TypedArray<PackedVector2Array> ret;
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	size_t polys_size = polys.size() + 1;
+	ret.resize(polys_size);
+
+	for (size_t i = 0; i < polys_size; ++i) {
+		ret[i] = polys[i];
 	}
 	return ret;
 }
@@ -1045,8 +1072,11 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
 	Vector<Size2i> rects;
-	for (int i = 0; i < p_rects.size(); i++) {
-		rects.push_back(p_rects[i]);
+	size_t p_rects_size = p_rects.size() + 1;
+	rects.resize(p_rects_size);
+
+	for (size_t i = 0; i < p_rects_size; i++) {
+		rects.write[i] = Size2i(int(p_rects[i].x), int(p_rects[i].y));
 	}
 
 	Vector<Point2i> result;
@@ -1055,8 +1085,11 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	::Geometry2D::make_atlas(rects, result, size);
 
 	Vector<Point2> r_result;
-	for (int i = 0; i < result.size(); i++) {
-		r_result.push_back(result[i]);
+	size_t result_size = result.size() + 1;
+	r_result.resize(result_size);
+
+	for (size_t i = 0; i < result_size; i++) {
+		r_result.write[i] = Size2i(int(result[i].x), int(result[i].y));
 	}
 
 	ret["points"] = r_result;

--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -97,24 +97,29 @@ bool DebuggerMarshalls::ScriptStackVariable::deserialize(const Array &p_arr) {
 }
 
 Array DebuggerMarshalls::OutputError::serialize() {
-	unsigned int size = callstack.size();
-	Array arr = {
-		hr,
-		min,
-		sec, msec,
-		source_file,
-		source_func,
-		source_line,
-		error,
-		error_descr,
-		warning,
-		size * 3
-	};
+	Array arr;
 	const ScriptLanguage::StackInfo *r = callstack.ptr();
-	for (int i = 0; i < callstack.size(); i++) {
-		arr.push_back(r[i].file);
-		arr.push_back(r[i].func);
-		arr.push_back(r[i].line);
+
+	unsigned int callstack_size = callstack.size();
+	unsigned int w_index = 11; // A friendly write index.
+	arr.resize(callstack_size + w_index); // callstack.size() + the next 11 headers.
+
+	arr[0] = hr;
+	arr[1] = min;
+	arr[2] = sec;
+	arr[3] = msec;
+	arr[4] = source_file;
+	arr[5] = source_func;
+	arr[6] = source_line;
+	arr[7] = error;
+	arr[8] = error_descr;
+	arr[9] = warning;
+	arr[10] = callstack_size * 3;
+
+	for (unsigned int i = 0; i < callstack_size; i++) {
+		arr[w_index++] = (r[i].file);
+		arr[w_index++] = (r[i].func);
+		arr[w_index++] = (r[i].line);
 	}
 	return arr;
 }

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -188,17 +188,21 @@ public:
 			Array arguments;
 			if (p_dict.has("arguments")) {
 				arguments = p_dict["arguments"];
-			}
-			for (int i = 0; i < arguments.size(); i++) {
-				doc.arguments.push_back(ArgumentDoc::from_dict(arguments[i]));
+				size_t arguments_size = arguments.size();
+				doc.arguments.resize(arguments_size);
+				for (size_t i = 0; i < arguments_size; i++) {
+					doc.arguments.write[i] = ArgumentDoc::from_dict(arguments[i]);
+				}
 			}
 
 			Array errors_returned;
 			if (p_dict.has("errors_returned")) {
 				errors_returned = p_dict["errors_returned"];
-			}
-			for (int i = 0; i < errors_returned.size(); i++) {
-				doc.errors_returned.push_back(errors_returned[i]);
+				size_t errors_returned_size = errors_returned.size();
+				doc.errors_returned.resize(errors_returned_size);
+				for (size_t i = 0; i < errors_returned_size; i++) {
+					doc.errors_returned.write[i] = errors_returned[i];
+				}
 			}
 
 			if (p_dict.has("keywords")) {
@@ -245,16 +249,20 @@ public:
 
 			if (!p_doc.arguments.is_empty()) {
 				Array arguments;
-				for (int i = 0; i < p_doc.arguments.size(); i++) {
-					arguments.push_back(ArgumentDoc::to_dict(p_doc.arguments[i]));
+				size_t p_doc_arguments_size = p_doc.arguments.size();
+				arguments.resize(p_doc_arguments_size);
+				for (size_t i = 0; i < p_doc_arguments_size; i++) {
+					arguments[i] = ArgumentDoc::to_dict(p_doc.arguments[i]);
 				}
 				dict["arguments"] = arguments;
 			}
 
 			if (!p_doc.errors_returned.is_empty()) {
 				Array errors_returned;
-				for (int i = 0; i < p_doc.errors_returned.size(); i++) {
-					errors_returned.push_back(p_doc.errors_returned[i]);
+				size_t p_doc_errors_returned_size = p_doc.errors_returned.size();
+				errors_returned.resize(p_doc_errors_returned_size);
+				for (size_t i = 0; i < p_doc_errors_returned_size; i++) {
+					errors_returned[i] = p_doc.errors_returned[i];
 				}
 				dict["errors_returned"] = errors_returned;
 			}
@@ -747,49 +755,61 @@ public:
 			Array tutorials;
 			if (p_dict.has("tutorials")) {
 				tutorials = p_dict["tutorials"];
-			}
-			for (int i = 0; i < tutorials.size(); i++) {
-				doc.tutorials.push_back(TutorialDoc::from_dict(tutorials[i]));
+				size_t tutorials_size = tutorials.size();
+				doc.tutorials.resize(tutorials_size);
+				for (size_t i = 0; i < tutorials_size; i++) {
+					doc.tutorials.write[i] = TutorialDoc::from_dict(tutorials[i]);
+				}
 			}
 
 			Array constructors;
 			if (p_dict.has("constructors")) {
 				constructors = p_dict["constructors"];
-			}
-			for (int i = 0; i < constructors.size(); i++) {
-				doc.constructors.push_back(MethodDoc::from_dict(constructors[i]));
+				size_t constructors_size = constructors.size();
+				doc.constructors.resize(constructors_size);
+				for (size_t i = 0; i < constructors_size; i++) {
+					doc.constructors.write[i] = MethodDoc::from_dict(constructors[i]);
+				}
 			}
 
 			Array methods;
 			if (p_dict.has("methods")) {
 				methods = p_dict["methods"];
-			}
-			for (int i = 0; i < methods.size(); i++) {
-				doc.methods.push_back(MethodDoc::from_dict(methods[i]));
+				size_t methods_size = methods.size();
+				doc.methods.resize(methods_size);
+				for (size_t i = 0; i < methods_size; i++) {
+					doc.methods.write[i] = MethodDoc::from_dict(methods[i]);
+				}
 			}
 
 			Array operators;
 			if (p_dict.has("operators")) {
 				operators = p_dict["operators"];
-			}
-			for (int i = 0; i < operators.size(); i++) {
-				doc.operators.push_back(MethodDoc::from_dict(operators[i]));
+				size_t operators_size = operators.size();
+				doc.operators.resize(operators_size);
+				for (size_t i = 0; i < operators_size; i++) {
+					doc.operators.write[i] = MethodDoc::from_dict(operators[i]);
+				}
 			}
 
 			Array signals;
 			if (p_dict.has("signals")) {
 				signals = p_dict["signals"];
-			}
-			for (int i = 0; i < signals.size(); i++) {
-				doc.signals.push_back(MethodDoc::from_dict(signals[i]));
+				size_t signals_size = signals.size();
+				doc.signals.resize(signals_size);
+				for (size_t i = 0; i < signals_size; i++) {
+					doc.signals.write[i] = MethodDoc::from_dict(signals[i]);
+				}
 			}
 
 			Array constants;
 			if (p_dict.has("constants")) {
 				constants = p_dict["constants"];
-			}
-			for (int i = 0; i < constants.size(); i++) {
-				doc.constants.push_back(ConstantDoc::from_dict(constants[i]));
+				size_t constants_size = constants.size();
+				doc.constants.resize(constants_size);
+				for (size_t i = 0; i < constants_size; i++) {
+					doc.constants.write[i] = ConstantDoc::from_dict(constants[i]);
+				}
 			}
 
 			Dictionary enums;
@@ -803,25 +823,31 @@ public:
 			Array properties;
 			if (p_dict.has("properties")) {
 				properties = p_dict["properties"];
-			}
-			for (int i = 0; i < properties.size(); i++) {
-				doc.properties.push_back(PropertyDoc::from_dict(properties[i]));
+				size_t properties_size = properties.size();
+				doc.properties.resize(properties_size);
+				for (size_t i = 0; i < properties_size; i++) {
+					doc.properties.write[i] = PropertyDoc::from_dict(properties[i]);
+				}
 			}
 
 			Array annotations;
 			if (p_dict.has("annotations")) {
 				annotations = p_dict["annotations"];
-			}
-			for (int i = 0; i < annotations.size(); i++) {
-				doc.annotations.push_back(MethodDoc::from_dict(annotations[i]));
+				size_t annotations_size = annotations.size();
+				doc.annotations.resize(annotations_size);
+				for (size_t i = 0; i < annotations_size; i++) {
+					doc.annotations.write[i] = MethodDoc::from_dict(annotations[i]);
+				}
 			}
 
 			Array theme_properties;
 			if (p_dict.has("theme_properties")) {
 				theme_properties = p_dict["theme_properties"];
-			}
-			for (int i = 0; i < theme_properties.size(); i++) {
-				doc.theme_properties.push_back(ThemeItemDoc::from_dict(theme_properties[i]));
+				size_t theme_properties_size = theme_properties.size();
+				doc.theme_properties.resize(theme_properties_size);
+				for (size_t i = 0; i < theme_properties_size; i++) {
+					doc.theme_properties.write[i] = ThemeItemDoc::from_dict(theme_properties[i]);
+				}
 			}
 
 #ifndef DISABLE_DEPRECATED
@@ -875,48 +901,60 @@ public:
 
 			if (!p_doc.tutorials.is_empty()) {
 				Array tutorials;
-				for (int i = 0; i < p_doc.tutorials.size(); i++) {
-					tutorials.push_back(TutorialDoc::to_dict(p_doc.tutorials[i]));
+				size_t p_doc_tutorials_size = p_doc.tutorials.size();
+				tutorials.resize(p_doc_tutorials_size);
+				for (size_t i = 0; i < p_doc_tutorials_size; i++) {
+					tutorials[i] = TutorialDoc::to_dict(p_doc.tutorials[i]);
 				}
 				dict["tutorials"] = tutorials;
 			}
 
 			if (!p_doc.constructors.is_empty()) {
 				Array constructors;
-				for (int i = 0; i < p_doc.constructors.size(); i++) {
-					constructors.push_back(MethodDoc::to_dict(p_doc.constructors[i]));
+				size_t p_doc_constructors_size = p_doc.constructors.size();
+				constructors.resize(p_doc_constructors_size);
+				for (size_t i = 0; i < p_doc_constructors_size; i++) {
+					constructors[i] = MethodDoc::to_dict(p_doc.constructors[i]);
 				}
 				dict["constructors"] = constructors;
 			}
 
 			if (!p_doc.methods.is_empty()) {
 				Array methods;
-				for (int i = 0; i < p_doc.methods.size(); i++) {
-					methods.push_back(MethodDoc::to_dict(p_doc.methods[i]));
+				size_t p_doc_methods_size = p_doc.methods.size();
+				methods.resize(p_doc_methods_size);
+				for (size_t i = 0; i < p_doc_methods_size; i++) {
+					methods[i] = MethodDoc::to_dict(p_doc.methods[i]);
 				}
 				dict["methods"] = methods;
 			}
 
 			if (!p_doc.operators.is_empty()) {
 				Array operators;
-				for (int i = 0; i < p_doc.operators.size(); i++) {
-					operators.push_back(MethodDoc::to_dict(p_doc.operators[i]));
+				size_t p_doc_operators_size = p_doc.operators.size();
+				operators.resize(p_doc_operators_size);
+				for (size_t i = 0; i < p_doc_operators_size; i++) {
+					operators[i] = MethodDoc::to_dict(p_doc.operators[i]);
 				}
 				dict["operators"] = operators;
 			}
 
 			if (!p_doc.signals.is_empty()) {
 				Array signals;
-				for (int i = 0; i < p_doc.signals.size(); i++) {
-					signals.push_back(MethodDoc::to_dict(p_doc.signals[i]));
+				size_t p_doc_signals_size = p_doc.signals.size();
+				signals.resize(p_doc_signals_size);
+				for (size_t i = 0; i < p_doc_signals_size; i++) {
+					signals[i] = MethodDoc::to_dict(p_doc.signals[i]);
 				}
 				dict["signals"] = signals;
 			}
 
 			if (!p_doc.constants.is_empty()) {
 				Array constants;
-				for (int i = 0; i < p_doc.constants.size(); i++) {
-					constants.push_back(ConstantDoc::to_dict(p_doc.constants[i]));
+				size_t p_doc_constants_size = p_doc.constants.size();
+				constants.resize(p_doc_constants_size);
+				for (size_t i = 0; i < p_doc_constants_size; i++) {
+					constants[i] = ConstantDoc::to_dict(p_doc.constants[i]);
 				}
 				dict["constants"] = constants;
 			}
@@ -931,24 +969,30 @@ public:
 
 			if (!p_doc.properties.is_empty()) {
 				Array properties;
-				for (int i = 0; i < p_doc.properties.size(); i++) {
-					properties.push_back(PropertyDoc::to_dict(p_doc.properties[i]));
+				size_t p_doc_properties_size = p_doc.properties.size();
+				properties.resize(p_doc_properties_size);
+				for (size_t i = 0; i < p_doc_properties_size; i++) {
+					properties[i] = PropertyDoc::to_dict(p_doc.properties[i]);
 				}
 				dict["properties"] = properties;
 			}
 
 			if (!p_doc.annotations.is_empty()) {
 				Array annotations;
-				for (int i = 0; i < p_doc.annotations.size(); i++) {
-					annotations.push_back(MethodDoc::to_dict(p_doc.annotations[i]));
+				size_t p_doc_annotations_size = p_doc.annotations.size();
+				annotations.resize(p_doc_annotations_size);
+				for (size_t i = 0; i < p_doc_annotations_size; i++) {
+					annotations[i] = MethodDoc::to_dict(p_doc.annotations[i]);
 				}
 				dict["annotations"] = annotations;
 			}
 
 			if (!p_doc.theme_properties.is_empty()) {
 				Array theme_properties;
-				for (int i = 0; i < p_doc.theme_properties.size(); i++) {
-					theme_properties.push_back(ThemeItemDoc::to_dict(p_doc.theme_properties[i]));
+				size_t p_doc_theme_properties_size = p_doc.theme_properties.size();
+				theme_properties.resize(p_doc_theme_properties_size);
+				for (size_t i = 0; i < p_doc_theme_properties_size; i++) {
+					theme_properties[i] = ThemeItemDoc::to_dict(p_doc.theme_properties[i]);
 				}
 				dict["theme_properties"] = theme_properties;
 			}

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1129,9 +1129,11 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 
 						Vector<uint32_t> compat_hashes = ClassDB::get_method_compatibility_hashes(class_name, method_name);
 						Array compatibility;
-						if (compat_hashes.size()) {
-							for (int i = 0; i < compat_hashes.size(); i++) {
-								compatibility.push_back(compat_hashes[i]);
+						size_t compat_hashes_size = compat_hashes.size();
+						if (compat_hashes_size) {
+							compatibility.resize(compat_hashes_size);
+							for (size_t i = 0; i < compat_hashes_size; i++) {
+								compatibility[i] = compat_hashes[i];
 							}
 						}
 

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -869,8 +869,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 			ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(_from_native(arr[i], p_full_objects, p_depth + 1));
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = _from_native(arr[i], p_full_objects, p_depth + 1);
 			}
 
 			return ret;
@@ -880,8 +883,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedByteArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -890,8 +895,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt32Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -900,8 +907,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt64Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -910,8 +919,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat32Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -920,8 +931,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat64Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -930,8 +943,10 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedStringArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			size_t arr_size = arr.size();
+			args.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
+				args[i] = arr[i];
 			}
 
 			RETURN_ARGS;
@@ -940,10 +955,13 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector2Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
+			size_t arr_size = arr.size();
+			args.resize(arr_size * 2);
+			size_t nice_index = 0;
+			for (size_t i = 0; i < arr_size; i++) {
 				Vector2 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
+				args[nice_index++] = v.x;
+				args[nice_index++] = v.y;
 			}
 
 			RETURN_ARGS;
@@ -952,11 +970,14 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector3Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
+			size_t arr_size = arr.size();
+			args.resize(arr_size * 3);
+			size_t nice_index = 0;
+			for (size_t i = 0; i < arr_size; i++) {
 				Vector3 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
+				args[nice_index++] = v.x;
+				args[nice_index++] = v.y;
+				args[nice_index++] = v.z;
 			}
 
 			RETURN_ARGS;
@@ -965,12 +986,15 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedColorArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
+			size_t arr_size = arr.size();
+			args.resize(arr_size * 4);
+			size_t nice_index = 0;
+			for (size_t i = 0; i < arr_size; i++) {
 				Color v = arr[i];
-				args.push_back(v.r);
-				args.push_back(v.g);
-				args.push_back(v.b);
-				args.push_back(v.a);
+				args[nice_index++] = v.r;
+				args[nice_index++] = v.g;
+				args[nice_index++] = v.b;
+				args[nice_index++] = v.a;
 			}
 
 			RETURN_ARGS;
@@ -979,12 +1003,15 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector4Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
+			size_t arr_size = arr.size();
+			args.resize(arr_size * 4);
+			size_t nice_index = 0;
+			for (size_t i = 0; i < arr_size; i++) {
 				Vector4 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
-				args.push_back(v.w);
+				args[nice_index++] = v.x;
+				args[nice_index++] = v.y;
+				args[nice_index++] = v.z;
+				args[nice_index++] = v.w;
 			}
 
 			RETURN_ARGS;
@@ -1314,8 +1341,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 
 					ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
-					ret.resize(args.size());
-					for (int i = 0; i < args.size(); i++) {
+					size_t args_size = args.size();
+					ret.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						ret[i] = _to_native(args[i], p_allow_objects, p_depth + 1);
 					}
 
@@ -1326,8 +1354,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedByteArray arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1337,8 +1366,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedInt32Array arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1348,8 +1378,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedInt64Array arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1359,8 +1390,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedFloat32Array arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1370,8 +1402,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedFloat64Array arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1381,8 +1414,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS();
 
 					PackedStringArray arr;
-					arr.resize(args.size());
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size();
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = args[i];
 					}
 
@@ -1392,8 +1426,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS_CHECK_FACTOR(2);
 
 					PackedVector2Array arr;
-					arr.resize(args.size() / 2);
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size() / 2;
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = Vector2(args[i * 2 + 0], args[i * 2 + 1]);
 					}
 
@@ -1403,8 +1438,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS_CHECK_FACTOR(3);
 
 					PackedVector3Array arr;
-					arr.resize(args.size() / 3);
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size() / 3;
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = Vector3(args[i * 3 + 0], args[i * 3 + 1], args[i * 3 + 2]);
 					}
 
@@ -1414,8 +1450,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS_CHECK_FACTOR(4);
 
 					PackedColorArray arr;
-					arr.resize(args.size() / 4);
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size() / 4;
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = Color(args[i * 4 + 0], args[i * 4 + 1], args[i * 4 + 2], args[i * 4 + 3]);
 					}
 
@@ -1425,8 +1462,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					LOAD_ARGS_CHECK_FACTOR(4);
 
 					PackedVector4Array arr;
-					arr.resize(args.size() / 4);
-					for (int i = 0; i < arr.size(); i++) {
+					size_t args_size = args.size() / 4;
+					arr.resize(args_size);
+					for (size_t i = 0; i < args_size; i++) {
 						arr.write[i] = Vector4(args[i * 4 + 0], args[i * 4 + 1], args[i * 4 + 2], args[i * 4 + 3]);
 					}
 
@@ -1497,8 +1535,9 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 			const Array arr = p_json;
 
 			Array ret;
-			ret.resize(arr.size());
-			for (int i = 0; i < arr.size(); i++) {
+			size_t arr_size = arr.size();
+			ret.resize(arr_size);
+			for (size_t i = 0; i < arr_size; i++) {
 				ret[i] = _to_native(arr[i], p_allow_objects, p_depth + 1);
 			}
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -428,8 +428,9 @@ public:
 				option.location = op["location"];
 				if (op.has("matches")) {
 					PackedInt32Array matches = op["matches"];
-					ERR_CONTINUE(matches.size() & 1);
-					for (int j = 0; j < matches.size(); j += 2) {
+					size_t matches_size = matches.size();
+					ERR_CONTINUE(matches_size & 1);
+					for (size_t j = 0; j < matches_size; j += 2) {
 						option.matches.push_back(Pair<int, int>(matches[j], matches[j + 1]));
 					}
 				}

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -390,11 +390,15 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E, bool p_execu
 					} else {
 						args.clear();
 
-						for (int i = 0; i < binds.size(); i++) {
-							args.push_back(&binds[i]);
+						size_t binds_size = binds.size();
+
+						args.resize(binds_size);
+
+						for (size_t i = 0; i < binds_size; i++) {
+							args[i] = &binds[i];
 						}
 
-						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds.size());
+						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds_size);
 					}
 				}
 			} break;


### PR DESCRIPTION
- Based on #1029 

I did a test with a blank project. Before the changes
 
```
$ ps -p `pgrep redot` -o vsz,rss,pmem                                                                         
   VSZ   RSS %MEM
4121136 791364  1.2
```

After the changes:

```
$ ps -p `pgrep redot` -o vsz,rss,pmem                                                                         
   VSZ   RSS %MEM
2300024 689524  1.0
```

I think this is an unrealistic, but it was consistently less resource intensive for both the CPU and for the RAM after repeated tests.

We can do better with memory management and I think this is a good starting point. I meant to pull these changes in from ReX before, but I must have forgot to. That's not an intentional pun.

