### PR TITLE
Fix warning for property not found: 'application/config/disable_project_settings_override'.

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -33,7 +33,6 @@
 #include "editor_run.h"
 
 #include "core/config/project_settings.h"
-#include "core/io/config_file.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
 #include "editor/run/run_instances_dialog.h"
@@ -264,24 +263,12 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 		placement.screen = DisplayServer::get_singleton()->get_primary_screen();
 	}
 
-	Ref<ConfigFile> cfg_override;
-	cfg_override.instantiate();
-	if (!bool(GLOBAL_GET("application/config/disable_project_settings_override")) && FileAccess::exists("res://override.cfg")) {
-		Error err = cfg_override->load("res://override.cfg");
-		if (err != OK) {
-			WARN_PRINT("Found override.cfg but could not load it.");
-		}
-	}
-
-#define GET_CONFIG_WITH_OVERRIDE(m_section, m_key) \
-	cfg_override->get_value(m_section, m_key, GLOBAL_GET(vformat("%s/%s", m_section, m_key)))
-
-	placement.size.x = GET_CONFIG_WITH_OVERRIDE("display", "window/size/viewport_width");
-	placement.size.y = GET_CONFIG_WITH_OVERRIDE("display", "window/size/viewport_height");
+	placement.size.x = GLOBAL_GET("display/window/size/viewport_width");
+	placement.size.y = GLOBAL_GET("display/window/size/viewport_height");
 
 	Size2 desired_size;
-	desired_size.x = GET_CONFIG_WITH_OVERRIDE("display", "window/size/window_width_override");
-	desired_size.y = GET_CONFIG_WITH_OVERRIDE("display", "window/size/window_height_override");
+	desired_size.x = GLOBAL_GET("display/window/size/window_width_override");
+	desired_size.y = GLOBAL_GET("display/window/size/window_height_override");
 	if (desired_size.x > 0 && desired_size.y > 0) {
 		placement.size = desired_size;
 	}
@@ -291,7 +278,7 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 	int window_placement = EDITOR_GET("run/window_placement/rect");
 	if (screen_rect != Rect2()) {
 		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HIDPI)) {
-			bool hidpi_proj = GET_CONFIG_WITH_OVERRIDE("display", "window/dpi/allow_hidpi");
+			bool hidpi_proj = GLOBAL_GET("display/window/dpi/allow_hidpi");
 			int display_scale = 1;
 
 			if (OS::get_singleton()->is_hidpi_allowed()) {
@@ -343,8 +330,6 @@ EditorRun::WindowPlacement EditorRun::get_window_placement() {
 			} break;
 		}
 	}
-
-#undef GET_CONFIG_WITH_OVERRIDE
 
 	return placement;
 }


### PR DESCRIPTION
fixes #1166 

Reverts commit fba863eb7bcb096030fe34e8459ff4ffb2961997.
As far as I can tell, this change is not needed for the 4.5.x branch and causes nuisance warnings. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal configuration settings handling to improve consistency and maintainability while preserving existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->