### PR TITLE
Fix incorrect version on pre-release Nuget packages

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -285,6 +285,9 @@ def generate_sdk_package_versions():
         if match:
             pos = match.start()
             version_status = version_status[:pos] + "." + version_status[pos:]
+        else:
+            version_status = f"{version_status}.{version_info['status_version']}"
+
         version_str += "-" + version_status
 
     import version


### PR DESCRIPTION
Added additional logic to `build_assemblies.py` to append the status_version number to the version number for non-stable packages.

