### PR TITLE
Changed default theme & Implement boot_splash_bg read from config file 

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -329,7 +329,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 				preset_base_color = Color(0.17, 0.17, 0.20);
 				preset_contrast = 0.4;
 			} else { // Default
-				preset_accent_color = Color(0.98, 0.31, 0.13);
+				preset_accent_color = Color(0.99, 0.40, 0.26);
 				preset_base_color = Color(0.06, 0.09, 0.14);
 				preset_contrast = config.default_contrast;
 			}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3897,7 +3897,7 @@ void Main::setup_boot_logo() {
 #ifndef NO_DEFAULT_BOOT_LOGO
 			MAIN_PRINT("Main: Create bootsplash");
 #if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
-			Ref<Image> splash = (editor || project_manager) ? memnew(Image(boot_splash_png)) : memnew(Image(boot_splash_png));
+			Ref<Image> splash = (editor || project_manager) ? memnew(Image(boot_splash_editor_png)) : memnew(Image(boot_splash_png));
 #else
 			Ref<Image> splash = memnew(Image(boot_splash_png));
 #endif


### PR DESCRIPTION
The EditorSettings isn't initialized at the time of boot_splash, we read the value directly from file

### New theme & Splash for LTS

<img width="1917" height="1036" alt="image" src="https://github.com/user-attachments/assets/3d54fbb2-df30-41ba-a48b-2785fb457102" />

<img width="1924" height="1016" alt="image" src="https://github.com/user-attachments/assets/ee1e7d95-9ff5-4be9-bd66-ce4653d3a734" />



## See comments for notes