### PR TITLE
Add API Type Override Method to `ClassDB` + `ClassDB` Binding Enhancements

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1642,6 +1642,19 @@ ClassDB::APIType ClassDB::class_get_api_type(const StringName &p_class) const {
 	return (APIType)api_type;
 }
 
+Error ClassDB::class_override_api_type(const StringName &p_class, ClassDB::APIType p_api) const {
+	return ::ClassDB::override_api_type(p_class, (::ClassDB::APIType)p_api);
+}
+
+ClassDB::APIType ClassDB::get_current_api() const {
+	::ClassDB::APIType api_type = ::ClassDB::get_current_api();
+	return (APIType)api_type;
+}
+
+void ClassDB::set_current_api(ClassDB::APIType p_api) const {
+	::ClassDB::set_current_api((::ClassDB::APIType)p_api);
+}
+
 bool ClassDB::class_has_signal(const StringName &p_class, const StringName &p_signal) const {
 	return ::ClassDB::has_signal(p_class, p_signal);
 }
@@ -1838,7 +1851,7 @@ void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List
 				pf == "class_has_method" || pf == "class_get_method_list" ||
 				pf == "class_get_integer_constant_list" || pf == "class_has_integer_constant" || pf == "class_get_integer_constant" ||
 				pf == "class_has_enum" || pf == "class_get_enum_list" || pf == "class_get_enum_constants" || pf == "class_get_integer_constant_enum" ||
-				pf == "is_class_enabled" || pf == "is_class_enum_bitfield" || pf == "class_get_api_type");
+				pf == "is_class_enabled" || pf == "is_class_enum_bitfield" || pf == "class_get_api_type" || pf == "get_current_api");
 	}
 	if (first_argument_is_class || pf == "is_parent_class") {
 		for (const String &E : get_class_list()) {
@@ -1860,6 +1873,9 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("instantiate", "class"), &ClassDB::instantiate);
 
 	::ClassDB::bind_method(D_METHOD("class_get_api_type", "class"), &ClassDB::class_get_api_type);
+	::ClassDB::bind_method(D_METHOD("class_override_api_type", "class", "api"), &ClassDB::class_override_api_type);
+	::ClassDB::bind_method(D_METHOD("get_current_api"), &ClassDB::get_current_api);
+	::ClassDB::bind_method(D_METHOD("set_current_api", "api"), &ClassDB::set_current_api);
 
 	::ClassDB::bind_method(D_METHOD("class_has_signal", "class", "signal"), &ClassDB::class_has_signal);
 	::ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &ClassDB::class_get_signal);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -525,6 +525,10 @@ public:
 	Variant instantiate(const StringName &p_class) const;
 
 	APIType class_get_api_type(const StringName &p_class) const;
+	Error class_override_api_type(const StringName &p_class, APIType p_api) const;
+	APIType get_current_api() const;
+	void set_current_api(APIType p_api) const;
+
 	bool class_has_signal(const StringName &p_class, const StringName &p_signal) const;
 	Dictionary class_get_signal(const StringName &p_class, const StringName &p_signal) const;
 	TypedArray<Dictionary> class_get_signal_list(const StringName &p_class, bool p_no_inheritance = false) const;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -369,6 +369,17 @@ ClassDB::APIType ClassDB::get_api_type(const StringName &p_class) {
 	return ti->api;
 }
 
+Error ClassDB::override_api_type(const StringName &p_class, ClassDB::APIType p_api) {
+	Locker::Lock lock(Locker::STATE_WRITE);
+
+	ClassInfo *ti = classes.getptr(p_class);
+
+	ERR_FAIL_NULL_V_MSG(ti, Error::ERR_DOES_NOT_EXIST, vformat("Cannot get class '%s'.", String(p_class)));
+	ti->api = p_api;
+
+	return Error::OK;
+}
+
 uint32_t ClassDB::get_api_hash(APIType p_api) {
 #ifdef DEBUG_ENABLED
 	Locker::Lock lock(Locker::STATE_WRITE);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -336,6 +336,7 @@ public:
 	static void set_object_extension_instance(Object *p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance);
 
 	static APIType get_api_type(const StringName &p_class);
+	static Error override_api_type(const StringName &p_class, APIType p_api);
 
 	static uint32_t get_api_hash(APIType p_api);
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -189,6 +189,15 @@
 				Returns whether [param class] or its ancestry has a signal called [param signal] or not.
 			</description>
 		</method>
+		<method name="class_override_api_type" qualifiers="const">
+			<return type="int" enum="Error" />
+			<param index="0" name="class" type="StringName" />
+			<param index="1" name="api" type="int" enum="ClassDB.APIType" />
+			<description>
+				Overrides the API type of [param class] to [param api]. See [enum ClassDB.APIType].
+				[b]Note:[/b] This should only be used with a thorough understanding of its implications.
+			</description>
+		</method>
 		<method name="class_set_property" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="object" type="Object" />
@@ -203,6 +212,12 @@
 			<description>
 				Returns the names of all engine classes available.
 				[b]Note:[/b] Script-defined classes with [code]class_name[/code] are not included in this list. Use [method ProjectSettings.get_global_class_list] to get a list of script-defined classes instead.
+			</description>
+		</method>
+		<method name="get_current_api" qualifiers="const">
+			<return type="int" enum="ClassDB.APIType" />
+			<description>
+				Returns the currently active API type. See [enum ClassDB.APIType].
 			</description>
 		</method>
 		<method name="get_inheriters_from_class" qualifiers="const">
@@ -248,6 +263,14 @@
 			<param index="1" name="inherits" type="StringName" />
 			<description>
 				Returns whether [param inherits] is an ancestor of [param class] or not.
+			</description>
+		</method>
+		<method name="set_current_api" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="api" type="int" enum="ClassDB.APIType" />
+			<description>
+				Sets the globally active API type to [param api]. See [enum ClassDB.APIType].
+				[b]Note:[/b] This should only be used with a thorough understanding of its implications.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
In Jenova it's possible to develop Nested Extensions using C++ and hot-reload them on-the-fly. Somehow, any extension class registered after the engine's initialization stage is automatically registered with `API_EDITOR_EXTENSION`. This causes the initiation of nested classes to fail when running the game in Debug mode.

To fix this issue I've added a new function to `ClassDB` to dynamically override a class api type. In addition to this function, I also added bindings for `set_current_api` and `get_current_api`. While these bindings aren't strictly necessary for enabling hot-reloading of Nested Extensions, I included them to anticipate future needs and reduce the likelihood of requiring a separate pull request.

## Simple demonstration of the PR in action
### Before Implementations 
https://github.com/user-attachments/assets/39af5dd6-41ca-4307-a26b-2a09cdec9fc7

### After Implementations 
https://github.com/user-attachments/assets/7ba18a62-c8e9-4dd8-9ae7-59b533594f52

To implement these changes, I closely followed existing implementations to ensure compatibility and avoid any conflicts, with all changes extending functionality without altering any existing code. Additionally, GitHub Actions build completed successfully with zero issues.

This PR includes following changes:
- Added `override_api_type` to `ClassDB` to dynamically override a registered class API type.
- Exposed `class_override_api_type` to GDExtension/Core Bindings
- Exposed `set_current_api` to GDExtension/Core Bindings
- Exposed `get_current_api` to GDExtension/Core Bindings
- Added Documentation for `ClassDB::class_override_api_type`
- Added Documentation for `ClassDB::set_current_api`
- Added Documentation for `ClassDB::get_current_api`

The documentation also includes a clear warning advising users against using these functions without a thorough understanding of their purpose and implications.