### PR TITLE
[4.4] Fix Quaternion arc constructor tolerance

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -146,7 +146,11 @@ struct [[nodiscard]] Quaternion {
 #ifdef MATH_CHECKS
 		ERR_FAIL_COND_MSG(p_v0.is_zero_approx() || p_v1.is_zero_approx(), "The vectors must not be zero.");
 #endif
-		constexpr real_t ALMOST_ONE = 1.0f - (real_t)CMP_EPSILON;
+#ifdef REAL_T_IS_DOUBLE
+		constexpr real_t ALMOST_ONE = 0.999999999999999;
+#else
+		constexpr real_t ALMOST_ONE = 0.99999975f;
+#endif
 		Vector3 n0 = p_v0.normalized();
 		Vector3 n1 = p_v1.normalized();
 		real_t d = n0.dot(n1);
@@ -169,6 +173,7 @@ struct [[nodiscard]] Quaternion {
 			z = c.z * rs;
 			w = s * 0.5f;
 		}
+		normalize();
 	}
 };
 


### PR DESCRIPTION
- Required By #1081 



Upstream PR
- https://github.com/godotengine/godot/pull/106337 

(cherry picked from commit 37aca09b237ee009e61574fb91082f9d55b0ad54)
