### PR TITLE
Remove unused build types from Github Actions

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -19,13 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor)
-            cache-name: android-editor
-            target: editor
-            scons-flags: >-
-              arch=arm64
-              production=yes
-
           - name: Template arm32 (target=template_release, arch=arm32)
             cache-name: android-template-arm32
             target: template_release

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -41,34 +41,6 @@ jobs:
             # Validate redot-cpp compatibility on one arbitrary editor build.
             redot-cpp: true
 
-          - name: Editor with doubles and GCC sanitizers (target=editor, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=mold)
-            cache-name: linux-editor-double-sanitizers
-            target: editor
-            # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
-            scons-flags: >-
-              dev_build=yes
-              scu_build=yes
-              debug_symbols=no
-              precision=double
-              use_asan=yes
-              use_ubsan=yes
-              linker=mold
-            bin: ./bin/redot.linuxbsd.editor.dev.double.x86_64.san
-            proj-test: true
-
-          - name: Editor with clang sanitizers (target=editor, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
-            cache-name: linux-editor-llvm-sanitizers
-            target: editor
-            scons-flags: >-
-              dev_build=yes
-              use_asan=yes
-              use_ubsan=yes
-              use_llvm=yes
-              linker=lld
-            bin: ./bin/redot.linuxbsd.editor.dev.x86_64.llvm.san
-            # Test our oldest supported SCons/Python versions on one arbitrary editor build.
-            legacy-scons: true
-
           - name: Editor with ThreadSanitizer (target=editor, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
             target: editor

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -34,15 +34,6 @@ jobs:
             bin: ./bin/redot.windows.editor.x86_64.exe
             compiler: msvc
 
-          - name: Editor w/ clang-cl (target=editor, use_llvm=yes)
-            cache-name: windows-editor-clang
-            target: editor
-            scons-flags: >-
-              windows_subsystem=console
-              use_llvm=yes
-            bin: ./bin/redot.windows.editor.x86_64.llvm.exe
-            compiler: clang
-
           - name: Template (target=template_release)
             cache-name: windows-template
             target: template_release


### PR DESCRIPTION
Removed automated actions for: 
 - Android editor -- not providing official support anymore
 - Linux Double Precision -- not needed
 - Linux Clang -- Not used for Linux production builds and is redundant. Clang is only really used for Mac and iOS.
 - Windows Clang -- Again, not really used in production builds.

Removing these 4 GitHub actions will greatly reduce our CI Minutes consumed, and slightly speed up checks on PRs.