### PR TITLE
Fixed arbitrary code execution exploit by preventing deserialzation of objects by default

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -886,7 +886,7 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			// If we're loading a project.godot from source code, we can operate some
 			// ProjectSettings conversions if need be.
@@ -1088,7 +1088,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 			}
 
 			String vstr;
-			VariantWriter::write_to_string(value, vstr);
+			VariantWriter::write_to_string(value, vstr, nullptr, nullptr, true, true);
 			file->store_string(F.property_name_encode() + "=" + vstr + "\n");
 		}
 	}
@@ -1564,6 +1564,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC("application/config/version", "");
 	GLOBAL_DEF_INTERNAL(PropertyInfo(Variant::STRING, "application/config/tags"), PackedStringArray());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res"), "");
+	GLOBAL_DEF_RST("application/run/disable_modified_security_assistance", false);
 	GLOBAL_DEF("application/run/disable_stdout", false);
 	GLOBAL_DEF("application/run/disable_stderr", false);
 	GLOBAL_DEF("application/run/print_header", true);

--- a/core/io/config_file.compat.inc
+++ b/core/io/config_file.compat.inc
@@ -1,0 +1,81 @@
+/**************************************************************************/
+/*  config_file.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2024-present Redot Engine contributors                   */
+/*                                          (see REDOT_AUTHORS.md)        */
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error ConfigFile::_save_bind_compat_redot764(const String &p_path) {
+	return save(p_path, false);
+}
+
+Error ConfigFile::_load_bind_compat_redot764(const String &p_path) {
+	return load(p_path, false);
+}
+
+Error ConfigFile::_parse_bind_compat_redot764(const String &p_path) {
+	return parse(p_path, false);
+}
+
+String ConfigFile::_encode_to_text_bind_compat_redot764() const {
+	return encode_to_text(false);
+}
+
+Error ConfigFile::_load_encrypted_bind_compat_redot764(const String &p_path, const Vector<uint8_t> &p_key) {
+	return load_encrypted(p_path, p_key, false);
+}
+
+Error ConfigFile::_load_encrypted_pass_bind_compat_redot764(const String &p_path, const String &p_pass) {
+	return load_encrypted_pass(p_path, p_pass, false);
+}
+
+Error ConfigFile::_save_encrypted_bind_compat_redot764(const String &p_path, const Vector<uint8_t> &p_key) {
+	return save_encrypted(p_path, p_key, false);
+}
+
+Error ConfigFile::_save_encrypted_pass_bind_compat_redot764(const String &p_path, const String &p_pass) {
+	return save_encrypted_pass(p_path, p_pass, false);
+}
+
+void ConfigFile::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save", "path"), &ConfigFile::_save_bind_compat_redot764);
+	ClassDB::bind_compatibility_method(D_METHOD("load", "path"), &ConfigFile::_load_bind_compat_redot764);
+	ClassDB::bind_compatibility_method(D_METHOD("parse", "data"), &ConfigFile::_parse_bind_compat_redot764);
+
+	ClassDB::bind_compatibility_method(D_METHOD("encode_to_text"), &ConfigFile::_encode_to_text_bind_compat_redot764);
+
+	ClassDB::bind_compatibility_method(D_METHOD("load_encrypted", "path", "key"), &ConfigFile::_load_encrypted_bind_compat_redot764);
+	ClassDB::bind_compatibility_method(D_METHOD("load_encrypted_pass", "path", "password"), &ConfigFile::_load_encrypted_pass_bind_compat_redot764);
+
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::_save_encrypted_bind_compat_redot764);
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::_save_encrypted_pass_bind_compat_redot764);
+}
+
+#endif

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -31,6 +31,7 @@
 /**************************************************************************/
 
 #include "config_file.h"
+#include "config_file.compat.inc"
 
 #include "core/io/file_access_encrypted.h"
 #include "core/string/string_builder.h"
@@ -121,7 +122,7 @@ void ConfigFile::erase_section_key(const String &p_section, const String &p_key)
 	}
 }
 
-String ConfigFile::encode_to_text() const {
+String ConfigFile::encode_to_text(bool p_full_objects) const {
 	StringBuilder sb;
 	bool first = true;
 	for (const KeyValue<String, HashMap<String, Variant>> &E : values) {
@@ -136,14 +137,14 @@ String ConfigFile::encode_to_text() const {
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;
-			VariantWriter::write_to_string(F.value, vstr);
+			VariantWriter::write_to_string(F.value, vstr, nullptr, nullptr, true, p_full_objects);
 			sb.append(F.key.property_name_encode() + "=" + vstr + "\n");
 		}
 	}
 	return sb.as_string();
 }
 
-Error ConfigFile::save(const String &p_path) {
+Error ConfigFile::save(const String &p_path, bool p_full_objects) {
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
@@ -151,10 +152,10 @@ Error ConfigFile::save(const String &p_path) {
 		return err;
 	}
 
-	return _internal_save(file);
+	return _internal_save(file, p_full_objects);
 }
 
-Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_key) {
+Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_full_objects) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
@@ -168,10 +169,10 @@ Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_
 	if (err) {
 		return err;
 	}
-	return _internal_save(fae);
+	return _internal_save(fae, p_full_objects);
 }
 
-Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass) {
+Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass, bool p_full_objects) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
@@ -186,10 +187,10 @@ Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass
 		return err;
 	}
 
-	return _internal_save(fae);
+	return _internal_save(fae, p_full_objects);
 }
 
-Error ConfigFile::_internal_save(Ref<FileAccess> file) {
+Error ConfigFile::_internal_save(Ref<FileAccess> file, bool p_full_objects) {
 	bool first = true;
 	for (const KeyValue<String, HashMap<String, Variant>> &E : values) {
 		if (first) {
@@ -203,7 +204,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;
-			VariantWriter::write_to_string(F.value, vstr);
+			VariantWriter::write_to_string(F.value, vstr, nullptr, nullptr, true, p_full_objects);
 			file->store_string(F.key.property_name_encode() + "=" + vstr + "\n");
 		}
 	}
@@ -211,7 +212,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 	return OK;
 }
 
-Error ConfigFile::load(const String &p_path) {
+Error ConfigFile::load(const String &p_path, bool p_allow_objects) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 
@@ -219,10 +220,10 @@ Error ConfigFile::load(const String &p_path) {
 		return err;
 	}
 
-	return _internal_load(p_path, f);
+	return _internal_load(p_path, f, p_allow_objects);
 }
 
-Error ConfigFile::load_encrypted(const String &p_path, const Vector<uint8_t> &p_key) {
+Error ConfigFile::load_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_allow_objects) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 
@@ -236,10 +237,10 @@ Error ConfigFile::load_encrypted(const String &p_path, const Vector<uint8_t> &p_
 	if (err) {
 		return err;
 	}
-	return _internal_load(p_path, fae);
+	return _internal_load(p_path, fae, p_allow_objects);
 }
 
-Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass) {
+Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass, bool p_allow_objects) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 
@@ -254,25 +255,25 @@ Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass
 		return err;
 	}
 
-	return _internal_load(p_path, fae);
+	return _internal_load(p_path, fae, p_allow_objects);
 }
 
-Error ConfigFile::_internal_load(const String &p_path, Ref<FileAccess> f) {
+Error ConfigFile::_internal_load(const String &p_path, Ref<FileAccess> f, bool p_allow_objects) {
 	VariantParser::StreamFile stream;
 	stream.f = f;
 
-	Error err = _parse(p_path, &stream);
+	Error err = _parse(p_path, &stream, p_allow_objects);
 
 	return err;
 }
 
-Error ConfigFile::parse(const String &p_data) {
+Error ConfigFile::parse(const String &p_data, bool p_allow_objects) {
 	VariantParser::StreamString stream;
 	stream.s = p_data;
-	return _parse("<string>", &stream);
+	return _parse("<string>", &stream, p_allow_objects);
 }
 
-Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) {
+Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream, bool p_allow_objects) {
 	String assign;
 	Variant value;
 	VariantParser::Tag next_tag;
@@ -283,11 +284,12 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 	String section;
 
 	while (true) {
-		assign = Variant();
+		assign = String();
+		value = Variant();
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		Error err = VariantParser::parse_tag_assign_eof(p_stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		Error err = VariantParser::parse_tag_assign_eof(p_stream, lines, error_text, next_tag, assign, value, nullptr, true, p_allow_objects);
 		if (err == ERR_FILE_EOF) {
 			return OK;
 		} else if (err != OK) {
@@ -322,19 +324,19 @@ void ConfigFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("erase_section", "section"), &ConfigFile::erase_section);
 	ClassDB::bind_method(D_METHOD("erase_section_key", "section", "key"), &ConfigFile::erase_section_key);
 
-	ClassDB::bind_method(D_METHOD("load", "path"), &ConfigFile::load);
-	ClassDB::bind_method(D_METHOD("parse", "data"), &ConfigFile::parse);
-	ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
+	ClassDB::bind_method(D_METHOD("load", "path", "allow_objects"), &ConfigFile::load, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("parse", "data", "allow_objects"), &ConfigFile::parse, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save", "path", "full_objects"), &ConfigFile::save, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("encode_to_text"), &ConfigFile::encode_to_text);
+	ClassDB::bind_method(D_METHOD("encode_to_text", "full_objects"), &ConfigFile::encode_to_text, DEFVAL(false));
 
 	BIND_METHOD_ERR_RETURN_DOC("load", ERR_FILE_CANT_OPEN);
 
-	ClassDB::bind_method(D_METHOD("load_encrypted", "path", "key"), &ConfigFile::load_encrypted);
-	ClassDB::bind_method(D_METHOD("load_encrypted_pass", "path", "password"), &ConfigFile::load_encrypted_pass);
+	ClassDB::bind_method(D_METHOD("load_encrypted", "path", "key", "allow_objects"), &ConfigFile::load_encrypted, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("load_encrypted_pass", "path", "password", "allow_objects"), &ConfigFile::load_encrypted_pass, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::save_encrypted);
-	ClassDB::bind_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::save_encrypted_pass);
+	ClassDB::bind_method(D_METHOD("save_encrypted", "path", "key", "full_objects"), &ConfigFile::save_encrypted, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_encrypted_pass", "path", "password", "full_objects"), &ConfigFile::save_encrypted_pass, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("clear"), &ConfigFile::clear);
 }

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -42,13 +42,31 @@ class ConfigFile : public RefCounted {
 
 	HashMap<String, HashMap<String, Variant>> values;
 
-	Error _internal_load(const String &p_path, Ref<FileAccess> f);
-	Error _internal_save(Ref<FileAccess> file);
+	PackedStringArray _get_sections() const;
+	PackedStringArray _get_section_keys(const String &p_section) const;
+	Error _internal_load(const String &p_path, Ref<FileAccess> f, bool p_allow_objects);
+	Error _internal_save(Ref<FileAccess> file, bool p_full_objects);
 
-	Error _parse(const String &p_path, VariantParser::Stream *p_stream);
+	Error _parse(const String &p_path, VariantParser::Stream *p_stream, bool p_allow_objects);
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	Error _save_bind_compat_redot764(const String &p_path);
+	Error _load_bind_compat_redot764(const String &p_path);
+	Error _parse_bind_compat_redot764(const String &p_path);
+
+	String _encode_to_text_bind_compat_redot764() const;
+
+	Error _load_encrypted_bind_compat_redot764(const String &p_path, const Vector<uint8_t> &p_key);
+	Error _load_encrypted_pass_bind_compat_redot764(const String &p_path, const String &p_pass);
+
+	Error _save_encrypted_bind_compat_redot764(const String &p_path, const Vector<uint8_t> &p_key);
+	Error _save_encrypted_pass_bind_compat_redot764(const String &p_path, const String &p_pass);
+
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
@@ -63,17 +81,17 @@ public:
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);
 
-	Error save(const String &p_path);
-	Error load(const String &p_path);
-	Error parse(const String &p_data);
+	Error save(const String &p_path, bool p_full_objects = false);
+	Error load(const String &p_path, bool p_allow_objects = false);
+	Error parse(const String &p_data, bool p_allow_objects = false);
 
-	String encode_to_text() const; // used by exporter
+	String encode_to_text(bool p_full_objects = false) const;
 
 	void clear();
 
-	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
-	Error load_encrypted_pass(const String &p_path, const String &p_pass);
+	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_allow_objects = false);
+	Error load_encrypted_pass(const String &p_path, const String &p_pass, bool p_allow_objects = false);
 
-	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
-	Error save_encrypted_pass(const String &p_path, const String &p_pass);
+	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_full_objects = false);
+	Error save_encrypted_pass(const String &p_path, const String &p_pass, bool p_full_objects = false);
 };

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -75,7 +75,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			if (p_load && !path_found && decomp_path_found) {
 				print_verbose(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
@@ -349,7 +349,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			return;
 		} else if (err != OK) {
@@ -592,12 +592,12 @@ void ResourceImporter::_bind_methods() {
 Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
-	Error err = cf->load(p_path + ".import");
+	Error err = cf->load(p_path + ".import", true);
 	if (err != OK) {
 		return err;
 	}
 	cf->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(p_uid));
-	cf->save(p_path + ".import");
+	cf->save(p_path + ".import", true);
 
 	return OK;
 }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1299,7 +1299,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 				next_tag.fields.clear();
 				next_tag.name = String();
 
-				err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+				err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 				if (err == ERR_FILE_EOF) {
 					break;
 				} else if (err != OK) {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3490,7 +3490,7 @@ void Variant::construct_from_string(const String &p_string, Variant &r_value, Ob
 
 String Variant::get_construct_string() const {
 	String vars;
-	VariantWriter::write_to_string(*this, vars);
+	VariantWriter::write_to_string(*this, vars, nullptr, nullptr, true, true);
 
 	return vars;
 }

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -32,6 +32,7 @@
 
 #include "variant_parser.h"
 
+#include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_uid.h"
@@ -675,10 +676,10 @@ Error VariantParser::_parse_byte_array(Stream *p_stream, Vector<uint8_t> &r_cons
 	return OK;
 }
 
-Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser) {
+Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser, bool p_allow_objects) {
 	if (token.type == TK_CURLY_BRACKET_OPEN) {
 		Dictionary d;
-		Error err = _parse_dictionary(d, p_stream, line, r_err_str, p_res_parser);
+		Error err = _parse_dictionary(d, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 		if (err) {
 			return err;
 		}
@@ -686,7 +687,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 		return OK;
 	} else if (token.type == TK_BRACKET_OPEN) {
 		Array a;
-		Error err = _parse_array(a, p_stream, line, r_err_str, p_res_parser);
+		Error err = _parse_array(a, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 		if (err) {
 			return err;
 		}
@@ -994,6 +995,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 		} else if (id == "Object") {
+			if (!p_allow_objects) {
+				r_err_str = R"(Object decoding is prevented because "allow_objects" is false)";
+				return ERR_UNAUTHORIZED;
+			}
+
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_OPEN) {
 				r_err_str = "Expected '('";
@@ -1079,7 +1085,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					}
 
 					Variant v;
-					err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
+					err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 					if (err) {
 						return err;
 					}
@@ -1089,6 +1095,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				}
 			}
 		} else if (id == "Resource" || id == "SubResource" || id == "ExtResource") {
+			if (!p_allow_objects) {
+				r_err_str = R"(Object decoding is prevented because "allow_objects" is false)";
+				return ERR_UNAUTHORIZED;
+			}
+
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_OPEN) {
 				r_err_str = "Expected '('";
@@ -1353,8 +1364,13 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			if (builtin_types.has(token.value)) {
 				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
 			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+				if (!p_allow_objects) {
+					r_err_str = R"(Object decoding is prevented because "allow_objects" is false)";
+					return ERR_UNAUTHORIZED;
+				}
+
 				Variant resource;
-				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
+				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 				if (err) {
 					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
@@ -1395,7 +1411,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			Array values;
-			err = _parse_array(values, p_stream, line, r_err_str, p_res_parser);
+			err = _parse_array(values, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 			if (err) {
 				return err;
 			}
@@ -1642,7 +1658,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 	}
 }
 
-Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser) {
+Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser, bool p_allow_objects) {
 	Token token;
 	bool need_comma = false;
 
@@ -1672,7 +1688,7 @@ Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, Str
 		}
 
 		Variant v;
-		err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
+		err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 		if (err) {
 			return err;
 		}
@@ -1682,7 +1698,7 @@ Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, Str
 	}
 }
 
-Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser) {
+Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser, bool p_allow_objects) {
 	bool at_key = true;
 	Variant key;
 	Token token;
@@ -1714,7 +1730,7 @@ Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int
 				}
 			}
 
-			err = parse_value(token, key, p_stream, line, r_err_str, p_res_parser);
+			err = parse_value(token, key, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 
 			if (err) {
 				return err;
@@ -1737,7 +1753,7 @@ Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int
 			}
 
 			Variant v;
-			err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
+			err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 			if (err && err != ERR_FILE_MISSING_DEPENDENCIES) {
 				return err;
 			}
@@ -1748,7 +1764,7 @@ Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int
 	}
 }
 
-Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser, bool p_simple_tag) {
+Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser, bool p_simple_tag, bool p_allow_objects) {
 	r_tag.fields.clear();
 
 	if (token.type != TK_BRACKET_OPEN) {
@@ -1862,7 +1878,7 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 
 		get_token(p_stream, token, line, r_err_str);
 		Variant value;
-		Error err = parse_value(token, value, p_stream, line, r_err_str, p_res_parser);
+		Error err = parse_value(token, value, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 		if (err) {
 			return err;
 		}
@@ -1873,7 +1889,7 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 	return OK;
 }
 
-Error VariantParser::parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser, bool p_simple_tag) {
+Error VariantParser::parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser, bool p_simple_tag, bool p_allow_objects) {
 	Token token;
 	get_token(p_stream, token, line, r_err_str);
 
@@ -1886,10 +1902,10 @@ Error VariantParser::parse_tag(Stream *p_stream, int &line, String &r_err_str, T
 		return ERR_PARSE_ERROR;
 	}
 
-	return _parse_tag(token, p_stream, line, r_err_str, r_tag, p_res_parser, p_simple_tag);
+	return _parse_tag(token, p_stream, line, r_err_str, r_tag, p_res_parser, p_simple_tag, p_allow_objects);
 }
 
-Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser, bool p_simple_tag) {
+Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser, bool p_simple_tag, bool p_allow_objects) {
 	//assign..
 	r_assign = "";
 	String what;
@@ -1926,7 +1942,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 			//it's a tag!
 			p_stream->saved = '['; //go back one
 
-			Error err = parse_tag(p_stream, line, r_err_str, r_tag, p_res_parser, p_simple_tag);
+			Error err = parse_tag(p_stream, line, r_err_str, r_tag, p_res_parser, p_simple_tag, p_allow_objects);
 
 			return err;
 		}
@@ -1952,7 +1968,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 				r_assign = what;
 				Token token;
 				get_token(p_stream, token, line, r_err_str);
-				Error err = parse_value(token, r_value, p_stream, line, r_err_str, p_res_parser);
+				Error err = parse_value(token, r_value, p_stream, line, r_err_str, p_res_parser, p_allow_objects);
 				return err;
 			}
 		} else if (c == '\n') {
@@ -1961,7 +1977,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 	}
 }
 
-Error VariantParser::parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser) {
+Error VariantParser::parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser, bool p_allow_objects) {
 	Token token;
 	Error err = get_token(p_stream, token, r_err_line, r_err_str);
 	if (err) {
@@ -1972,7 +1988,7 @@ Error VariantParser::parse(Stream *p_stream, Variant &r_ret, String &r_err_str, 
 		return ERR_FILE_EOF;
 	}
 
-	return parse_value(token, r_ret, p_stream, r_err_line, r_err_str, p_res_parser);
+	return parse_value(token, r_ret, p_stream, r_err_line, r_err_str, p_res_parser, p_allow_objects);
 }
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -2015,7 +2031,10 @@ static String encode_resource_reference(const String &path) {
 	}
 }
 
-Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count, bool p_compat) {
+Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count, bool p_compat, bool p_full_objects) {
+	static bool modified_security_assistance_disabled = GLOBAL_GET("application/run/disable_modified_security_assistance");
+	p_full_objects = p_full_objects || modified_security_assistance_disabled;
+
 	switch (p_variant.get_type()) {
 		case Variant::NIL: {
 			p_store_string_func(p_store_string_ud, "null");
@@ -2185,10 +2204,16 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		} break;
 
 		case Variant::OBJECT: {
+			if (!p_full_objects) {
+				ERR_PRINT(R"(Object encoding skipped because "full_objects" is false.)");
+				p_store_string_func(p_store_string_ud, "null");
+				break;
+			}
+
 			if (unlikely(p_recursion_count > MAX_RECURSION)) {
 				ERR_PRINT("Max recursion reached");
 				p_store_string_func(p_store_string_ud, "null");
-				return OK;
+				break;
 			}
 			p_recursion_count++;
 
@@ -2196,7 +2221,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 			if (!obj) {
 				p_store_string_func(p_store_string_ud, "null");
-				break; // don't save it
+				break;
 			}
 
 			Ref<Resource> res = p_variant;
@@ -2240,7 +2265,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 					}
 
 					p_store_string_func(p_store_string_ud, "\"" + E.name + "\":");
-					write(obj->get(E.name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+					write(obj->get(E.name), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat, p_full_objects);
 				}
 			}
 
@@ -2329,9 +2354,9 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 					for (uint32_t i = 0; i < keys.size(); i++) {
 						const Variant &key = keys[i];
-						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat, p_full_objects);
 						p_store_string_func(p_store_string_ud, ": ");
-						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat, p_full_objects);
 						if (i + 1 < keys.size()) {
 							p_store_string_func(p_store_string_ud, ",\n");
 						} else {
@@ -2359,18 +2384,23 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				Ref<Script> script = array.get_typed_script();
 
 				if (script.is_valid()) {
-					String resource_text = String();
-					if (p_encode_res_func) {
-						resource_text = p_encode_res_func(p_encode_res_ud, script);
-					}
-					if (resource_text.is_empty() && script->get_path().is_resource_file()) {
-						resource_text = encode_resource_reference(script->get_path());
-					}
+					if (p_full_objects) {
+						String resource_text = String();
+						if (p_encode_res_func) {
+							resource_text = p_encode_res_func(p_encode_res_ud, script);
+						}
+						if (resource_text.is_empty() && script->get_path().is_resource_file()) {
+							resource_text = encode_resource_reference(script->get_path());
+						}
 
-					if (!resource_text.is_empty()) {
-						p_store_string_func(p_store_string_ud, resource_text);
+						if (!resource_text.is_empty()) {
+							p_store_string_func(p_store_string_ud, resource_text);
+						} else {
+							ERR_PRINT("Failed to encode a path to a custom script for an array type.");
+							p_store_string_func(p_store_string_ud, class_name);
+						}
 					} else {
-						ERR_PRINT("Failed to encode a path to a custom script for an array type.");
+						ERR_PRINT(R"(Object encoding skipped because "full_objects" is false.)");
 						p_store_string_func(p_store_string_ud, class_name);
 					}
 				} else if (class_name != StringName()) {
@@ -2397,7 +2427,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 					} else {
 						p_store_string_func(p_store_string_ud, ", ");
 					}
-					write(var, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+					write(var, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat, p_full_objects);
 				}
 
 				p_store_string_func(p_store_string_ud, "]");
@@ -2580,8 +2610,8 @@ static Error _write_to_str(void *ud, const String &p_string) {
 	return OK;
 }
 
-Error VariantWriter::write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_compat) {
+Error VariantWriter::write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, bool p_compat, bool p_full_objects) {
 	r_string = String();
 
-	return write(p_variant, _write_to_str, &r_string, p_encode_res_func, p_encode_res_ud, 0, p_compat);
+	return write(p_variant, _write_to_str, &r_string, p_encode_res_func, p_encode_res_ud, 0, p_compat, p_full_objects);
 }

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -41,7 +41,7 @@ public:
 	struct Stream {
 	private:
 		enum { READAHEAD_SIZE = 2048 };
-		char32_t readahead_buffer[READAHEAD_SIZE];
+		char32_t readahead_buffer[READAHEAD_SIZE]{};
 		uint32_t readahead_pointer = 0;
 		uint32_t readahead_filled = 0;
 		bool eof = false;
@@ -144,17 +144,17 @@ private:
 	static Error _parse_construct(Stream *p_stream, Vector<T> &r_construct, int &line, String &r_err_str);
 	static Error _parse_byte_array(Stream *p_stream, Vector<uint8_t> &r_construct, int &line, String &r_err_str);
 	static Error _parse_enginecfg(Stream *p_stream, Vector<String> &strings, int &line, String &r_err_str);
-	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
-	static Error _parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
-	static Error _parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
+	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
+	static Error _parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
+	static Error _parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
 
 public:
-	static Error parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
-	static Error parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
+	static Error parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
+	static Error parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
 
-	static Error parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
+	static Error parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
 	static Error get_token(Stream *p_stream, Token &r_token, int &line, String &r_err_str);
-	static Error parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser = nullptr);
+	static Error parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
 };
 
 class VariantWriter {
@@ -162,6 +162,6 @@ public:
 	typedef Error (*StoreStringFunc)(void *ud, const String &p_string);
 	typedef String (*EncodeResourceFunc)(void *ud, const Ref<Resource> &p_resource);
 
-	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0, bool p_compat = true);
-	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr, bool p_compat = true);
+	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0, bool p_compat = true, bool p_full_objects = false);
+	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr, bool p_compat = true, bool p_full_objects = false);
 };

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1055,7 +1055,13 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 
 String VariantUtilityFunctions::var_to_str(const Variant &p_var) {
 	String vars;
-	VariantWriter::write_to_string(p_var, vars);
+	VariantWriter::write_to_string(p_var, vars, nullptr, nullptr, true, false);
+	return vars;
+}
+
+String VariantUtilityFunctions::var_to_str_with_objects(const Variant &p_var) {
+	String vars;
+	VariantWriter::write_to_string(p_var, vars, nullptr, nullptr, true, true);
 	return vars;
 }
 
@@ -1064,9 +1070,27 @@ Variant VariantUtilityFunctions::str_to_var(const String &p_var) {
 	ss.s = p_var;
 
 	String errs;
-	int line;
+	int line = 1;
 	Variant ret;
-	(void)VariantParser::parse(&ss, ret, errs, line);
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, false);
+	if (err != OK) {
+		ERR_PRINT("Parse error at line " + itos(line) + ": " + errs + ".");
+	}
+
+	return ret;
+}
+
+Variant VariantUtilityFunctions::str_to_var_with_objects(const String &p_var) {
+	VariantParser::StreamString ss;
+	ss.s = p_var;
+
+	String errs;
+	int line = 1;
+	Variant ret;
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, true);
+	if (err != OK) {
+		ERR_PRINT("Parse error at line " + itos(line) + ": " + errs + ".");
+	}
 
 	return ret;
 }
@@ -1786,6 +1810,9 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(var_to_str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(str_to_var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+
+	FUNCBINDR(var_to_str_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(str_to_var_with_objects, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
 	FUNCBINDR(var_to_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(bytes_to_var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -146,7 +146,9 @@ struct VariantUtilityFunctions {
 	static void push_error(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void push_warning(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static String var_to_str(const Variant &p_var);
+	static String var_to_str_with_objects(const Variant &p_var);
 	static Variant str_to_var(const String &p_var);
+	static Variant str_to_var_with_objects(const String &p_var);
 	static PackedByteArray var_to_bytes(const Variant &p_var);
 	static PackedByteArray var_to_bytes_with_objects(const Variant &p_var);
 	static Variant bytes_to_var(const PackedByteArray &p_arr);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1431,7 +1431,8 @@
 			<return type="Variant" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Converts a formatted [param string] that was returned by [method var_to_str] to the original [Variant].
+				Converts a formatted [param string] that was returned by [method var_to_str] to the equivalent [Variant], without decoding objects.
+				[b]Note:[/b] If you need object deserialization, see [method str_to_var_with_objects].
 				[codeblocks]
 				[gdscript]
 				var data = '{ "a": 1, "b": 2 }' # data is a String
@@ -1444,6 +1445,14 @@
 				GD.Print(dict["a"]);                              // Prints 1
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="str_to_var_with_objects">
+			<return type="Variant" />
+			<param index="0" name="string" type="String" />
+			<description>
+				Converts a formatted [param string] that was returned by [method var_to_str_with_objects] to the equivalent [Variant]. Decoding objects is allowed.
+				[b]Warning:[/b] Deserialized object can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats (remote code execution).
 			</description>
 		</method>
 		<method name="tan">
@@ -1535,7 +1544,8 @@
 			<return type="String" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var].
+				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var], without encoding objects.
+				[b]Note:[/b] If you need object serialization, see [method var_to_str_with_objects].
 				[codeblocks]
 				[gdscript]
 				var a = { "a": 1, "b": 2 }
@@ -1554,6 +1564,13 @@
 				}
 				[/codeblock]
 				[b]Note:[/b] Converting [Signal] or [Callable] is not supported and will result in an empty value for these types, regardless of their data.
+			</description>
+		</method>
+		<method name="var_to_str_with_objects">
+			<return type="String" />
+			<param index="0" name="variable" type="Variant" />
+			<description>
+				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var_with_objects]. Encoding objects is allowed (and can potentially include executable code).
 			</description>
 		</method>
 		<method name="weakref">

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -100,8 +100,11 @@
 		</method>
 		<method name="encode_to_text" qualifiers="const">
 			<return type="String" />
+			<param index="0" name="full_objects" type="bool" default="false" />
 			<description>
-				Obtain the text version of this config file (the same text that would be written to a file).
+				Obtain the text version of this config file (the same text that would be written to a file). If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] and [method @GlobalScope.var_to_str_with_objects] methods.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 		<method name="erase_section">
@@ -161,61 +164,74 @@
 			<returns_error number="0"/>
 			<returns_error number="12"/>
 			<param index="0" name="path" type="String" />
+			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
+				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.str_to_var] and [method @GlobalScope.str_to_var_with_objects] methods.
+				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
 		<method name="load_encrypted">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="allow_objects" type="bool" default="false" />
 			<description>
 				Loads the encrypted config file specified as a parameter, using the provided [param key] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method load] for details.
 			</description>
 		</method>
 		<method name="load_encrypted_pass">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
+			<param index="2" name="allow_objects" type="bool" default="false" />
 			<description>
 				Loads the encrypted config file specified as a parameter, using the provided [param password] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method load] for details.
 			</description>
 		</method>
 		<method name="parse">
 			<return type="int" enum="Error" />
 			<param index="0" name="data" type="String" />
+			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Parses the passed string as the contents of a config file. The string is parsed and loaded in the ConfigFile object which the method was called on.
+				Parses the passed string as the contents of a config file. The string is parsed and loaded in the ConfigFile object which the method was called on. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.str_to_var] and [method @GlobalScope.str_to_var_with_objects] methods.
+				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure.
+				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] and [method @GlobalScope.var_to_str_with_objects] method.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 		<method name="save_encrypted">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="full_objects" type="bool" default="false" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method save] for details.
 			</description>
 		</method>
 		<method name="save_encrypted_pass">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
+			<param index="2" name="full_objects" type="bool" default="false" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method save] for details.
 			</description>
 		</method>
 		<method name="set_value">

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -308,8 +308,8 @@
 			<return type="Variant" />
 			<param index="0" name="allow_objects" type="bool" default="false" />
 			<description>
-				Returns the next [Variant] value from the file. If [param allow_objects] is [code]true[/code], decoding objects is allowed. This advances the file cursor by the number of bytes read.
-				Internally, this uses the same decoding mechanism as the [method @GlobalScope.bytes_to_var] method, as described in the [url=$DOCS_URL/tutorials/io/binary_serialization_api.html]Binary serialization API[/url] documentation.
+				Returns the next [Variant] value from the file. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.bytes_to_var] and [method @GlobalScope.bytes_to_var_with_objects] methods.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -562,10 +562,9 @@
 			<param index="0" name="value" type="Variant" />
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Stores any Variant value in the file. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code). This advances the file cursor by the number of bytes written. Returns [code]true[/code] if the operation is successful.
-				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] method, as described in the [url=$DOCS_URL/tutorials/io/binary_serialization_api.html]Binary serialization API[/url] documentation.
-				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object._get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags.
-				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+				Stores any Variant value in the file. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] and [method @GlobalScope.var_to_bytes_with_objects] methods.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -348,6 +348,20 @@
 			[b]Note:[/b] Delta smoothing is only attempted when [member display/window/vsync/vsync_mode] is set to [code]enabled[/code], as it does not work well without V-Sync.
 			It may take several seconds at a stable frame rate before the smoothing is initially activated. It will only be active on machines where performance is adequate to render frames at the refresh rate.
 		</member>
+		<member name="application/run/disable_modified_security_assistance" type="bool" setter="" getter="" default="false">
+			If [code]false[/code] (default), security features intended to reduce exploit attack vectors are enabled. These features:
+			- Prevents [method @GlobalScope.var_to_str] from accepting [Object]s. Use [method @GlobalScope.var_to_str_with_objects] instead.
+			- Prevents [method @GlobalScope.str_to_var] from parsing [Object]s. Use [method @GlobalScope.str_to_var_with_objects] instead.
+			- Prevents [method ConfigFile.encode_to_text] from encoding [Object]s by default. Call with [code]full_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.load] from loading [Object]s by default. Call with [code]allow_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.load_encrypted] from loading [Object]s by default. Call with [code]allow_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.load_encrypted_pass] from loading [Object]s by default. Call with [code]allow_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.parse] from parsing [Object]s in the [ConfigFile] by default. Call with [code]allow_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.save] from saving [Object]s by default. Call with [code]full_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.save_encrypted] from saving [Object]s by default. Call with [code]full_objects[/code] set to [code]true[/code] instead.
+			- Prevents [method ConfigFile.save_encrypted_pass] from saving [Object]s by default. Call with [code]full_objects[/code] set to [code]true[/code] instead.
+			[b]Warning:[/b] If [code]true[/code], this re-enables legacy object encode/decode behavior and must only be used for fully trusted data sources. Do not enable for untrusted input such as files, network traffic, or user-supplied content, as this can introduce security vulnerabilities and exploit attack vectors.
+		</member>
 		<member name="application/run/disable_stderr" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], disables printing to standard error. If [code]true[/code], this also hides error and warning messages printed by [method @GlobalScope.push_error] and [method @GlobalScope.push_warning]. See also [member application/run/disable_stdout].
 			Changes to this setting will only be applied upon restarting the application. To control this at runtime, use [member Engine.print_error_messages].

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -59,7 +59,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 			// Todo the modified times of remapped files should most likely be kept in EditorFileSystem to speed this up in the future.
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			Error err = cf->load(f + ".import");
+			Error err = cf->load(f + ".import", true);
 
 			ERR_CONTINUE(err != OK);
 			{

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1246,7 +1246,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 		if (FileAccess::exists(fpath + ".import")) {
 			Ref<ConfigFile> config;
 			config.instantiate();
-			Error err = config->load(fpath + ".import");
+			Error err = config->load(fpath + ".import", true);
 			if (err == OK) {
 				if (config->has_section_key("remap", "importer")) {
 					String importer = config->get_value("remap", "importer");
@@ -3916,7 +3916,7 @@ void FileSystemDock::_update_import_dock() {
 		const String &fpath = efiles[i];
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		Error err = cf->load(fpath + ".import");
+		Error err = cf->load(fpath + ".import", true);
 		if (err != OK) {
 			imports.clear();
 			break;

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -101,7 +101,7 @@ ImportDock *ImportDock::singleton = nullptr;
 void ImportDock::set_edit_path(const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
-	Error err = config->load(p_path + ".import");
+	Error err = config->load(p_path + ".import", true);
 	if (err != OK) {
 		clear();
 		return;
@@ -234,7 +234,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		Ref<ConfigFile> config;
 		config.instantiate();
 		extensions.insert(p_paths[i].get_extension());
-		Error err = config->load(p_paths[i] + ".import");
+		Error err = config->load(p_paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		if (i == 0) {
@@ -418,7 +418,7 @@ void ImportDock::_importer_selected(int i_idx) {
 		if (params->paths.size()) {
 			String path = params->paths[0];
 			config.instantiate();
-			Error err = config->load(path + ".import");
+			Error err = config->load(path + ".import", true);
 			if (err != OK) {
 				config.unref();
 			}
@@ -553,7 +553,7 @@ void ImportDock::_reimport_attempt() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(params->paths[i] + ".import");
+		Error err = config->load(params->paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		String imported_with = config->get_value("remap", "importer");
@@ -634,7 +634,7 @@ void ImportDock::_reimport() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(params->paths[i] + ".import");
+		Error err = config->load(params->paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		if (params->importer.is_valid()) {
@@ -682,7 +682,7 @@ void ImportDock::_reimport() {
 			}
 		}
 
-		config->save(params->paths[i] + ".import");
+		config->save(params->paths[i] + ".import", true);
 	}
 
 	EditorFileSystem::get_singleton()->reimport_files(params->paths);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1336,7 +1336,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Ref<ConfigFile> config;
 		if (has_import_file) {
 			config.instantiate();
-			err = config->load(path + ".import");
+			err = config->load(path + ".import", true);
 			if (err != OK) {
 				ERR_PRINT("Could not parse: '" + path + "', not exported.");
 				continue;
@@ -1433,7 +1433,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 					config->erase_section("params");
 				}
 
-				String import_text = config->encode_to_text();
+				String import_text = config->encode_to_text(true);
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());
@@ -1500,7 +1500,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 					config->erase_section("params");
 				}
 
-				String import_text = config->encode_to_text();
+				String import_text = config->encode_to_text(true);
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -615,7 +615,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, const String &p_
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			break;
 		} else if (err != OK) {
@@ -700,7 +700,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, const String &p_
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&md5_stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&md5_stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 
 		if (err == ERR_FILE_EOF) {
 			break;
@@ -2587,7 +2587,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 	for (int i = 0; i < p_files.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(p_files[i] + ".import");
+		Error err = config->load(p_files[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 		ERR_CONTINUE(!config->has_section_key("remap", "importer"));
 		String file_importer_name = config->get_value("remap", "importer");
@@ -2713,7 +2713,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 					v = source_file_options[file][base];
 				}
 				String value;
-				VariantWriter::write_to_string(v, value);
+				VariantWriter::write_to_string(v, value, nullptr, nullptr, true, true);
 				f->store_line(base + "=" + value);
 			}
 		}
@@ -2804,7 +2804,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		//use existing
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		Error err = cf->load(p_file + ".import");
+		Error err = cf->load(p_file + ".import", true);
 		if (err == OK) {
 			if (cf->has_section("params")) {
 				Vector<String> sk = cf->get_section_keys("params");
@@ -2962,7 +2962,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 			}
 
 			String value;
-			VariantWriter::write_to_string(genf, value);
+			VariantWriter::write_to_string(genf, value, nullptr, nullptr, true, true);
 			f->store_line("files=" + value);
 			f->store_line("");
 		}
@@ -2986,7 +2986,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		for (const ResourceImporter::ImportOption &E : opts) {
 			String base = E.option.name;
 			String value;
-			VariantWriter::write_to_string(params[base], value);
+			VariantWriter::write_to_string(params[base], value, nullptr, nullptr, true, true);
 			f->store_line(base + "=" + value);
 		}
 	}
@@ -3472,7 +3472,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 			Ref<ConfigFile> config;
 			config.instantiate();
 			String path = efd->get_file_path(i) + ".import";
-			Error err = config->load(path);
+			Error err = config->load(path, true);
 			if (err != OK) {
 				continue;
 			}
@@ -3489,7 +3489,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 				}
 			}
 
-			config->save(path);
+			config->save(path, true);
 		}
 	}
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -790,7 +790,7 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(p_path + ".import");
+		Error err = config->load(p_path + ".import", true);
 		if (err == OK) {
 			Vector<String> keys = config->get_section_keys("params");
 			for (const String &E : keys) {

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -436,7 +436,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 	if (stream.is_valid()) {
 		Ref<ConfigFile> config_file;
 		config_file.instantiate();
-		Error err = config_file->load(p_path + ".import");
+		Error err = config_file->load(p_path + ".import", true);
 		updating_settings = true;
 		if (err == OK) {
 			double bpm = config_file->get_value("params", "bpm", 0);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -855,7 +855,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	config.instantiate();
 	ERR_FAIL_COND(config.is_null());
 
-	Error err = config->load(p_path + ".import");
+	Error err = config->load(p_path + ".import", true);
 	print_verbose("Loading import settings:");
 	if (err == OK) {
 		Vector<String> keys = config->get_section_keys("params");

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -102,7 +102,7 @@ void ResourceImporterTexture::update_imports() {
 		cf.instantiate();
 		String src_path = String(E.key) + ".import";
 
-		Error err = cf->load(src_path);
+		Error err = cf->load(src_path, true);
 		ERR_CONTINUE(err != OK);
 
 		bool changed = false;
@@ -151,7 +151,7 @@ void ResourceImporterTexture::update_imports() {
 		}
 
 		if (changed) {
-			cf->save(src_path);
+			cf->save(src_path, true);
 			to_reimport.push_back(E.key);
 		}
 	}

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -723,14 +723,14 @@ void ProjectDialog::ok_pressed() {
 		// Load project.godot as ConfigFile to set the new name.
 		ConfigFile cfg;
 		String project_godot = path.path_join("project.godot");
-		Error err = cfg.load(project_godot);
+		Error err = cfg.load(project_godot, true);
 		if (err != OK) {
 			dialog_error->set_text(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err));
 			dialog_error->popup_centered();
 			return;
 		}
 		cfg.set_value("application", "config/name", project_name->get_text().strip_edges());
-		err = cfg.save(project_godot);
+		err = cfg.save(project_godot, true);
 		if (err != OK) {
 			dialog_error->set_text(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err));
 			dialog_error->popup_centered();

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -585,7 +585,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 	bool recovery_mode = false;
 
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	Error cf_err = cf->load(conf);
+	Error cf_err = cf->load(conf, true);
 
 	int config_version = 0;
 	String cf_project_name;

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -157,6 +157,10 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 			args.push_back(run_arg);
 		}
 	}
+	// Pass the debugger stop shortcut to the running instance(s).
+	String shortcut;
+	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut, nullptr, nullptr, true, true);
+	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
 
 	String exec = OS::get_singleton()->get_executable_path();
 	int instance_count = RunInstancesDialog::get_singleton()->get_instance_count();

--- a/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -152,7 +152,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 
 		config.instantiate();
 		if (FileAccess::exists(p_path + ".import")) {
-			config->load(p_path + ".import");
+			config->load(p_path + ".import", true);
 		}
 
 		config->set_value("remap", "importer", "3d_texture");
@@ -165,7 +165,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 		config->set_value("params", "slices/horizontal", 1);
 		config->set_value("params", "slices/vertical", bake_img->get_meta("depth"));
 
-		config->save(p_path + ".import");
+		config->save(p_path + ".import", true);
 
 		Error err = bake_img->save_exr(p_path, false);
 		ERR_FAIL_COND(err);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2193,6 +2193,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// for project settings. For example, a Linux user should be able to configure that they want
 	// to export for D3D12 on Windows and Metal on macOS even if their host platform can't use those.
 
+	if (GLOBAL_GET("application/run/disable_modified_security_assistance")) {
+		WARN_PRINT("Modified Security Assistance disabled, this application can perform unsafe behavior by default. Consider disabling application/run/disable_modified_security_assistance in the Project Settings.");
+	}
+
 	{
 		// RenderingDevice driver overrides per platform.
 		GLOBAL_DEF_RST("rendering/rendering_device/driver", "vulkan");
@@ -3003,7 +3007,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 						next_tag.fields.clear();
 						next_tag.name = String();
 
-						err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, true);
+						err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, true, true);
 						if (err == ERR_FILE_EOF) {
 							break;
 						}

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -1,0 +1,111 @@
+This file contains the expected output of --validate-extension-api when run against the extension_api.json of the
+4.3-stable tag (the basename of this file).
+
+Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored. They
+should instead be used to justify these changes and describe how users should work around these changes.
+
+Add new entries at the end of the file.
+
+## Changes between 4.3-stable and 4.4-stable
+
+GH-95374
+--------
+Validate extension JSON: Error: Field 'classes/ShapeCast2D/properties/collision_result': getter changed value in new API, from "_get_collision_result" to &"get_collision_result".
+Validate extension JSON: Error: Field 'classes/ShapeCast3D/properties/collision_result': getter changed value in new API, from "_get_collision_result" to &"get_collision_result".
+
+These getters have been renamed to expose them. GDExtension language bindings couldn't have exposed these properties before.
+
+
+GH-90993
+--------
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments': size changed value in new API, from 9 to 10.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': type changed value in new API, from "Array" to "int".
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': default_value changed value in new API, from "Array[RID]([])" to "0".
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': type changed value in new API, from "typedarray::RID" to "int".
+
+draw_list_begin added a new optional debug argument called breadcrumb.
+There used to be an Array argument as arg #9 initially, then changed to typedarray::RID in 4.1, and finally removed in 4.3.
+Since we're adding a new one at the same location, we need to silence those warnings for 4.1 and 4.3.
+
+
+GH-95126
+--------
+Validate extension JSON: Error: Field 'classes/Shader/methods/get_default_texture_parameter/return_value': type changed value in new API, from "Texture2D" to "Texture".
+Validate extension JSON: Error: Field 'classes/Shader/methods/set_default_texture_parameter/arguments/1': type changed value in new API, from "Texture2D" to "Texture".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeCubemap/methods/get_cube_map/return_value': type changed value in new API, from "Cubemap" to "TextureLayered".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeCubemap/methods/set_cube_map/arguments/0': type changed value in new API, from "Cubemap" to "TextureLayered".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeCubemap/properties/cube_map': type changed value in new API, from "Cubemap" to "Cubemap,CompressedCubemap,PlaceholderCubemap,TextureCubemapRD".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeTexture2DArray/methods/get_texture_array/return_value': type changed value in new API, from "Texture2DArray" to "TextureLayered".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeTexture2DArray/methods/set_texture_array/arguments/0': type changed value in new API, from "Texture2DArray" to "TextureLayered".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeTexture2DArray/properties/texture_array': type changed value in new API, from "Texture2DArray" to "Texture2DArray,CompressedTexture2DArray,PlaceholderTexture2DArray,Texture2DArrayRD".
+
+Allow setting a cubemap as default parameter to shader.
+Compatibility methods registered.
+
+
+GH-93605
+--------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Semaphore/methods/post': arguments
+
+Optional arguments added. Compatibility methods registered.
+
+
+GH-95212
+--------
+Validate extension JSON: Error: Field 'classes/RegEx/methods/compile/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/RegEx/methods/create_from_string/arguments': size changed value in new API, from 1 to 2.
+
+Add optional argument to control error printing on compilation fail. Compatibility methods registered.
+
+
+GH-95375
+--------
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
+Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
+
+These setters have been renamed to expose them. GDExtension language bindings couldn't have exposed these properties before.
+
+
+GH-94322
+--------
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_node_selector/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_property_selector/arguments': size changed value in new API, from 3 to 4.
+
+Added optional argument to popup_property_selector and popup_node_selector to specify the current value.
+
+
+GH-94434
+--------
+Validate extension JSON: Error: Field 'classes/OS/methods/execute_with_pipe/arguments': size changed value in new API, from 2 to 3.
+
+Optional argument added. Compatibility method registered.
+
+
+GH-94684
+--------
+Validate extension JSON: Error: Field 'classes/SoftBody3D/methods/set_point_pinned/arguments': size changed value in new API, from 3 to 4.
+
+Optional argument added to allow for adding pin point at specific index. Compatibility method registered.
+
+
+GH-97281
+--------
+Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/arguments/1': default_value changed value in new API, from "0.5" to "0.2".
+
+Default deadzone value was changed. No adjustments should be necessary.
+Compatibility method registered.
+
+
+GH-Redot-764
+--------
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load_encrypted/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load_encrypted_pass/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/parse/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted_pass/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ConfigFile/methods/encode_to_text': arguments
+
+Added optional argument. Compatibility method registered. Behavior compatibility broken for security and consistency with binary serialization. Object encoding/decoding is now disabled by default. Can be disabled by Project Setting.

--- a/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
@@ -11,7 +11,7 @@ var test_class := MyClass
 var test_enum := MyEnum
 
 func check_gdscript_native_class(value: Variant) -> void:
-	print(var_to_str(value).get_slice(",", 0).trim_prefix("Object("))
+	print(var_to_str_with_objects(value).get_slice(",", 0).trim_prefix("Object("))
 
 func check_gdscript(value: GDScript) -> void:
 	print(value.get_class())

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4065,7 +4065,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 				if (FileAccess::exists(file_path + ".import")) {
 					Ref<ConfigFile> config;
 					config.instantiate();
-					config->load(file_path + ".import");
+					config->load(file_path + ".import", true);
 					if (config->has_section_key("remap", "generator_parameters")) {
 						generator_parameters = (Dictionary)config->get_value("remap", "generator_parameters");
 					}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -597,12 +597,12 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
 
-        internal static partial void godotsharp_str_to_var(scoped in godot_string p_str, out godot_variant r_ret);
+        internal static partial void godotsharp_str_to_var(scoped in godot_string p_str, godot_bool p_allow_objects, out godot_variant r_ret);
 
         internal static partial void godotsharp_var_to_bytes(scoped in godot_variant p_what, godot_bool p_full_objects,
             out godot_packed_byte_array r_bytes);
 
-        internal static partial void godotsharp_var_to_str(scoped in godot_variant p_var, out godot_string r_ret);
+        internal static partial void godotsharp_var_to_str(scoped in godot_variant p_var, godot_bool p_full_objects, out godot_string r_ret);
 
         internal static partial void godotsharp_err_print_error(in godot_string p_function, in godot_string p_file, int p_line, in godot_string p_error, in godot_string p_message = default, godot_bool p_editor_notify = godot_bool.False, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1493,21 +1493,21 @@ void godotsharp_err_print_error(const godot_string *p_function, const godot_stri
 			p_editor_notify, p_type);
 }
 
-void godotsharp_var_to_str(const godot_variant *p_var, godot_string *r_ret) {
+void godotsharp_var_to_str(const godot_variant *p_var, bool p_full_objects, godot_string *r_ret) {
 	const Variant &var = *reinterpret_cast<const Variant *>(p_var);
 	String &vars = *memnew_placement(r_ret, String);
-	VariantWriter::write_to_string(var, vars);
+	VariantWriter::write_to_string(var, vars, nullptr, nullptr, /*p_compat*/ false, p_full_objects);
 }
 
-void godotsharp_str_to_var(const godot_string *p_str, godot_variant *r_ret) {
+void godotsharp_str_to_var(const godot_string *p_str, bool p_allow_objects, godot_variant *r_ret) {
 	Variant ret;
 
 	VariantParser::StreamString ss;
 	ss.s = *reinterpret_cast<const String *>(p_str);
 
 	String errs;
-	int line;
-	Error err = VariantParser::parse(&ss, ret, errs, line);
+	int line = 1;
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, p_allow_objects);
 	if (err != OK) {
 		String err_str = "Parse error at line " + itos(line) + ": " + errs + ".";
 		ERR_PRINT(err_str);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -272,7 +272,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				String assign;
 				Variant value;
 
-				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &parser);
+				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &parser, false, true);
 
 				if (error) {
 					if (error == ERR_FILE_MISSING_DEPENDENCIES) {
@@ -355,7 +355,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					unbinds,
 					bind_ints);
 
-			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser);
+			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -378,7 +378,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			packed_scene->get_state()->add_editable_instance(path.simplified());
 
-			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser);
+			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -474,7 +474,7 @@ Error ResourceLoaderText::load() {
 			}
 		}
 
-		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (error) {
 			_printerr();
@@ -594,7 +594,7 @@ Error ResourceLoaderText::load() {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp, false, true);
 
 			if (error) {
 				_printerr();
@@ -723,7 +723,7 @@ Error ResourceLoaderText::load() {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -927,7 +927,7 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 
 		p_dependencies->push_back(path);
 
-		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err) {
 			print_line(error_text + " - " + itos(lines));
@@ -952,7 +952,7 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 	uint64_t tag_end = f->get_position();
 
 	while (true) {
-		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err != OK) {
 			error = ERR_FILE_CORRUPT;
@@ -1081,7 +1081,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	resource_current = 0;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		error = err;
@@ -1138,7 +1138,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	}
 
 	if (!p_skip_first_tag) {
-		err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err) {
 			error_text = "Unexpected end of file";
@@ -1167,7 +1167,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 	rp_new.userdata = &dummy_read;
 
 	while (next_tag.name == "ext_resource") {
-		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new);
+		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new, false, true);
 
 		if (error) {
 			_printerr();
@@ -1194,7 +1194,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, false, true);
 
 			if (error) {
 				if (error == ERR_FILE_EOF) {
@@ -1237,7 +1237,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, false, true);
 
 			if (error) {
 				if (error == ERR_FILE_MISSING_DEPENDENCIES) {
@@ -1278,7 +1278,7 @@ String ResourceLoaderText::recognize_script_class(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -1316,7 +1316,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -1360,7 +1360,7 @@ ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -1948,7 +1948,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 				}
 
 				String vars;
-				VariantWriter::write_to_string(value, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(value, vars, _write_resources, this, use_compat, true);
 				f->store_string(name.property_name_encode() + " = " + vars + "\n");
 			}
 		}
@@ -2012,14 +2012,14 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			if (!instance_placeholder.is_empty()) {
 				String vars;
 				f->store_string(" instance_placeholder=");
-				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this, use_compat, true);
 				f->store_string(vars);
 			}
 
 			if (instance.is_valid()) {
 				String vars;
 				f->store_string(" instance=");
-				VariantWriter::write_to_string(instance, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(instance, vars, _write_resources, this, use_compat, true);
 				f->store_string(vars);
 			}
 
@@ -2027,7 +2027,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
 				String vars;
-				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this, use_compat, true);
 
 				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
 			}
@@ -2061,7 +2061,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			f->store_string(connstr);
 			if (binds.size()) {
 				String vars;
-				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat);
+				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat, true);
 				f->store_string(" binds= " + vars);
 			}
 

--- a/tests/core/io/test_config_file.h
+++ b/tests/core/io/test_config_file.h
@@ -116,6 +116,27 @@ antialiasing = false ; Duplicate key.
 			"The configuration file shouldn't parse successfully.");
 }
 
+TEST_CASE("[ConfigFile] Parsing object") {
+	const String config_source = R"(
+[test]
+
+test=Object(RefCounted,"script":null)
+)";
+	ConfigFile config_file;
+
+	ERR_PRINT_OFF;
+	Error error = config_file.parse(config_source);
+	ERR_PRINT_ON;
+
+	CHECK(error == ERR_UNAUTHORIZED);
+	CHECK(!config_file.has_section_key("test", "test"));
+
+	error = config_file.parse(config_source, true);
+
+	CHECK(error == OK);
+	CHECK(config_file.get_value("test", "test").get_type() == Variant::OBJECT);
+}
+
 TEST_CASE("[ConfigFile] Saving file") {
 	ConfigFile config_file;
 	config_file.set_value("player", "name", "Unnamed Player");

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -1911,6 +1911,49 @@ TEST_CASE("[Variant] Writer recursive dictionary on keys") {
 }
 #endif
 
+TEST_CASE("[Variant] Writer and parser object") {
+	Ref<RefCounted> ref_counted;
+	ref_counted.instantiate();
+	ref_counted->set_meta("test", 123);
+	const String expected = "Object(RefCounted,\"script\":null,\"metadata/test\":123)\n";
+	String encoded;
+
+	ERR_PRINT_OFF;
+	VariantWriter::write_to_string(ref_counted, encoded);
+	ERR_PRINT_ON;
+
+	CHECK_EQ(encoded, "null");
+
+	encoded.clear();
+	VariantWriter::write_to_string(ref_counted, encoded, nullptr, nullptr, true, true);
+
+	CHECK_EQ(encoded, expected);
+
+	VariantParser::StreamString ss;
+	ss.s = expected;
+	Variant parsed;
+	String errs;
+	int line;
+
+	ERR_PRINT_OFF;
+	Error error = VariantParser::parse(&ss, parsed, errs, line);
+	ERR_PRINT_ON;
+
+	CHECK_EQ(error, ERR_UNAUTHORIZED);
+	CHECK_EQ(parsed, Variant());
+
+	ss = VariantParser::StreamString();
+	ss.s = expected;
+
+	error = VariantParser::parse(&ss, parsed, errs, line, nullptr, true);
+
+	CHECK_EQ(error, OK);
+	ref_counted = parsed;
+	CHECK(ref_counted.is_valid());
+	CHECK_EQ(ref_counted->get_class(), RefCounted::get_class_static());
+	CHECK_EQ(ref_counted->get_meta("test"), Variant(123));
+}
+
 TEST_CASE("[Variant] Basic comparison") {
 	CHECK_EQ(Variant(1), Variant(1));
 	CHECK_FALSE(Variant(1) != Variant(1));


### PR DESCRIPTION
Adapted from commit dalexeev/godot@377ff7998384afb7e65fda32c47d261d87bba1a0

Fixes https://github.com/Redot-Engine/redot-engine/issues/760

This fixes an arbitrary code execution exploit in Godot's serialization system that would allow a malicious actor to inject code into an object, that would get executed during the deserialization process. 

This could be injected into things like JSON objects and data commonly exchanged in multiplayer environments allowing an attacker to execute their own scripts and code on remote machines such as other players or the server.

Logic was added to block this behavior by default, and an error is thrown instead. A setting was also added to re-enable the old behavior if a developer really needs this functionality.


- Add "disable_modified_security_assistance" project setting
	Warns about application performing unsafe behavior by default when enabled

- Rename compat functions to redot764
- Fix uninitialized array warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `var_to_str_with_objects()` and `str_to_var_with_objects()` utility functions for variant serialization and deserialization with object support.
  * ConfigFile load, save, parse, and encode operations now support optional parameters for controlling object handling during serialization.
  * Added new project setting `application/run/disable_modified_security_assistance` for security configuration.

* **Documentation**
  * Updated variant utility and ConfigFile method documentation with new parameters and security guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->