### PR TITLE
Add Godot drop-in replacement for GDExtension version checks

### DIFF
--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -314,10 +314,30 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 	} else {
 		compatible = REDOT_VERSION_PATCH >= compatibility_minimum[2];
 	}
+
+	bool disable_godot_checks = config->get_value("configuration", "disable_godot_checks", false);
+
+	if (!compatible && !disable_godot_checks) {
+		// Check Godot version lexicographically.
+		if (GODOT_VERSION_MAJOR != compatibility_minimum[0]) {
+			compatible = GODOT_VERSION_MAJOR > compatibility_minimum[0];
+		} else if (GODOT_VERSION_MINOR != compatibility_minimum[1]) {
+			compatible = GODOT_VERSION_MINOR > compatibility_minimum[1];
+		} else {
+			compatible = GODOT_VERSION_PATCH >= compatibility_minimum[2];
+		}
+	}
+
 	if (!compatible) {
-		ERR_PRINT(vformat("GDExtension only compatible with Redot version %d.%d.%d or later: %s, but your Redot version is %d.%d.%d",
-				compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path,
-				REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH));
+		if (disable_godot_checks) {
+			ERR_PRINT(vformat("GDExtension only compatible with Redot version %d.%d.%d or later: %s, but your Redot version is %d.%d.%d",
+					compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path,
+					REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH));
+		} else {
+			ERR_PRINT(vformat("GDExtension only compatible with Redot/Godot version %d.%d.%d or later: %s, but your Redot version is %d.%d.%d, while its Godot minimum supported version is %d.%d.%d",
+					compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path,
+					REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH, GODOT_VERSION_MAJOR, GODOT_VERSION_MINOR, GODOT_VERSION_PATCH));
+		}
 		return ERR_INVALID_DATA;
 	}
 
@@ -348,9 +368,28 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 		}
 #endif
 
+		if (!compatible && !disable_godot_checks) {
+			if (GODOT_VERSION_MAJOR != compatibility_maximum[0]) {
+				compatible = GODOT_VERSION_MAJOR < compatibility_maximum[0];
+			} else if (GODOT_VERSION_MINOR != compatibility_maximum[1]) {
+				compatible = GODOT_VERSION_MINOR < compatibility_maximum[1];
+			}
+#if GODOT_VERSION_PATCH
+			// #if check to avoid -Wtype-limits warning when 0.
+			else {
+				compatible = GODOT_VERSION_PATCH <= compatibility_maximum[2];
+			}
+#endif
+		}
+
 		if (!compatible) {
-			ERR_PRINT(vformat("GDExtension only compatible with Redot version %s or earlier: %s, but your Redot version is %d.%d.%d",
-					compat_string, p_path, REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH));
+			if (disable_godot_checks) {
+				ERR_PRINT(vformat("GDExtension only compatible with Redot version %s or earlier: %s, but your Redot version is %d.%d.%d",
+						compat_string, p_path, REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH));
+			} else {
+				ERR_PRINT(vformat("GDExtension only compatible with Redot/Godot version %s or earlier: %s, but your Redot version is %d.%d.%d, while its Godot maximum supported version is %d.%d.%d",
+						compat_string, p_path, REDOT_VERSION_MAJOR, REDOT_VERSION_MINOR, REDOT_VERSION_PATCH, GODOT_VERSION_MAJOR, GODOT_VERSION_MINOR, GODOT_VERSION_PATCH));
+			}
 			return ERR_INVALID_DATA;
 		}
 	}


### PR DESCRIPTION
- Fixes #1071  

Add disable flag via `disable_godot_checks`