### PR TITLE
Fix GCC warnings - 4.4

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2393,6 +2393,10 @@ void Image::initialize_data(const char **p_xpm) {
 			} break;
 			case READING_PIXELS: {
 				int y = line - colormap_size - 1;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wstringop-overflow=0"
+#endif
 				for (int x = 0; x < size_width; x++) {
 					char pixelstr[6] = { 0, 0, 0, 0, 0, 0 };
 					for (int i = 0; i < pixelchars; i++) {
@@ -2407,6 +2411,9 @@ void Image::initialize_data(const char **p_xpm) {
 					}
 					_put_pixelb(x, y, pixel_size, data_write, pixel);
 				}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 				if (y == (size_height - 1)) {
 					status = DONE;

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -32,7 +32,14 @@
 
 #include "geometry_2d.h"
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-zero"
+#endif
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include "thirdparty/misc/polypartition.h"
 #define STB_RECT_PACK_IMPLEMENTATION
 #include "thirdparty/misc/stb_rect_pack.h"

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -159,6 +159,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	const NodeData *nd = &nodes[0];
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
+	ret_nodes[0] = nullptr; // Sidesteps "maybe uninitialized" false-positives on GCC.
 
 	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.is_empty();
 


### PR DESCRIPTION
Cherrypicks from up stream to fix the GCC warnings for Windows, allowing build pipelines to succeed.
These cherrypicks are specific to 4.4, each version of Redot will need it's own set.

Cherrypick: bc320db5e316f80e6e9998e2c4b76859dab30242

Fixes: https://github.com/Redot-Engine/redot-engine/issues/1104
