### PR TITLE
Cherrypick 4.4: Add Missing `NodePath.Slice()` method to the C# API (#1097)

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -533,6 +533,9 @@ namespace Godot.NativeInterop
 
         public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
 
+        public static partial void godotsharp_node_path_slice(scoped in godot_node_path p_self, int p_begin, int p_end,
+            out godot_node_path r_result);
+
         public static partial godot_bool godotsharp_node_path_is_absolute(in godot_node_path p_self);
 
         public static partial godot_bool godotsharp_node_path_equals(in godot_node_path p_self, in godot_node_path p_other);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -275,6 +275,31 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the slice of the <em>NodePath</em>, from <c>begin</c> (inclusive) to <c>end</c> (exclusive), as a
+        /// new <em>NodePath</em>.<br/>
+        /// The absolute value of <c>begin</c> and <c>end</c> will be clamped to the sum of
+        /// <see cref="NodePath.GetNameCount">GetNameCount</see> and
+        /// <see cref="NodePath.GetSubNameCount">GetSubNameCount</see>, so the default value for <c>end</c> makes it
+        /// slice to the end of the <em>NodePath</em> by default (i.e. <c>path.Slice(1)</c> is a shorthand for
+        /// <c>path.Slice(1, path.GetNameCount() + path.GetSubNameCount())</c>).<br/>
+        /// If either <c>begin</c> or <c>end</c> are negative, they will be relative to the end of the <em>NodePath</em>
+        /// (i.e. <c>path.Slice(0, -2)</c> is shorthand for
+        /// <c>path.Slice(0, path.GetNameCount() + path.GetSubNameCount() - 2)</c>).
+        /// </summary>
+        /// <param name="begin">The index of the name or subname at which to start the slice.</param>
+        /// <param name="end">The index (exclusive) of the name or subname at which to end the slice.</param>
+        /// <returns>A slice of the <em>NodePath</em> bounded by <c>begin</c> and <c>end</c>.</returns>
+        public NodePath Slice(int begin, int end = Int32.MaxValue)
+        {
+            var self = (godot_node_path)NativeValue;
+
+            NativeFuncs.godotsharp_node_path_slice(self, begin, end, out godot_node_path slicedNodePath);
+
+            using (slicedNodePath)
+                return new NodePath(slicedNodePath);
+        }
+
+        /// <summary>
         /// Returns <see langword="true"/> if the node path is absolute (as opposed to relative),
         /// which means that it starts with a slash character (<c>/</c>). Absolute node paths can
         /// be used to access the root node (<c>"/root"</c>) or autoloads (e.g. <c>"/global"</c>

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1331,6 +1331,10 @@ int32_t godotsharp_node_path_get_subname_count(const NodePath *p_self) {
 	return p_self->get_subname_count();
 }
 
+void godotsharp_node_path_slice(const NodePath *p_self, int32_t p_begin, int32_t p_end, NodePath *r_result) {
+	memnew_placement(r_result, NodePath(p_self->slice(p_begin, p_end)));
+}
+
 bool godotsharp_node_path_is_absolute(const NodePath *p_self) {
 	return p_self->is_absolute();
 }
@@ -1712,6 +1716,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_node_path_get_name_count,
 	(void *)godotsharp_node_path_get_subname,
 	(void *)godotsharp_node_path_get_subname_count,
+	(void *)godotsharp_node_path_slice,
 	(void *)godotsharp_node_path_is_absolute,
 	(void *)godotsharp_node_path_equals,
 	(void *)godotsharp_node_path_hash,


### PR DESCRIPTION
* Add missing `NodePath.Slice()` method to the C# API

* Fix syntax error due to missing parenthesis.

* Replace space indentation with tab

* Fix incorrect type name


