### PR TITLE
[4.3] Add Godot drop-in replacement for GDExtension version checks

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -959,8 +959,26 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 	} else {
 		compatible = VERSION_PATCH >= compatibility_minimum[2];
 	}
+
+	bool disable_godot_checks = config->get_value("configuration", "disable_godot_checks", false);
+
+	if (!compatible && !disable_godot_checks) {
+		// Check Godot version lexicographically.
+		if (GODOT_VERSION_MAJOR != compatibility_minimum[0]) {
+			compatible = GODOT_VERSION_MAJOR > compatibility_minimum[0];
+		} else if (GODOT_VERSION_MINOR != compatibility_minimum[1]) {
+			compatible = GODOT_VERSION_MINOR > compatibility_minimum[1];
+		} else {
+			compatible = GODOT_VERSION_PATCH >= compatibility_minimum[2];
+		}
+	}
+
 	if (!compatible) {
-		ERR_PRINT(vformat("GDExtension only compatible with Godot version %d.%d.%d or later: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
+		if (disable_godot_checks) {
+			ERR_PRINT(vformat("GDExtension only compatible with Redot version %d.%d.%d or later: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
+		} else {
+			ERR_PRINT(vformat("GDExtension only compatible with Redot/Godot version %d.%d.%d or later: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
+		}
 		return ERR_INVALID_DATA;
 	}
 
@@ -991,8 +1009,26 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 		}
 #endif
 
+		if (!compatible && !disable_godot_checks) {
+			if (GODOT_VERSION_MAJOR != compatibility_maximum[0]) {
+				compatible = GODOT_VERSION_MAJOR < compatibility_maximum[0];
+			} else if (GODOT_VERSION_MINOR != compatibility_maximum[1]) {
+				compatible = GODOT_VERSION_MINOR < compatibility_maximum[1];
+			}
+#if GODOT_VERSION_PATCH
+			// #if check to avoid -Wtype-limits warning when 0.
+			else {
+				compatible = GODOT_VERSION_PATCH <= compatibility_maximum[2];
+			}
+#endif
+		}
+
 		if (!compatible) {
-			ERR_PRINT(vformat("GDExtension only compatible with Godot version %s or earlier: %s", compat_string, p_path));
+			if (disable_godot_checks) {
+				ERR_PRINT(vformat("GDExtension only compatible with Redot version %s or earlier: %s", compat_string, p_path));
+			} else {
+				ERR_PRINT(vformat("GDExtension only compatible with Redot/Godot version %s or earlier: %s", compat_string, p_path));
+			}
 			return ERR_INVALID_DATA;
 		}
 	}


### PR DESCRIPTION
- Original PR: #1072

(cherry picked from commit 265c6fd3f29f17ffcfd59ae2b4862d21090f7dbe)

---

Add disable flag via `disable_godot_checks`
