### PR TITLE
Fix project manager showing "(DEBUG)" in title instead of "Redot Engine - Project Manager"

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4465,9 +4465,13 @@ int Main::start() {
 			appname = TranslationServer::get_singleton()->translate(appname);
 #ifdef DEBUG_ENABLED
 			// Append a suffix to the window title to denote that the project is running
-			// from a debug build (including the editor). Since this results in lower performance,
-			// this should be clearly presented to the user.
-			DisplayServer::get_singleton()->window_set_title(vformat("%s (DEBUG)", appname));
+			// from a debug build (including the editor, excluding the project manager).
+			// Since this results in lower performance, this should be clearly presented to the user.
+			if (!Engine::get_singleton()->is_project_manager_hint()) {
+				DisplayServer::get_singleton()->window_set_title(vformat("%s (DEBUG)", appname));
+			} else {
+				DisplayServer::get_singleton()->window_set_title(appname);
+			}
 #else
 			DisplayServer::get_singleton()->window_set_title(appname);
 #endif

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/lliizlbviv90xbgxh8l8hb2cc0mpp7b6-nix-shell

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/lliizlbviv90xbgxh8l8hb2cc0mpp7b6-nix-shell


### PR DESCRIPTION
Fixes #1037

  The project manager was incorrectly showing "(DEBUG)" suffix in its window title during debug builds,
  instead of showing the proper "Redot Engine - Project Manager" title.

  This change modifies the debug title logic in `main/main.cpp` to only append "(DEBUG)" when not running the
   project manager, using `Engine::get_singleton()->is_project_manager_hint()` to detect this case.

  **Changes:**
  - Added condition check to exclude project manager from debug title suffix
  - Project manager now displays proper title even in debug builds
  - Regular projects still show "(DEBUG)" suffix as intended

  **Testing:**
  - Verified project manager shows correct title in debug builds
  - Confirmed regular projects still show "(DEBUG)" suffix appropriately

(tested on Debian 13)
![image](https://github.com/user-attachments/assets/00f6ec59-2366-4586-a868-619e016139a4)
