### PR TITLE
Fix project manager title showing as (DEBUG) 

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1419,6 +1419,8 @@ void Window::_notification(int p_what) {
 				// Append a suffix to the window title to denote that the project is running
 				// from a debug build (including the editor). Since this results in lower performance,
 				// this should be clearly presented to the user.
+				if (tr_title.is_empty())
+					break;
 				tr_title = vformat("%s (DEBUG)", tr_title);
 			}
 #endif


### PR DESCRIPTION
- Fixes #1037 
- Closes #1086 
- Closes #1087 

Ensure that when a translated title is being applied to the main window it isn't empty. If it is break early to prevent setting `(DEBUG)` as the title.  Instead it will keep the title it had previously.  The Project Manager currently is the only instance making this check necessary.

Testing of the engine after the fix shows translations for window titles working as expected. Titles for current project running projects and popup dialogues are working as intended 
