### PR TITLE
[4.3] Fix: Updated version specific strings to reference RedotSharp

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -325,7 +325,7 @@ namespace Godot.Bridge
             if (wrapperType == null)
             {
                 var editorAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                    .FirstOrDefault(a => a.GetName().Name == "GodotSharpEditor");
+                    .FirstOrDefault(a => a.GetName().Name == "RedotSharpEditor");
 
                 if (editorAssembly != null)
                 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -183,7 +183,7 @@ namespace Godot
         {
             var name = t.Assembly.GetName().Name;
 
-            if (name == "GodotSharp" || name == "GodotSharpEditor")
+            if (name == "RedotSharp" || name == "RedotSharpEditor")
                 return t;
 
             Debug.Assert(t.BaseType is not null, "Script types must derive from a native Redot type.");


### PR DESCRIPTION
Fixed hardcoded assembly name strings to reflect RedotSharp.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
