### PR TITLE
Fix comment in project manager to reference Redot instead of Godot

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -108,7 +108,7 @@ void ProjectManager::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			// TRANSLATORS: This refers to the application where users manage their Godot projects.
+			// TRANSLATORS: This refers to the application where users manage their Redot projects.
 			SceneTree::get_singleton()->get_root()->set_title(REDOT_VERSION_NAME + String(" - ") + TTR("Project Manager", "Application"));
 
 			const String line1 = TTR("You don't have any projects yet.");


### PR DESCRIPTION
- Updated translator comment to refer to 'Redot projects' instead of 'Godot projects'

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
