### PR TITLE
Fix OutputError Serializing #1103

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -102,7 +102,7 @@ Array DebuggerMarshalls::OutputError::serialize() {
 
 	unsigned int callstack_size = callstack.size();
 	unsigned int w_index = 11; // A friendly write index.
-	arr.resize(callstack_size + w_index); // callstack.size() + the next 11 headers.
+	arr.resize(callstack_size * 3 + w_index); // callstack.size() * 3 (due to the use of file, func, and line) + the next 11 headers.
 
 	arr[0] = hr;
 	arr[1] = min;


### PR DESCRIPTION
Warnings/Errors no longer lead to gameplay crashes

Closes https://github.com/Redot-Engine/redot-engine/pull/1100

Cherrypicks https://github.com/Redot-Engine/redot-engine/commit/b35f8495745340f6dbc0e8cd51bac61d6380dadd by @Dreamy-Cat-X
