### PR TITLE
Add .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -966,7 +966,7 @@ package-ios:
     - cd ..
     - rm -rf ios_xcode
   artifacts:
-    expire_in: 3 days,
+    expire_in: 3 days
     paths: [ out/templates/ios.zip, out/templates-mono/ios.zip ]
 
 sign-mac-editor:


### PR DESCRIPTION
Transfer over the build pipeline file from the 4.4 branch, and remove jobs for 32 bit builds and windows arm64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a comprehensive automated CI/CD pipeline covering Linux, Windows, macOS, iOS, Android and Web.
  * Standardized platform- and architecture-specific build templates and multi-stage workflows for consistent builds and per-target variants.
  * Added automated packaging (tarballs, zips, platform packages), artifact retention, and consolidated release asset assembly.
  * Added optional signing/notarization flows and release publishing hooks (including NuGet) for distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->