### PR TITLE
Fix MSVC warning for potential mod by 0 (C4724)

### DIFF
--- a/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_polygon_3d_gizmo_plugin.cpp
@@ -100,8 +100,10 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	float depth = polygon->get_depth() * 0.5;
 
 	Vector<Vector3> lines;
-	for (int i = 0; i < points.size(); i++) {
-		int n = (i + 1) % points.size();
+	const int points_size = points.size();
+
+	for (int i = 0; i < points_size; i++) {
+		int n = (i + 1) % points_size;
 		lines.push_back(Vector3(points[i].x, points[i].y, depth));
 		lines.push_back(Vector3(points[n].x, points[n].y, depth));
 		lines.push_back(Vector3(points[i].x, points[i].y, -depth));
@@ -121,13 +123,13 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		// Determine orientation of the 2D polygon's vertices to determine
 		// which direction to draw outer polygons.
 		float signed_area = 0.0f;
-		for (int i = 0; i < points.size(); i++) {
-			const int j = (i + 1) % points.size();
+		for (int i = 0; i < points_size; i++) {
+			const int j = (i + 1) % points_size;
 			signed_area += points[i].x * points[j].y - points[j].x * points[i].y;
 		}
 
 		// Generate triangles for the sides of the extruded polygon.
-		for (int i = 0; i < points.size(); i++) {
+		for (int i = 0; i < points_size; i++) {
 			verts.push_back(Vector3(points[i].x, points[i].y, depth));
 			verts.push_back(Vector3(points[i].x, points[i].y, -depth));
 
@@ -135,10 +137,11 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			colors.push_back(collision_color);
 		}
 
-		for (int i = 0; i < verts.size(); i += 2) {
-			const int j = (i + 1) % verts.size();
-			const int k = (i + 2) % verts.size();
-			const int l = (i + 3) % verts.size();
+		const int verts_size = verts.size();
+		for (int i = 0; i < verts_size; i += 2) {
+			const int j = (i + 1) % verts_size;
+			const int k = (i + 2) % verts_size;
+			const int l = (i + 3) % verts_size;
 
 			indices.push_back(i);
 			if (signed_area < 0) {
@@ -167,18 +170,19 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector<Color> cap_colours_bottom;
 			Vector<int> cap_indices_bottom;
 
-			const int index_offset = verts.size();
+			const int index_offset = verts_size;
 
 			const Vector<Vector2> &convex = decomp[i];
+			const int convex_size = convex.size();
 
-			for (int j = 0; j < convex.size(); j++) {
+			for (int j = 0; j < convex_size; j++) {
 				cap_verts_bottom.push_back(Vector3(convex[j].x, convex[j].y, -depth));
 				cap_colours_bottom.push_back(collision_color);
 			}
 
-			if (convex.size() >= 3) {
-				for (int j = 1; j < convex.size(); j++) {
-					const int k = (j + 1) % convex.size();
+			if (convex_size >= 3) {
+				for (int j = 1; j < convex_size; j++) {
+					const int k = (j + 1) % convex_size;
 
 					cap_indices_bottom.push_back(index_offset + 0);
 					cap_indices_bottom.push_back(index_offset + j);
@@ -196,18 +200,19 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector<Color> cap_colours_top;
 			Vector<int> cap_indices_top;
 
-			const int index_offset = verts.size();
+			const int index_offset = verts_size;
 
 			const Vector<Vector2> &convex = decomp[i];
+			const int convex_size = convex.size();
 
-			for (int j = 0; j < convex.size(); j++) {
+			for (int j = 0; j < convex_size; j++) {
 				cap_verts_top.push_back(Vector3(convex[j].x, convex[j].y, depth));
 				cap_colours_top.push_back(collision_color);
 			}
 
-			if (convex.size() >= 3) {
-				for (int j = 1; j < convex.size(); j++) {
-					const int k = (j + 1) % convex.size();
+			if (convex_size >= 3) {
+				for (int j = 1; j < convex_size; j++) {
+					const int k = (j + 1) % convex_size;
 
 					cap_indices_top.push_back(index_offset + k);
 					cap_indices_top.push_back(index_offset + j);


### PR DESCRIPTION
- Original PR: godotengine/godot#106634

(cherry picked from commit 9d3f4cad6da0441f21ecccff2135b822017be958)

---

With `dev_mode=yes`, MSVC warns that some modulo expressions may be `x % 0` and refuses to compile.

By assigning the size variables to local variables, the compiler knows `size > 0` if the loop bodies are entered. Without the local variable, it's technically possible for `size()` to become zero after entering the body.

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4724?view=msvc-170
