### PR TITLE
X11: Allow moving a fullscreen/maximized window to another screen/display

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2307,10 +2307,12 @@ void DisplayServerX11::window_set_current_screen(int p_screen, WindowID p_window
 	}
 
 	if (window_get_mode(p_window) == WINDOW_MODE_FULLSCREEN || window_get_mode(p_window) == WINDOW_MODE_MAXIMIZED) {
+		WindowMode current_mode = window_get_mode(p_window);
+		window_set_mode(WINDOW_MODE_WINDOWED, p_window);
 		Point2i position = screen_get_position(p_screen);
 		Size2i size = screen_get_size(p_screen);
-
 		XMoveResizeWindow(x11_display, wd.x11_window, position.x, position.y, size.x, size.y);
+		window_set_mode(current_mode, p_window);
 	} else {
 		Rect2i srect = screen_get_usable_rect(p_screen);
 		Point2i wpos = window_get_position(p_window) - screen_get_position(window_get_current_screen(p_window));


### PR DESCRIPTION
- Allows X11 to move a game to another screen/display
- Tested & works as expected
- Ports Godot's PR#114820 to Redot (which was also created by me)

> [!NOTE]
> Contributed by 2LazyDevs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue on Linux where fullscreen and maximized windows could not be properly repositioned or moved between displays. These windows are now temporarily switched to windowed mode during the operation and restored to their original state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->