### PR TITLE
fixed simple get_tile_data to not return error if tile does not exist (simply returns nullptr)

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -5460,7 +5460,9 @@ int TileSetAtlasSource::get_alternative_tile_id(const Vector2i p_atlas_coords, i
 }
 
 TileData *TileSetAtlasSource::get_tile_data(const Vector2i p_atlas_coords, int p_alternative_tile) const {
-	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), nullptr, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
+	if(!tiles.has(p_atlas_coords)) {
+		return nullptr;
+	}
 	p_alternative_tile = alternative_no_transform(p_alternative_tile);
 	ERR_FAIL_COND_V_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), nullptr, vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
 


### PR DESCRIPTION
issue #1047 :
```func isWall(posInTiles:Vector2i):
	var tileData = walls.get_cell_tile_data(posInTiles)
	if tileData != null:
		if tileData.get_custom_data("type") == 0:
			return true
```
This should be a standard practice for tests. Tests can (and in my case often do) return null. This is expected behaviour and should not be treated as error.

Solution:
Check for existence, return nullptr without throwing an error.