### PR TITLE
Signal viewer dock

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -48,6 +48,10 @@
 #include "core/string/translation_server.h"
 #include "core/variant/typed_array.h"
 
+// Static member initialization for signal emission callback
+Object::SignalEmissionCallback Object::signal_emission_callback = nullptr;
+bool Object::signal_emission_callback_enabled = false;
+
 #ifdef DEBUG_ENABLED
 
 struct _ObjectDebugLock {
@@ -1237,6 +1241,12 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 #endif
 			//not connected? just return
 			return ERR_UNAVAILABLE;
+		}
+
+		// STEP 1: Signal emission hook - Call the registered callback if enabled
+		// This allows editor tools like the Signal Viewer to track signal emissions globally
+		if (signal_emission_callback_enabled && signal_emission_callback) {
+			signal_emission_callback(this, p_name, p_args, p_argcount);
 		}
 
 		if (s->slot_map.size() > MAX_SLOTS_ON_STACK) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -49,8 +49,8 @@
 #include "core/variant/typed_array.h"
 
 // Static member initialization for signal emission callback
-Object::SignalEmissionCallback Object::signal_emission_callback = nullptr;
-bool Object::signal_emission_callback_enabled = false;
+std::atomic<Object::SignalEmissionCallback> Object::signal_emission_callback = nullptr;
+std::atomic<bool> Object::signal_emission_callback_enabled = false;
 
 #ifdef DEBUG_ENABLED
 
@@ -1229,6 +1229,12 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 	uint32_t *slot_flags = slot_flags_stack;
 	uint32_t slot_count = 0;
 
+	// STEP 1: Signal emission hook - Declare variables for callback capture
+	// This allows editor tools like the Signal Viewer to track signal emissions globally
+	// We capture the callback while holding the lock, but call it after releasing to prevent deadlocks
+	Object::SignalEmissionCallback emission_callback = nullptr;
+	bool should_call_callback = false;
+
 	{
 		OBJ_SIGNAL_LOCK
 
@@ -1243,10 +1249,10 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 			return ERR_UNAVAILABLE;
 		}
 
-		// STEP 1: Signal emission hook - Call the registered callback if enabled
-		// This allows editor tools like the Signal Viewer to track signal emissions globally
-		if (signal_emission_callback_enabled && signal_emission_callback) {
-			signal_emission_callback(this, p_name, p_args, p_argcount);
+		// Capture callback state under lock (thread-safe atomic load)
+		should_call_callback = signal_emission_callback_enabled.load(std::memory_order_acquire) && signal_emission_callback.load(std::memory_order_acquire);
+		if (should_call_callback) {
+			emission_callback = signal_emission_callback.load(std::memory_order_acquire);
 		}
 
 		if (s->slot_map.size() > MAX_SLOTS_ON_STACK) {
@@ -1277,6 +1283,12 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 				_disconnect(p_name, slot_callables[i]);
 			}
 		}
+	}
+
+	// STEP 1: Call the emission callback outside the lock to prevent deadlocks
+	// if the callback re-enters signal code paths
+	if (should_call_callback && emission_callback) {
+		emission_callback(this, p_name, p_args, p_argcount);
 	}
 
 	OBJ_DEBUG_LOCK

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -807,7 +807,30 @@ public: // @todo Should be protected, but bug in clang++.
 public:
 	static constexpr bool _class_is_enabled = true;
 
-	void notify_property_list_changed(); ///< Scripts may add variables, so refresh is desired
+	// Signal tracking callback for editor tools (e.g., Signal Viewer)
+	// This callback is invoked whenever a signal is emitted, allowing tools to track signal activity
+	// The callback is only active when explicitly registered to minimize performance impact
+	typedef void (*SignalEmissionCallback)(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount);
+
+private:
+	static SignalEmissionCallback signal_emission_callback;
+	static bool signal_emission_callback_enabled;
+
+public:
+	static void set_signal_emission_callback(SignalEmissionCallback p_callback) {
+		signal_emission_callback = p_callback;
+		signal_emission_callback_enabled = (p_callback != nullptr);
+	}
+
+	static SignalEmissionCallback get_signal_emission_callback() {
+		return signal_emission_callback;
+	}
+
+	static bool is_signal_emission_callback_enabled() {
+		return signal_emission_callback_enabled;
+	}
+
+	void notify_property_list_changed();
 
 	static void *get_class_ptr_static() {
 		static int ptr;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -813,21 +813,21 @@ public:
 	typedef void (*SignalEmissionCallback)(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount);
 
 private:
-	static SignalEmissionCallback signal_emission_callback;
-	static bool signal_emission_callback_enabled;
+	static std::atomic<SignalEmissionCallback> signal_emission_callback;
+	static std::atomic<bool> signal_emission_callback_enabled;
 
 public:
 	static void set_signal_emission_callback(SignalEmissionCallback p_callback) {
-		signal_emission_callback = p_callback;
-		signal_emission_callback_enabled = (p_callback != nullptr);
+		signal_emission_callback.store(p_callback, std::memory_order_release);
+		signal_emission_callback_enabled.store(p_callback != nullptr, std::memory_order_release);
 	}
 
 	static SignalEmissionCallback get_signal_emission_callback() {
-		return signal_emission_callback;
+		return signal_emission_callback.load(std::memory_order_acquire);
 	}
 
 	static bool is_signal_emission_callback_enabled() {
-		return signal_emission_callback_enabled;
+		return signal_emission_callback_enabled.load(std::memory_order_acquire);
 	}
 
 	void notify_property_list_changed();

--- a/doc/classes/SignalViewerRuntime.xml
+++ b/doc/classes/SignalViewerRuntime.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SignalViewerRuntime" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_tracking_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="send_node_signal_data">
+			<return type="void" />
+			<param index="0" name="node_id" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="start_tracking">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="stop_tracking">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -74,7 +74,6 @@ if env.editor_build:
     env.add_source_files(env.editor_sources, gen_exporters)
     env.add_source_files(env.editor_sources, translation_targets.keys())
 
-
     SConscript("animation/SCsub")
     SConscript("asset_library/SCsub")
     SConscript("audio/SCsub")
@@ -98,7 +97,6 @@ if env.editor_build:
     SConscript("themes/SCsub")
     SConscript("translations/SCsub")
     SConscript("version_control/SCsub")
-
 
     lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -74,6 +74,7 @@ if env.editor_build:
     env.add_source_files(env.editor_sources, gen_exporters)
     env.add_source_files(env.editor_sources, translation_targets.keys())
 
+
     SConscript("animation/SCsub")
     SConscript("asset_library/SCsub")
     SConscript("audio/SCsub")
@@ -97,6 +98,7 @@ if env.editor_build:
     SConscript("themes/SCsub")
     SConscript("translations/SCsub")
     SConscript("version_control/SCsub")
+
 
     lib = env.add_library("editor", env.editor_sources)
     env.Prepend(LIBS=[lib])

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -520,7 +520,7 @@ Dictionary DebugAdapterParser::req_godot_put_msg(const Dictionary &p_params) con
 	String msg = args["message"];
 	Array data = args["data"];
 
-	EditorDebuggerNode::get_singleton()->get_default_debugger()->_put_msg(msg, data);
+	EditorDebuggerNode::get_singleton()->get_default_debugger()->put_msg(msg, data);
 
 	return prepare_success_response(p_params);
 }

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -511,12 +511,12 @@ void ScriptEditorDebugger::_msg_signal_viewer_signal_emitted(uint64_t p_thread_i
 	String node_class = p_data[2];
 	String signal_name = p_data[3];
 	int count = p_data[4];
-	Array connections = p_data[5];
+	Array signal_connections = p_data[5];
 
 	// Get SignalizeDock singleton and update it
 	SignalizeDock *signal_viewer = SignalizeDock::get_singleton();
 	if (signal_viewer) {
-		signal_viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, count, connections);
+		signal_viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, count, signal_connections);
 	} else {
 		print_line("[ScriptEditorDebugger] WARNING: No SignalizeDock singleton");
 	}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -79,7 +79,7 @@
 
 using CameraOverride = EditorDebuggerNode::CameraOverride;
 
-void ScriptEditorDebugger::_put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id) {
+void ScriptEditorDebugger::put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id) {
 	ERR_FAIL_COND(p_thread_id == Thread::UNASSIGNED_ID);
 	if (is_session_active()) {
 		Array msg = { p_message, p_thread_id, p_data };
@@ -105,7 +105,7 @@ void ScriptEditorDebugger::debug_skip_breakpoints() {
 	}
 
 	Array msg = { skip_breakpoints_value };
-	_put_msg("set_skip_breakpoints", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+	put_msg("set_skip_breakpoints", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 }
 
 void ScriptEditorDebugger::debug_ignore_error_breaks() {
@@ -117,27 +117,27 @@ void ScriptEditorDebugger::debug_ignore_error_breaks() {
 	}
 
 	Array msg = { ignore_error_breaks_value };
-	_put_msg("set_ignore_error_breaks", msg);
+	put_msg("set_ignore_error_breaks", msg);
 }
 
 void ScriptEditorDebugger::debug_next() {
 	ERR_FAIL_COND(!is_breaked());
 
-	_put_msg("next", Array(), debugging_thread_id);
+	put_msg("next", Array(), debugging_thread_id);
 	_clear_execution();
 }
 
 void ScriptEditorDebugger::debug_step() {
 	ERR_FAIL_COND(!is_breaked());
 
-	_put_msg("step", Array(), debugging_thread_id);
+	put_msg("step", Array(), debugging_thread_id);
 	_clear_execution();
 }
 
 void ScriptEditorDebugger::debug_break() {
 	ERR_FAIL_COND(is_breaked());
 
-	_put_msg("break", Array());
+	put_msg("break", Array());
 }
 
 void ScriptEditorDebugger::debug_continue() {
@@ -149,8 +149,8 @@ void ScriptEditorDebugger::debug_continue() {
 	}
 
 	_clear_execution();
-	_put_msg("continue", Array(), debugging_thread_id);
-	_put_msg("servers:foreground", Array());
+	put_msg("continue", Array(), debugging_thread_id);
+	put_msg("servers:foreground", Array());
 }
 
 void ScriptEditorDebugger::update_tabs() {
@@ -175,7 +175,7 @@ void ScriptEditorDebugger::clear_style() {
 
 void ScriptEditorDebugger::save_node(ObjectID p_id, const String &p_file) {
 	Array msg = { p_id, p_file };
-	_put_msg("scene:save_node", msg);
+	put_msg("scene:save_node", msg);
 }
 
 void ScriptEditorDebugger::_file_selected(const String &p_file) {
@@ -259,7 +259,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 }
 
 void ScriptEditorDebugger::request_remote_tree() {
-	_put_msg("scene:request_scene_tree", Array());
+	put_msg("scene:request_scene_tree", Array());
 }
 
 const SceneDebuggerTree *ScriptEditorDebugger::get_remote_tree() {
@@ -268,29 +268,29 @@ const SceneDebuggerTree *ScriptEditorDebugger::get_remote_tree() {
 
 void ScriptEditorDebugger::request_remote_evaluate(const String &p_expression, int p_stack_frame) {
 	Array msg = { p_expression, p_stack_frame };
-	_put_msg("evaluate", msg);
+	put_msg("evaluate", msg);
 }
 
 void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value, const String &p_field) {
 	Array msg = { p_obj_id, p_prop, p_value };
 	if (p_field.is_empty()) {
-		_put_msg("scene:set_object_property", msg);
+		put_msg("scene:set_object_property", msg);
 	} else {
 		msg.push_back(p_field);
-		_put_msg("scene:set_object_property_field", msg);
+		put_msg("scene:set_object_property_field", msg);
 	}
 }
 
 void ScriptEditorDebugger::request_remote_objects(const TypedArray<uint64_t> &p_obj_ids, bool p_update_selection) {
 	ERR_FAIL_COND(p_obj_ids.is_empty());
 	Array msg = { p_obj_ids.duplicate(), p_update_selection };
-	_put_msg("scene:inspect_objects", msg);
+	put_msg("scene:inspect_objects", msg);
 }
 
 void ScriptEditorDebugger::clear_inspector(bool p_send_msg) {
 	inspector->clear_remote_inspector();
 	if (p_send_msg) {
-		_put_msg("scene:clear_selection", Array());
+		put_msg("scene:clear_selection", Array());
 	}
 }
 
@@ -311,7 +311,7 @@ void ScriptEditorDebugger::_remote_object_property_updated(ObjectID p_id, const 
 }
 
 void ScriptEditorDebugger::_video_mem_request() {
-	_put_msg("servers:memory", Array());
+	put_msg("servers:memory", Array());
 }
 
 void ScriptEditorDebugger::_video_mem_export() {
@@ -337,7 +337,7 @@ void ScriptEditorDebugger::_thread_debug_enter(uint64_t p_thread_id) {
 		tabs->set_current_tab(0);
 	}
 	inspector->clear_cache(); // Take a chance to force remote objects update.
-	_put_msg("get_stack_dump", Array(), p_thread_id);
+	put_msg("get_stack_dump", Array(), p_thread_id);
 }
 
 void ScriptEditorDebugger::_select_thread(int p_index) {
@@ -1179,7 +1179,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						transform.columns[2] = -offset * zoom;
 
 						Array msg = { transform };
-						_put_msg("scene:transform_camera_2d", msg);
+						put_msg("scene:transform_camera_2d", msg);
 					}
 
 					// Node3D Editor
@@ -1197,12 +1197,12 @@ void ScriptEditorDebugger::_notification(int p_what) {
 						}
 						msg.push_back(cam->get_near());
 						msg.push_back(cam->get_far());
-						_put_msg("scene:transform_camera_3d", msg);
+						put_msg("scene:transform_camera_3d", msg);
 					}
 				}
 
 				if (is_breaked() && can_request_idle_draw) {
-					_put_msg("servers:draw", Array());
+					put_msg("servers:draw", Array());
 					can_request_idle_draw = false;
 				}
 			}
@@ -1289,7 +1289,7 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	_update_buttons_state();
 
 	Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
-	_put_msg("scene:setup_scene", quit_keys);
+	put_msg("scene:setup_scene", quit_keys);
 
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
 		profiler->set_profiling(true);
@@ -1377,7 +1377,7 @@ void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {
 	Array msg_data = { p_enable };
 	switch (p_type) {
 		case PROFILER_VISUAL:
-			_put_msg("profiler:visual", msg_data);
+			put_msg("profiler:visual", msg_data);
 			break;
 		case PROFILER_SCRIPTS_SERVERS:
 			if (p_enable) {
@@ -1389,7 +1389,7 @@ void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {
 				Array opts = { CLAMP(max_funcs, 16, 512), include_native };
 				msg_data.push_back(opts);
 			}
-			_put_msg("profiler:servers", msg_data);
+			put_msg("profiler:servers", msg_data);
 			break;
 		default:
 			ERR_FAIL_MSG("Invalid profiler type");
@@ -1429,7 +1429,7 @@ String ScriptEditorDebugger::get_var_value(const String &p_var) const {
 
 void ScriptEditorDebugger::_resources_reimported(const PackedStringArray &p_resources) {
 	Array msg = { p_resources };
-	_put_msg("scene:reload_cached_files", msg);
+	put_msg("scene:reload_cached_files", msg);
 }
 
 int ScriptEditorDebugger::_get_node_path_cache(const NodePath &p_path) {
@@ -1442,7 +1442,7 @@ int ScriptEditorDebugger::_get_node_path_cache(const NodePath &p_path) {
 
 	node_path_cache[p_path] = last_path_id;
 	Array msg = { p_path, last_path_id };
-	_put_msg("scene:live_node_path", msg);
+	put_msg("scene:live_node_path", msg);
 
 	return last_path_id;
 }
@@ -1458,7 +1458,7 @@ int ScriptEditorDebugger::_get_res_path_cache(const String &p_path) {
 
 	res_path_cache[p_path] = last_path_id;
 	Array msg = { p_path, last_path_id };
-	_put_msg("scene:live_res_path", msg);
+	put_msg("scene:live_res_path", msg);
 
 	return last_path_id;
 }
@@ -1486,7 +1486,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 			//no pointers, sorry
 			msg.push_back(*p_args[i]);
 		}
-		_put_msg("scene:live_node_call", msg);
+		put_msg("scene:live_node_call", msg);
 
 		return;
 	}
@@ -1502,7 +1502,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 			//no pointers, sorry
 			msg.push_back(*p_args[i]);
 		}
-		_put_msg("scene:live_res_call", msg);
+		put_msg("scene:live_res_call", msg);
 
 		return;
 	}
@@ -1523,11 +1523,11 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 			Ref<Resource> res = p_value;
 			if (res.is_valid() && !res->get_path().is_empty()) {
 				Array msg = { pathid, p_property, res->get_path() };
-				_put_msg("scene:live_node_prop_res", msg);
+				put_msg("scene:live_node_prop_res", msg);
 			}
 		} else {
 			Array msg = { pathid, p_property, p_value };
-			_put_msg("scene:live_node_prop", msg);
+			put_msg("scene:live_node_prop", msg);
 		}
 
 		return;
@@ -1543,11 +1543,11 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 			Ref<Resource> res2 = p_value;
 			if (res2.is_valid() && !res2->get_path().is_empty()) {
 				Array msg = { pathid, p_property, res2->get_path() };
-				_put_msg("scene:live_res_prop_res", msg);
+				put_msg("scene:live_res_prop_res", msg);
 			}
 		} else {
 			Array msg = { pathid, p_property, p_value };
-			_put_msg("scene:live_res_prop", msg);
+			put_msg("scene:live_res_prop", msg);
 		}
 
 		return;
@@ -1593,7 +1593,7 @@ bool ScriptEditorDebugger::request_stack_dump(const int &p_frame) {
 	ERR_FAIL_COND_V(!is_session_active() || p_frame < 0, false);
 
 	Array msg = { p_frame };
-	_put_msg("get_stack_frame_vars", msg, debugging_thread_id);
+	put_msg("get_stack_frame_vars", msg, debugging_thread_id);
 	return true;
 }
 
@@ -1642,56 +1642,56 @@ void ScriptEditorDebugger::update_live_edit_root() {
 	} else {
 		msg.push_back("");
 	}
-	_put_msg("scene:live_set_root", msg);
+	put_msg("scene:live_set_root", msg);
 	live_edit_root->set_text(String(np));
 }
 
 void ScriptEditorDebugger::live_debug_create_node(const NodePath &p_parent, const String &p_type, const String &p_name) {
 	if (live_debug) {
 		Array msg = { p_parent, p_type, p_name };
-		_put_msg("scene:live_create_node", msg);
+		put_msg("scene:live_create_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_instantiate_node(const NodePath &p_parent, const String &p_path, const String &p_name) {
 	if (live_debug) {
 		Array msg = { p_parent, p_path, p_name };
-		_put_msg("scene:live_instantiate_node", msg);
+		put_msg("scene:live_instantiate_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_remove_node(const NodePath &p_at) {
 	if (live_debug) {
 		Array msg = { p_at };
-		_put_msg("scene:live_remove_node", msg);
+		put_msg("scene:live_remove_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_remove_and_keep_node(const NodePath &p_at, ObjectID p_keep_id) {
 	if (live_debug) {
 		Array msg = { p_at, p_keep_id };
-		_put_msg("scene:live_remove_and_keep_node", msg);
+		put_msg("scene:live_remove_and_keep_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_restore_node(ObjectID p_id, const NodePath &p_at, int p_at_pos) {
 	if (live_debug) {
 		Array msg = { p_id, p_at, p_at_pos };
-		_put_msg("scene:live_restore_node", msg);
+		put_msg("scene:live_restore_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_duplicate_node(const NodePath &p_at, const String &p_new_name) {
 	if (live_debug) {
 		Array msg = { p_at, p_new_name };
-		_put_msg("scene:live_duplicate_node", msg);
+		put_msg("scene:live_duplicate_node", msg);
 	}
 }
 
 void ScriptEditorDebugger::live_debug_reparent_node(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos) {
 	if (live_debug) {
 		Array msg = { p_at, p_new_place, p_new_name, p_at_pos };
-		_put_msg("scene:live_reparent_node", msg);
+		put_msg("scene:live_reparent_node", msg);
 	}
 }
 
@@ -1701,7 +1701,7 @@ bool ScriptEditorDebugger::get_debug_mute_audio() const {
 
 void ScriptEditorDebugger::set_debug_mute_audio(bool p_mute) {
 	Array msg = { p_mute };
-	_put_msg("scene:debug_mute_audio", msg);
+	put_msg("scene:debug_mute_audio", msg);
 	debug_mute_audio = p_mute;
 }
 
@@ -1714,14 +1714,14 @@ void ScriptEditorDebugger::set_camera_override(CameraOverride p_override) {
 		p_override != CameraOverride::OVERRIDE_NONE,
 		p_override == CameraOverride::OVERRIDE_EDITORS
 	};
-	_put_msg("scene:override_cameras", msg);
+	put_msg("scene:override_cameras", msg);
 
 	camera_override = p_override;
 }
 
 void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {
 	Array msg = { p_path, p_line, p_enabled };
-	_put_msg("breakpoint", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+	put_msg("breakpoint", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 
 	TreeItem *path_item = breakpoints_tree->search_item_text(p_path);
 	if (path_item == nullptr) {
@@ -1764,11 +1764,11 @@ void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool
 }
 
 void ScriptEditorDebugger::reload_all_scripts() {
-	_put_msg("reload_all_scripts", Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+	put_msg("reload_all_scripts", Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 }
 
 void ScriptEditorDebugger::reload_scripts(const Vector<String> &p_script_paths) {
-	_put_msg("reload_scripts", Variant(p_script_paths).operator Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+	put_msg("reload_scripts", Variant(p_script_paths).operator Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
 }
 
 bool ScriptEditorDebugger::is_skip_breakpoints() const {
@@ -2050,12 +2050,12 @@ void ScriptEditorDebugger::switch_to_debugger(int p_debugger_tab_idx) {
 }
 
 void ScriptEditorDebugger::send_message(const String &p_message, const Array &p_args) {
-	_put_msg(p_message, p_args);
+	put_msg(p_message, p_args);
 }
 
 void ScriptEditorDebugger::toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data) {
 	Array msg_data = { p_enable, p_data };
-	_put_msg("profiler:" + p_profiler, msg_data);
+	put_msg("profiler:" + p_profiler, msg_data);
 }
 
 ScriptEditorDebugger::ScriptEditorDebugger() {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -501,7 +501,7 @@ void ScriptEditorDebugger::_msg_signal_viewer_signal_emitted(uint64_t p_thread_i
 	// Data format: [emitter_id, node_name, node_class, signal_name, count, connections_array]
 
 	if (p_data.size() < 6) {
-		print_line("[ScriptEditorDebugger] WARNING: Invalid signal_viewer data, expected 6 elements");
+		ERR_PRINT("[ScriptEditorDebugger] Invalid signal_viewer data, expected 6 elements");
 		return;
 	}
 
@@ -515,11 +515,12 @@ void ScriptEditorDebugger::_msg_signal_viewer_signal_emitted(uint64_t p_thread_i
 
 	// Get SignalizeDock singleton and update it
 	SignalizeDock *signal_viewer = SignalizeDock::get_singleton();
-	if (signal_viewer) {
-		signal_viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, count, signal_connections);
-	} else {
-		print_line("[ScriptEditorDebugger] WARNING: No SignalizeDock singleton");
+	if (!signal_viewer) {
+		ERR_PRINT("[ScriptEditorDebugger] No SignalizeDock singleton");
+		return;
 	}
+
+	signal_viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, count, signal_connections);
 }
 
 void ScriptEditorDebugger::_msg_signal_viewer_node_signal_data(uint64_t p_thread_id, const Array &p_data) {
@@ -527,19 +528,18 @@ void ScriptEditorDebugger::_msg_signal_viewer_node_signal_data(uint64_t p_thread
 	// Data format: [node_id, node_name, node_class, [signals_data]]
 
 	if (p_data.is_empty()) {
-		print_line("[ScriptEditorDebugger] WARNING: Invalid node_signal_data, empty array");
+		ERR_PRINT("[ScriptEditorDebugger] Invalid node_signal_data, empty array");
 		return;
 	}
 
-	print_line(vformat("[ScriptEditorDebugger] Received node signal data with %d elements", p_data.size()));
-
 	// Get SignalizeDock singleton and forward the data
 	SignalizeDock *signal_viewer = SignalizeDock::get_singleton();
-	if (signal_viewer) {
-		signal_viewer->_on_node_signal_data_received(p_data);
-	} else {
-		print_line("[ScriptEditorDebugger] WARNING: No SignalizeDock singleton for node_signal_data");
+	if (!signal_viewer) {
+		ERR_PRINT("[ScriptEditorDebugger] No SignalizeDock singleton for node_signal_data");
+		return;
 	}
+
+	signal_viewer->_on_node_signal_data_received(p_data);
 }
 
 void ScriptEditorDebugger::_msg_stack_dump(uint64_t p_thread_id, const Array &p_data) {
@@ -995,28 +995,14 @@ void ScriptEditorDebugger::_msg_embed_next_frame(uint64_t p_thread_id, const Arr
 void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data) {
 	emit_signal(SNAME("debug_data"), p_msg, p_data);
 
-	// DEBUG: Log signal_viewer messages
-	if (p_msg.contains("signal_viewer")) {
-		print_line(vformat("[ScriptEditorDebugger] Received message: '%s'", p_msg));
-	}
-
 	ParseMessageFunc *fn_ptr = parse_message_handlers.getptr(p_msg);
 	if (fn_ptr) {
-		if (p_msg.contains("signal_viewer")) {
-			print_line(vformat("[ScriptEditorDebugger] Found handler for: '%s'", p_msg));
-		}
 		(this->**fn_ptr)(p_thread_id, p_data);
 	} else {
-		if (p_msg.contains("signal_viewer")) {
-			print_line(vformat("[ScriptEditorDebugger] No handler found for: '%s', trying plugins_capture", p_msg));
-		}
 		int colon_index = p_msg.find_char(':');
 		ERR_FAIL_COND_MSG(colon_index < 1, "Invalid message received");
 
 		bool parsed = EditorDebuggerNode::get_singleton()->plugins_capture(this, p_msg, p_data);
-		if (p_msg.contains("signal_viewer")) {
-			print_line(vformat("[ScriptEditorDebugger] plugins_capture returned: %s", parsed ? "TRUE" : "FALSE"));
-		}
 		if (!parsed) {
 			WARN_PRINT("Unknown message: " + p_msg);
 		}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -49,6 +49,7 @@
 #include "editor/debugger/editor_visual_profiler.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
+#include "editor/docks/signalize_dock.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -493,6 +494,52 @@ void ScriptEditorDebugger::_msg_servers_memory_usage(uint64_t p_thread_id, const
 
 void ScriptEditorDebugger::_msg_servers_drawn(uint64_t p_thread_id, const Array &p_data) {
 	can_request_idle_draw = true;
+}
+
+void ScriptEditorDebugger::_msg_signal_viewer_signal_emitted(uint64_t p_thread_id, const Array &p_data) {
+	// Forward signal emission data to SignalizeDock
+	// Data format: [emitter_id, node_name, node_class, signal_name, count, connections_array]
+
+	if (p_data.size() < 6) {
+		print_line("[ScriptEditorDebugger] WARNING: Invalid signal_viewer data, expected 6 elements");
+		return;
+	}
+
+	// Extract the data
+	ObjectID emitter_id = p_data[0];
+	String node_name = p_data[1];
+	String node_class = p_data[2];
+	String signal_name = p_data[3];
+	int count = p_data[4];
+	Array connections = p_data[5];
+
+	// Get SignalizeDock singleton and update it
+	SignalizeDock *signal_viewer = SignalizeDock::get_singleton();
+	if (signal_viewer) {
+		signal_viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, count, connections);
+	} else {
+		print_line("[ScriptEditorDebugger] WARNING: No SignalizeDock singleton");
+	}
+}
+
+void ScriptEditorDebugger::_msg_signal_viewer_node_signal_data(uint64_t p_thread_id, const Array &p_data) {
+	// Forward node signal data response to SignalizeDock
+	// Data format: [node_id, node_name, node_class, [signals_data]]
+
+	if (p_data.is_empty()) {
+		print_line("[ScriptEditorDebugger] WARNING: Invalid node_signal_data, empty array");
+		return;
+	}
+
+	print_line(vformat("[ScriptEditorDebugger] Received node signal data with %d elements", p_data.size()));
+
+	// Get SignalizeDock singleton and forward the data
+	SignalizeDock *signal_viewer = SignalizeDock::get_singleton();
+	if (signal_viewer) {
+		signal_viewer->_on_node_signal_data_received(p_data);
+	} else {
+		print_line("[ScriptEditorDebugger] WARNING: No SignalizeDock singleton for node_signal_data");
+	}
 }
 
 void ScriptEditorDebugger::_msg_stack_dump(uint64_t p_thread_id, const Array &p_data) {
@@ -948,14 +995,28 @@ void ScriptEditorDebugger::_msg_embed_next_frame(uint64_t p_thread_id, const Arr
 void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data) {
 	emit_signal(SNAME("debug_data"), p_msg, p_data);
 
+	// DEBUG: Log signal_viewer messages
+	if (p_msg.contains("signal_viewer")) {
+		print_line(vformat("[ScriptEditorDebugger] Received message: '%s'", p_msg));
+	}
+
 	ParseMessageFunc *fn_ptr = parse_message_handlers.getptr(p_msg);
 	if (fn_ptr) {
+		if (p_msg.contains("signal_viewer")) {
+			print_line(vformat("[ScriptEditorDebugger] Found handler for: '%s'", p_msg));
+		}
 		(this->**fn_ptr)(p_thread_id, p_data);
 	} else {
+		if (p_msg.contains("signal_viewer")) {
+			print_line(vformat("[ScriptEditorDebugger] No handler found for: '%s', trying plugins_capture", p_msg));
+		}
 		int colon_index = p_msg.find_char(':');
 		ERR_FAIL_COND_MSG(colon_index < 1, "Invalid message received");
 
 		bool parsed = EditorDebuggerNode::get_singleton()->plugins_capture(this, p_msg, p_data);
+		if (p_msg.contains("signal_viewer")) {
+			print_line(vformat("[ScriptEditorDebugger] plugins_capture returned: %s", parsed ? "TRUE" : "FALSE"));
+		}
 		if (!parsed) {
 			WARN_PRINT("Unknown message: " + p_msg);
 		}
@@ -976,6 +1037,8 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 #endif // DISABLE_DEPRECATED
 	parse_message_handlers["servers:memory_usage"] = &ScriptEditorDebugger::_msg_servers_memory_usage;
 	parse_message_handlers["servers:drawn"] = &ScriptEditorDebugger::_msg_servers_drawn;
+	parse_message_handlers["signal_viewer:signal_emitted"] = &ScriptEditorDebugger::_msg_signal_viewer_signal_emitted;
+	parse_message_handlers["signal_viewer:node_signal_data"] = &ScriptEditorDebugger::_msg_signal_viewer_node_signal_data;
 	parse_message_handlers["stack_dump"] = &ScriptEditorDebugger::_msg_stack_dump;
 	parse_message_handlers["stack_frame_vars"] = &ScriptEditorDebugger::_msg_stack_frame_vars;
 	parse_message_handlers["stack_frame_var"] = &ScriptEditorDebugger::_msg_stack_frame_var;

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -314,7 +314,7 @@ public:
 
 	/// Needed by _live_edit_set, buttons state.
 	// Send message to game process - made public for SignalizeDock
-	void _put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
+	void put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
 
 	// Needed by _live_edit_set, buttons state.
 	void set_editor_remote_tree(const Tree *p_tree) { editor_remote_tree = p_tree; }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -216,6 +216,8 @@ private:
 #endif // DISABLE_DEPRECATED
 	void _msg_servers_memory_usage(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_drawn(uint64_t p_thread_id, const Array &p_data);
+	void _msg_signal_viewer_signal_emitted(uint64_t p_thread_id, const Array &p_data);
+	void _msg_signal_viewer_node_signal_data(uint64_t p_thread_id, const Array &p_data);
 	void _msg_stack_dump(uint64_t p_thread_id, const Array &p_data);
 	void _msg_stack_frame_vars(uint64_t p_thread_id, const Array &p_data);
 	void _msg_stack_frame_var(uint64_t p_thread_id, const Array &p_data);
@@ -281,7 +283,6 @@ private:
 	void _item_menu_id_pressed(int p_option);
 	void _tab_changed(int p_tab);
 
-	void _put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
 	void _export_csv();
 
 	void _clear_execution();
@@ -312,7 +313,12 @@ public:
 	void clear_inspector(bool p_send_msg = true);
 
 	/// Needed by _live_edit_set, buttons state.
+	// Send message to game process - made public for SignalizeDock
+	void _put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
+
+	// Needed by _live_edit_set, buttons state.
 	void set_editor_remote_tree(const Tree *p_tree) { editor_remote_tree = p_tree; }
+	const Tree *get_editor_remote_tree() const { return editor_remote_tree; }
 
 	void request_remote_tree();
 	const SceneDebuggerTree *get_remote_tree();

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -39,6 +39,7 @@
 #include "core/object/script_language.h"
 #include "core/templates/hash_set.h"
 #include "core/variant/callable.h"
+#include <functional>
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_interface.h"
@@ -857,7 +858,7 @@ Color SignalizeDock::_get_editor_node_icon_color(Node *p_node) {
 	}
 
 	Ref<Texture2D> icon = editor->get_object_icon(p_node, "Node");
-	if (!icon.is_valid() || icon == nullptr) {
+	if (!icon.is_valid()) {
 		// No icon available, use default color
 		return Color(0.92, 0.92, 0.92, 1.0);
 	}

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -2577,7 +2577,7 @@ void SignalizeDock::_inspect_remote_node(ObjectID p_node_id, const String &p_nod
 
 	// Send with "scene:" prefix to reach SceneDebugger handlers
 	// Pass args directly (not wrapped), as the handler expects: [node_id, node_path]
-	debugger->_put_msg("scene:signal_viewer_request_node_data", args);
+	debugger->put_msg("scene:signal_viewer_request_node_data", args);
 
 	// Update inspection state
 	inspected_node_id = p_node_id;

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -39,7 +39,6 @@
 #include "core/object/script_language.h"
 #include "core/templates/hash_set.h"
 #include "core/variant/callable.h"
-#include <functional>
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_interface.h"
@@ -59,6 +58,7 @@
 #include "scene/gui/tree.h"
 #include "scene/main/timer.h"
 #include "scene/resources/style_box_flat.h"
+#include <functional>
 
 // Static member initialization
 SignalizeDock *SignalizeDock::singleton_instance = nullptr;

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -1,0 +1,3142 @@
+#include "signalize_dock.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_interface.h"
+#include "editor/settings/editor_settings.h"
+#include "editor/inspector/editor_inspector.h"
+#include "editor/debugger/editor_debugger_node.h"
+#include "editor/debugger/script_editor_debugger.h"
+#include "editor/run/editor_run_bar.h"
+#include "editor/script/script_editor_plugin.h"
+#include "scene/debugger/scene_debugger.h"
+#include "scene/gui/tree.h"
+#include "core/debugger/engine_debugger.h"
+#include "core/object/script_language.h"
+#include "core/object/script_instance.h"
+#include "core/variant/callable.h"
+#include "core/input/input_event.h"
+#include "core/object/class_db.h"
+#include "scene/gui/control.h"
+#include "scene/gui/label.h"
+#include "scene/gui/color_picker.h"
+#include "scene/gui/spin_box.h"
+#include "scene/gui/option_button.h"
+#include "scene/resources/style_box_flat.h"
+#include "scene/gui/box_container.h"
+#include "scene/main/timer.h"
+#include "editor/gui/window_wrapper.h"
+#include "core/templates/hash_set.h"
+
+// Static member initialization
+SignalizeDock *SignalizeDock::singleton_instance = nullptr;
+const String SignalizeDock::MESSAGE_SIGNAL_EMITTED = "signal_viewer:signal_emitted";
+const String SignalizeDock::MESSAGE_NODE_SIGNAL_DATA = "signal_viewer:node_signal_data";
+
+SignalizeDock::SignalizeDock() {
+	// Set singleton instance for global callback access
+	singleton_instance = this;
+	set_name("Signalize");
+	set_h_size_flags(SIZE_EXPAND_FILL);
+	set_v_size_flags(SIZE_EXPAND_FILL);
+
+	// Create WindowWrapper (not added yet - only added when floating)
+	window_wrapper = memnew(WindowWrapper);
+	window_wrapper->set_margins_enabled(true);
+	window_wrapper->set_window_title(TTR("Signalize - Signal Viewer"));
+
+	// Create a content container that holds all the UI
+	// This container can be reparented between SignalizeDock (docked) and WindowWrapper (floating)
+	content_container = memnew(VBoxContainer);
+	content_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	content_container->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(content_container);
+
+	// Top bar with search, refresh, and floating button
+	HBoxContainer *top_bar = memnew(HBoxContainer);
+	content_container->add_child(top_bar);
+
+	title_label = memnew(Label("Signalize"));
+	title_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	top_bar->add_child(title_label);
+
+	search_box = memnew(LineEdit);
+	search_box->set_placeholder("Filter nodes...");
+	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_box->connect("text_changed", callable_mp(this, &SignalizeDock::_on_search_changed));
+	top_bar->add_child(search_box);
+
+	refresh_button = memnew(Button);
+	refresh_button->set_text("Build Graph");
+	refresh_button->set_tooltip_text("Rebuild the signal graph from the edited scene");
+	refresh_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_refresh_pressed));
+	top_bar->add_child(refresh_button);
+
+	// Per-node inspection: Add button to inspect selected remote node
+	Button *inspect_button = memnew(Button);
+	inspect_button->set_text("Inspect Selected Node");
+	// Note: Button doesn't have set_tooltip in Godot 4.x, tooltip is set via theme or custom logic
+	inspect_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_inspect_selected_button_pressed));
+	top_bar->add_child(inspect_button);
+
+	// Connection color picker
+	connection_color_button = memnew(ColorPickerButton);
+
+	// Load saved color from editor settings
+	Ref<EditorSettings> editor_settings = EditorSettings::get_singleton();
+	if (editor_settings.is_valid()) {
+		Variant saved_color = editor_settings->get("signalize/connection_color");
+		if (saved_color.get_type() == Variant::COLOR) {
+			custom_connection_color = saved_color;
+		}
+
+		// Load verbosity level from editor settings
+		Variant saved_verbosity = editor_settings->get("signalize/verbosity_level");
+		if (saved_verbosity.get_type() == Variant::INT) {
+			verbosity_level = saved_verbosity;
+		}
+	}
+
+	connection_color_button->set_pick_color(custom_connection_color);
+	connection_color_button->set_tooltip_text("Connection line color");
+	connection_color_button->connect("color_changed", callable_mp(this, &SignalizeDock::_on_connection_color_changed));
+	top_bar->add_child(connection_color_button);
+
+	// Settings button
+	settings_button = memnew(Button);
+	settings_button->set_theme_type_variation(SceneStringName(FlatButton));
+	settings_button->set_tooltip_text("Signalize Settings");
+	settings_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_settings_pressed));
+	top_bar->add_child(settings_button);
+
+	// Make Floating button (using icon like ScriptEditor)
+	make_floating_button = memnew(Button);
+	make_floating_button->set_theme_type_variation(SceneStringName(FlatButton));
+	// Icon will be set in NOTIFICATION_THEME_CHANGED
+	make_floating_button->set_tooltip_text("Make Signalize floating (Alt+F)");
+	make_floating_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_make_floating_pressed));
+	top_bar->add_child(make_floating_button);
+
+	// Graph view
+	graph_edit = memnew(GraphEdit);
+	graph_edit->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph_edit->set_v_size_flags(SIZE_EXPAND_FILL);
+	graph_edit->set_zoom(0.8);
+	graph_edit->set_show_zoom_label(true);
+	content_container->add_child(graph_edit);
+
+	// Connect to play/stop signals to rebuild graph with runtime nodes
+	EditorRunBar *run_bar = EditorRunBar::get_singleton();
+	if (run_bar) {
+		run_bar->connect("play_pressed", callable_mp(this, &SignalizeDock::_on_play_pressed));
+		run_bar->connect("stop_pressed", callable_mp(this, &SignalizeDock::_on_stop_pressed));
+	} else {
+		ERR_PRINT("[Signalize] Could not connect to EditorRunBar signals");
+	}
+
+	// Try to connect to debugger for message handling
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (debugger_node) {
+		// Debugger node available
+	}
+
+	// Create timer to check when game is running and send start_tracking message
+	game_start_check_timer = memnew(Timer);
+	game_start_check_timer->set_wait_time(0.5); // Check every 0.5 seconds
+	game_start_check_timer->set_one_shot(false);
+	game_start_check_timer->connect("timeout", callable_mp(this, &SignalizeDock::_on_game_start_check_timer_timeout));
+	game_start_check_timer->set_autostart(false);
+	content_container->add_child(game_start_check_timer);
+	game_start_check_timer->set_process_internal(true); // Make sure timer processes
+
+	// NOTE: Global signal tracking DISABLED by default
+	// We'll only enable it when a node is being inspected during gameplay
+	tracking_enabled = false;
+	was_playing_last_frame = false;
+	remote_scene_root_id = ObjectID(); // Initialize to invalid ID
+
+	// Register inspector plugin to detect when nodes are clicked in remote tree
+	inspector_plugin = memnew(SignalizeInspectorPlugin);
+	inspector_plugin->set_signal_viewer_dock(this);
+	EditorInspector::add_inspector_plugin(inspector_plugin);
+
+	// Register message capture to receive signal emissions from game process
+	if (EngineDebugger::get_singleton()) {
+		EngineDebugger::register_message_capture("signal_viewer", EngineDebugger::Capture(nullptr, _capture_signal_viewer_messages));
+		// Also register for "scene" messages to detect node selection in remote tree
+		EngineDebugger::register_message_capture("scene", EngineDebugger::Capture(nullptr, _capture_signal_viewer_messages));
+	}
+
+	// Build initial graph from edited scene (only works when game is not running)
+	_build_graph();
+}
+
+void SignalizeDock::_on_test_signal() {
+	// Test handler - can be removed in production
+}
+
+void SignalizeDock::_on_refresh_pressed() {
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	ScriptEditorDebugger *debugger = nullptr;
+
+	if (debugger_node) {
+		debugger = debugger_node->get_current_debugger();
+	}
+
+	// If game is running, don't allow full graph refresh
+	if (debugger && debugger->is_session_active()) {
+		ERR_PRINT("[Signalize] Cannot refresh full graph while game is running. Use 'Inspect Selected Node' instead.");
+		return;
+	}
+
+	// Clear the existing graph and rebuild from the edited scene
+	_clear_inspection();
+	_build_graph();
+}
+
+void SignalizeDock::_on_make_floating_pressed() {
+	if (!window_wrapper || !content_container) {
+		return;
+	}
+
+	if (!is_floating) {
+		// Create a shortcut for toggling floating
+		Ref<Shortcut> make_floating_shortcut;
+		make_floating_shortcut.instantiate();
+		make_floating_shortcut->set_name("signalize/make_floating");
+
+		Ref<InputEventKey> key_event;
+		key_event.instantiate();
+		key_event->set_keycode(Key::F);
+		key_event->set_alt_pressed(true);
+
+		Array events;
+		events.push_back(key_event);
+		make_floating_shortcut->set_events(events);
+
+		// Reparent content_container from SignalizeDock to WindowWrapper
+		remove_child(content_container);
+		window_wrapper->set_wrapped_control(content_container, make_floating_shortcut);
+
+		// Add WindowWrapper to the scene tree as a child of SignalizeDock's parent
+		if (get_parent()) {
+			get_parent()->add_child(window_wrapper);
+		}
+
+		// Enable floating mode
+		window_wrapper->set_window_enabled(true);
+		is_floating = true;
+	} else {
+		// Disable floating mode first
+		window_wrapper->set_window_enabled(false);
+
+		// Reparent content_container back to SignalizeDock
+		window_wrapper->release_wrapped_control();
+		add_child(content_container);
+
+		// Remove WindowWrapper from scene tree
+		if (window_wrapper->get_parent()) {
+			window_wrapper->get_parent()->remove_child(window_wrapper);
+		}
+
+		is_floating = false;
+	}
+}
+
+void SignalizeDock::_on_search_changed(const String &p_text) {
+	// Show/hide nodes based on search
+	String search_lower = p_text.to_lower();
+
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		GraphNode *gn = kv.value;
+		if (!gn) {
+			continue;
+		}
+
+		String node_name = gn->get_title();
+		bool visible = search_lower.is_empty() || node_name.to_lower().contains(search_lower);
+		gn->set_visible(visible);
+	}
+}
+
+void SignalizeDock::_on_connection_color_changed(const Color &p_color) {
+	// Update the custom connection color
+	custom_connection_color = p_color;
+
+	// Save to editor settings
+	Ref<EditorSettings> editor_settings = EditorSettings::get_singleton();
+	if (editor_settings.is_valid()) {
+		editor_settings->set("signalize/connection_color", p_color);
+		editor_settings->save();
+	}
+
+	
+	// Note: We don't rebuild the graph here because:
+	// 1. Rebuilding triggers the color_changed signal again, creating an infinite loop
+	// 2. The new color will be applied automatically when the graph is next rebuilt for any reason
+	// 3. Connection highlights during runtime will use the new color immediately
+	// The user can force a rebuild by clicking the "Build Graph" button if they want to see the change immediately
+}
+
+void SignalizeDock::_on_settings_pressed() {
+	// Create settings dialog if it doesn't exist
+	if (!settings_dialog) {
+		settings_dialog = memnew(AcceptDialog);
+		settings_dialog->set_title("Signalize Settings");
+		settings_dialog->set_min_size(Size2(300, 100));
+		add_child(settings_dialog);
+
+		VBoxContainer *vbox = memnew(VBoxContainer);
+		settings_dialog->add_child(vbox);
+
+		// Verbosity setting
+		HBoxContainer *verbosity_row = memnew(HBoxContainer);
+		vbox->add_child(verbosity_row);
+
+		Label *verbosity_label = memnew(Label("Verbosity Level:"));
+		verbosity_label->set_h_size_flags(SIZE_EXPAND_FILL);
+		verbosity_row->add_child(verbosity_label);
+
+		OptionButton *verbosity_option = memnew(OptionButton);
+		verbosity_option->add_item("Silent (errors only)", 0);
+		verbosity_option->add_item("Quiet (graph stats)", 1);
+		verbosity_option->add_item("Normal (inspector updates)", 2);
+		verbosity_option->add_item("Verbose (full output)", 3);
+		verbosity_option->select(verbosity_level);
+		verbosity_option->connect("item_selected", callable_mp(this, &SignalizeDock::_on_verbosity_changed));
+		verbosity_row->add_child(verbosity_option);
+
+		// Pulse duration setting
+		HBoxContainer *duration_row = memnew(HBoxContainer);
+		vbox->add_child(duration_row);
+
+		Label *duration_label = memnew(Label("Connection Pulse Duration (seconds):"));
+		duration_label->set_h_size_flags(SIZE_EXPAND_FILL);
+		duration_row->add_child(duration_label);
+
+		SpinBox *duration_spin = memnew(SpinBox);
+		duration_spin->set_min(0.1);
+		duration_spin->set_max(10.0);
+		duration_spin->set_step(0.1);
+		duration_spin->set_value(connection_pulse_duration);
+		duration_spin->connect("value_changed", callable_mp(this, &SignalizeDock::_on_pulse_duration_changed));
+		duration_row->add_child(duration_spin);
+	}
+
+	settings_dialog->popup_centered();
+}
+
+void SignalizeDock::_on_pulse_duration_changed(double p_value) {
+	connection_pulse_duration = p_value;
+}
+
+void SignalizeDock::_on_verbosity_changed(int p_level) {
+	verbosity_level = p_level;
+	Ref<EditorSettings> editor_settings = EditorSettings::get_singleton();
+	if (editor_settings.is_valid()) {
+		editor_settings->set("signalize/verbosity_level", verbosity_level);
+		editor_settings->save();
+	}
+}
+
+void SignalizeDock::_on_open_function_button_pressed(ObjectID p_node_id, const String &p_method_name) {
+	// Get the node
+	Object *obj = ObjectDB::get_instance(p_node_id);
+	if (!obj) {
+		ERR_PRINT(vformat("[Signalize] Cannot open function: node not found (ID: %s)", String::num_uint64((uint64_t)p_node_id)));
+		return;
+	}
+
+	Node *node = Object::cast_to<Node>(obj);
+	if (!node) {
+		ERR_PRINT(vformat("[Signalize] Cannot open function: object is not a Node"));
+		return;
+	}
+
+	// Get the script attached to this node
+	Ref<Script> script = node->get_script();
+	if (!script.is_valid()) {
+		ERR_PRINT(vformat("[Signalize] Cannot open function: node '%s' has no script", node->get_name()));
+		return;
+	}
+
+	// Get the script editor
+	ScriptEditor *script_editor = ScriptEditor::get_singleton();
+	if (!script_editor) {
+		ERR_PRINT("[Signalize] Cannot open function: ScriptEditor not available");
+		return;
+	}
+
+	// First, try to find the method in the direct script
+	bool success = script_editor->script_goto_method(script, p_method_name);
+
+	// If not found and the script has a base class, search the base class script
+	if (!success) {
+		Ref<Script> base_script = script->get_base_script();
+		while (base_script.is_valid()) {
+			success = script_editor->script_goto_method(base_script, p_method_name);
+			if (success) {
+				break;
+			}
+
+			// Try next base class in the inheritance chain
+			base_script = base_script->get_base_script();
+		}
+	}
+
+	if (!success) {
+			}
+}
+
+void SignalizeDock::_build_graph() {
+	// Save current node positions before clearing
+	saved_node_positions.clear();
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		GraphNode *gn = kv.value;
+		if (gn) {
+			saved_node_positions[kv.key] = gn->get_position_offset();
+		}
+	}
+
+// Cleanup old runtime tracking connections before rebuilding
+	_cleanup_runtime_signal_tracking();
+
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		ERR_PRINT("[Signalize] No EditorNode - cannot build graph");
+		return;
+	}
+
+	Node *scene_root = editor_node->get_edited_scene();
+	if (!scene_root) {
+		ERR_PRINT("[Signalize] No edited scene - cannot build graph");
+		return;
+	}
+
+	
+	// First pass: collect all nodes that participate in signal connections
+	// ONLY include nodes that BOTH emit signals AND have their targets also included
+	// This ensures all nodes in the graph will have visible connections
+	List<ObjectID> connected_nodes;
+	HashMap<ObjectID, int> emitter_connection_counts; // Track how many signals each node emits
+	List<Node *> all_nodes;
+	_collect_all_nodes(scene_root, all_nodes);
+
+	// Build a set of all nodes in the scene for quick lookup
+	HashMap<ObjectID, Node*> node_lookup;
+	for (Node *node : all_nodes) {
+		node_lookup[node->get_instance_id()] = node;
+	}
+
+	// Find all nodes that emit signals to OTHER nodes in the scene
+	for (Node *node : all_nodes) {
+		List<MethodInfo> signals;
+		node->get_signal_list(&signals);
+
+		bool has_connection_to_scene_node = false;
+		for (const MethodInfo &sig : signals) {
+			List<Object::Connection> conns;
+			node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target = conn.callable.get_object();
+				if (target) {
+					Node *target_node = Object::cast_to<Node>(target);
+					// Only count if target is a different node (not self-connection)
+					if (target_node && target_node != node) {
+						// Check if the target is also in our scene
+						if (node_lookup.has(target_node->get_instance_id())) {
+							has_connection_to_scene_node = true;
+							ObjectID emitter_id = node->get_instance_id();
+
+							if (!emitter_connection_counts.has(emitter_id)) {
+								emitter_connection_counts[emitter_id] = 0;
+							}
+							emitter_connection_counts[emitter_id]++;
+							break;
+						}
+					}
+				}
+			}
+			if (has_connection_to_scene_node) {
+				break;
+			}
+		}
+	}
+
+	// Now collect all emitters AND their receivers
+	HashMap<ObjectID, bool> final_nodes;
+	for (Node *node : all_nodes) {
+		List<MethodInfo> signals;
+		node->get_signal_list(&signals);
+
+		for (const MethodInfo &sig : signals) {
+			List<Object::Connection> conns;
+			node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target = conn.callable.get_object();
+				if (target) {
+					Node *target_node = Object::cast_to<Node>(target);
+					if (target_node && target_node != node && node_lookup.has(target_node->get_instance_id())) {
+						// Filter out internal engine connections that aren't user-created
+						String method_name = conn.callable.get_method();
+
+						// Check if target has a script with this method
+						bool has_script_method = false;
+						ScriptInstance *script = target_node->get_script_instance();
+						if (script) {
+							// Check if this method exists in the script
+							has_script_method = script->has_method(StringName(method_name));
+						}
+
+						// Only include if it's a real user connection (to a script method)
+						if (!has_script_method) {
+							// This is an internal engine connection, skip it
+							continue;
+						}
+
+						// This is a valid user-created connection within the scene
+						ObjectID emitter_id = node->get_instance_id();
+						ObjectID receiver_id = target_node->get_instance_id();
+
+						// Add both emitter and receiver to final list
+						final_nodes[emitter_id] = true;
+						final_nodes[receiver_id] = true;
+					}
+				}
+			}
+		}
+	}
+
+	// Convert set to list
+	for (const KeyValue<ObjectID, bool> &KV : final_nodes) {
+		connected_nodes.push_back(KV.key);
+	}
+
+	// Third pass: create graph nodes only for connected nodes
+	int index = 0;
+	for (Node *node : all_nodes) {
+		if (connected_nodes.find(node->get_instance_id()) != nullptr) {
+			_create_graph_node(node, 0, index++);
+		}
+	}
+
+
+	// Fourth pass: create the signal connections
+	_connect_all_node_signals();
+
+	// Log graph build result (level 1 - Quiet)
+	if (should_log(1)) {
+		print_line(vformat("[Signalize] Graph built: %d nodes, %d connections",
+			node_graph_nodes.size(), connections.size()));
+	}
+
+	// Auto-arrange the graph nodes for better visualization
+	graph_edit->arrange_nodes();
+
+	// Restore saved positions for nodes that still exist (overriding auto-layout)
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		if (saved_node_positions.has(kv.key)) {
+			kv.value->set_position_offset(saved_node_positions[kv.key]);
+		}
+	}
+	}
+void SignalizeDock::_collect_all_nodes(Node *p_node, List<Node *> &r_list) {
+	if (!p_node) {
+		return;
+	}
+
+	r_list.push_back(p_node);
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		Node *child = Object::cast_to<Node>(p_node->get_child(i));
+		if (child) {
+			_collect_all_nodes(child, r_list);
+		}
+	}
+}
+
+void SignalizeDock::_build_graph_for_single_node(Node *p_node) {
+	if (!p_node) {
+		ERR_PRINT("[Signalize] Cannot build graph - node is null");
+		return;
+	}
+
+	
+	// Clear previous graph
+	_clear_inspection();
+
+	ObjectID node_id = p_node->get_instance_id();
+	String node_name = p_node->get_name();
+	String node_class = p_node->get_class();
+
+	// Collect receiver methods (what this node receives)
+	HashMap<ObjectID, List<ReceiverMethodInfo>> receiver_methods_list;
+
+	// Collect all signals this node emits
+	List<String> emitted_signals;
+	List<MethodInfo> signals;
+	p_node->get_signal_list(&signals);
+
+	for (const MethodInfo &sig : signals) {
+		List<Object::Connection> conns;
+		p_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+		// Collect receiver info for connections to script methods only
+		for (const Object::Connection &conn : conns) {
+			Object *target_obj = conn.callable.get_object();
+			if (!target_obj) {
+				continue;
+			}
+
+			Node *target_node = Object::cast_to<Node>(target_obj);
+			if (!target_node) {
+				continue;
+			}
+
+			String target_method = conn.callable.get_method();
+			if (target_method.is_empty()) {
+				continue;
+			}
+
+			// Filter: Only include connections to script methods
+			ScriptInstance *script = target_node->get_script_instance();
+			if (!script || !script->has_method(StringName(target_method))) {
+				continue; // Skip internal engine connections
+			}
+
+			if (emitted_signals.find(sig.name) == nullptr) {
+				emitted_signals.push_back(sig.name);
+			}
+
+			ObjectID target_id = target_node->get_instance_id();
+
+			if (!receiver_methods_list.has(target_id)) {
+				receiver_methods_list[target_id] = List<ReceiverMethodInfo>();
+			}
+
+			// Check if already added
+			bool already_added = false;
+			for (const ReceiverMethodInfo &info : receiver_methods_list[target_id]) {
+				if (info.method_name == target_method) {
+					already_added = true;
+					break;
+				}
+			}
+
+			if (!already_added) {
+				ReceiverMethodInfo info;
+				info.target_id = target_id;
+				info.method_name = target_method;
+				receiver_methods_list[target_id].push_back(info);
+			}
+		}
+	}
+
+	// Also check what this node receives from other nodes
+	// We need to scan all nodes in the scene to find signals that connect to this node
+	EditorNode *editor = EditorNode::get_singleton();
+	if (!editor) {
+		return;
+	}
+
+	Node *scene_root = editor->get_edited_scene();
+	if (!scene_root) {
+		ERR_PRINT("[Signalize] No edited scene");
+		return;
+	}
+
+	List<Node *> all_nodes;
+	_collect_all_nodes(scene_root, all_nodes);
+
+	// Find all signals that connect TO this node (script methods only)
+	for (Node *emitter_node : all_nodes) {
+		if (emitter_node == p_node) {
+			continue; // Skip self
+		}
+
+		List<MethodInfo> emitter_signals;
+		emitter_node->get_signal_list(&emitter_signals);
+
+		for (const MethodInfo &sig : emitter_signals) {
+			List<Object::Connection> conns;
+			emitter_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target_obj = conn.callable.get_object();
+				if (!target_obj) {
+					continue;
+				}
+
+				// Check if this connection targets our node
+				if (target_obj == p_node) {
+					// Check if this is a connection to a script method
+					String target_method = conn.callable.get_method();
+					if (target_method.is_empty()) {
+						continue;
+					}
+
+					// Filter: Only include if p_node has this method in a script
+					ScriptInstance *script = p_node->get_script_instance();
+					if (!script || !script->has_method(StringName(target_method))) {
+						continue; // Skip internal engine connections
+					}
+
+					// This emitter sends a signal to our node's script method - add it to the graph
+					ObjectID emitter_id = emitter_node->get_instance_id();
+					if (!node_graph_nodes.has(emitter_id)) {
+						_create_graph_node(emitter_node, 0, node_graph_nodes.size());
+					}
+					break; // Found a valid connection from this emitter, stop checking other signals
+				}
+			}
+		}
+	}
+
+	// Create graph node for the main node
+	if (!node_graph_nodes.has(node_id)) {
+		_create_graph_node(p_node, 0, node_graph_nodes.size());
+	}
+
+	// Create graph nodes for all receivers
+	for (const KeyValue<ObjectID, List<ReceiverMethodInfo>> &KV : receiver_methods_list) {
+		ObjectID target_id = KV.key;
+		if (target_id == node_id) {
+			continue; // Skip self
+		}
+
+		// Find the target node
+		Node *target_node = nullptr;
+		for (Node *node : all_nodes) {
+			if (node->get_instance_id() == target_id) {
+				target_node = node;
+				break;
+			}
+		}
+
+		if (target_node && !node_graph_nodes.has(target_id)) {
+			_create_graph_node(target_node, 0, node_graph_nodes.size());
+		}
+	}
+
+	// Now add all GraphNodes to GraphEdit
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		GraphNode *gn = kv.value;
+		if (gn->get_parent() == nullptr) {
+			graph_edit->add_child(gn);
+		}
+	}
+
+	// Now create all the connections and labels
+	_connect_all_node_signals();
+
+	// Log single-node graph build result (level 2 - Normal, inspector updates)
+	if (should_log(2)) {
+		print_line(vformat("[Signalize] Built graph for node %s: %d nodes, %d connections",
+			node_name, node_graph_nodes.size(), pending_connections.size()));
+	}
+}
+
+bool SignalizeDock::_node_has_connections(Node *p_node) {
+	if (!p_node) {
+		return false;
+	}
+
+	// Check if this node emits signals to other nodes
+	List<MethodInfo> signals;
+	p_node->get_signal_list(&signals);
+
+	for (const MethodInfo &sig : signals) {
+		List<Object::Connection> conns;
+		p_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+		// Check if this is a user connection (both editor and runtime)
+		if (conns.size() > 0) {
+			return true;
+		}
+	}
+
+	// Also check if this node receives signals from other nodes
+	// We need to scan all nodes to find connections to this node
+	return false; // Will be handled by the emitter check
+}
+
+void SignalizeDock::_create_graph_node(Node *p_node, int p_depth, int p_index) {
+	if (!p_node) {
+		return;
+	}
+
+	ObjectID node_id = p_node->get_instance_id();
+
+	// Skip if already created
+	if (node_graph_nodes.has(node_id)) {
+		return;
+	}
+
+	// Create graph node for this node
+	GraphNode *gn = memnew(GraphNode);
+	String title = vformat("%s(%s)", p_node->get_name(), p_node->get_class());
+	gn->set_title(title);
+	gn->set_position_offset(Vector2(p_depth * 350, p_index * 150));
+
+	// Get the actual icon color from the editor (matches Scene tree colors)
+	Color node_color = _get_editor_node_icon_color(p_node);
+
+	// Set the node's titlebar color using theme override (like Visual Shader does)
+	Ref<StyleBoxFlat> sb_colored = gn->get_theme_stylebox("titlebar", "GraphNode")->duplicate();
+	sb_colored->set_bg_color(node_color);
+	gn->add_theme_style_override("titlebar", sb_colored);
+
+	// Also set the selected state color
+	Ref<StyleBoxFlat> sb_colored_selected = gn->get_theme_stylebox("titlebar_selected", "GraphNode")->duplicate();
+	sb_colored_selected->set_bg_color(node_color.lightened(0.2));
+	gn->add_theme_style_override("titlebar_selected", sb_colored_selected);
+
+	// Set the title text to black
+	HBoxContainer *titlebar = gn->get_titlebar_hbox();
+	if (titlebar) {
+		for (int i = 0; i < titlebar->get_child_count(); i++) {
+			Label *title_label = Object::cast_to<Label>(titlebar->get_child(i));
+			if (title_label) {
+				title_label->add_theme_color_override("font_color", Color(0, 0, 0, 1)); // Black text
+				break;
+			}
+		}
+	}
+
+	// Store the color for use with labels
+	node_colors[node_id] = node_color;
+
+	// Set a unique name for this graph node
+	String graph_name = vformat("GraphNode_%s", String::num_uint64((uint64_t)node_id));
+	gn->set_name(graph_name);
+
+	// DON'T add to graph_edit yet! We'll add it after slots are configured
+	node_graph_nodes[node_id] = gn;
+	node_graph_names[node_id] = graph_name;
+}
+
+Color SignalizeDock::_get_editor_node_icon_color(Node *p_node) {
+	// Get the actual icon from the editor (same as used in Scene tree)
+	EditorNode *editor = EditorNode::get_singleton();
+	if (!editor) {
+		// Fallback to default color if editor not available
+		return Color(0.92, 0.92, 0.92, 1.0);
+	}
+
+	Ref<Texture2D> icon = editor->get_object_icon(p_node, "Node");
+	if (!icon.is_valid() || icon == nullptr) {
+		// No icon available, use default color
+		return Color(0.92, 0.92, 0.92, 1.0);
+	}
+
+	// Sample the center pixel of the icon to get its representative color
+	// This gives us the actual color the editor uses for this node type
+	Vector2 icon_size = icon->get_size();
+	if (icon_size.x <= 0 || icon_size.y <= 0) {
+		return Color(0.92, 0.92, 0.92, 1.0);
+	}
+
+	// Get image data from the texture
+	Ref<Image> icon_image = icon->get_image();
+	if (!icon_image.is_valid()) {
+		// Last resort: use default color
+		return Color(0.92, 0.92, 0.92, 1.0);
+	}
+
+	// Sample a pixel from the center of the icon
+	int center_x = icon_image->get_width() / 2;
+	int center_y = icon_image->get_height() / 2;
+	Color icon_color = icon_image->get_pixel(center_x, center_y);
+
+	// If the sampled pixel is transparent or near-black, try another position
+	if (icon_color.a < 0.1) {
+		// Try top-left quadrant
+		icon_color = icon_image->get_pixel(icon_image->get_width() / 4, icon_image->get_height() / 4);
+		if (icon_color.a < 0.1) {
+			// Still transparent, use default
+			icon_color = Color(0.92, 0.92, 0.92, 1.0);
+		}
+	}
+
+	return icon_color;
+}
+
+Color SignalizeDock::_get_editor_node_icon_color_by_class(const String &p_class_name) {
+	// Simple color mapping based on inheritance hierarchy
+	// Colors match the editor Scene tree icons
+
+	// Special cases: AnimationPlayer and AnimationTree
+	if (p_class_name == "AnimationPlayer" || p_class_name == "AnimationTree") {
+		return Color(0.76, 0.56, 0.95, 1.0); // #c38ef1
+	}
+
+	// Check inheritance hierarchy using ClassDB
+	// Note: Check most specific types first (Control before Node, Node3D before Node)
+
+	// Control (green)
+	if (ClassDB::is_parent_class(p_class_name, "Control")) {
+		return Color(0.56, 0.94, 0.59, 1.0); // #8eef96
+	}
+
+	// Node3D (red)
+	if (ClassDB::is_parent_class(p_class_name, "Node3D")) {
+		return Color(0.99, 0.5, 0.49, 1.0); // #fc7f7e
+	}
+
+	// Node2D (blue)
+	if (ClassDB::is_parent_class(p_class_name, "Node2D")) {
+		return Color(0.55, 0.65, 0.95, 1.0); // #8da5f3
+	}
+
+	// Node (white) - catch-all for anything inheriting from Node
+	if (ClassDB::is_parent_class(p_class_name, "Node")) {
+		return Color(1.0, 1.0, 1.0, 1.0); // #ffffff
+	}
+
+	// Fallback for unknown classes
+	return Color(1.0, 1.0, 1.0, 1.0); // #ffffff
+}
+
+Color SignalizeDock::_get_node_type_color(const String &p_class_name) {
+	// Color mapping based on common node types
+	// Pastel colors - softer, lighter, less saturated for better readability
+	// 2D nodes - Pastel blues
+	if (p_class_name == "Node2D" || p_class_name.contains("2D")) {
+		return Color(0.75, 0.85, 0.95, 1.0); // Pastel sky blue
+	}
+	if (p_class_name == "Sprite2D" || p_class_name == "AnimatedSprite2D") {
+		return Color(0.7, 0.8, 0.95, 1.0); // Pastel blue
+	}
+	if (p_class_name == "Area2D") {
+		return Color(0.85, 0.75, 0.95, 1.0); // Pastel periwinkle
+	}
+	if (p_class_name == "Camera2D") {
+		return Color(0.75, 0.9, 0.95, 1.0); // Pastel cyan
+	}
+
+	// 3D nodes - Pastel greens
+	if (p_class_name == "Node3D" || p_class_name.contains("3D")) {
+		return Color(0.75, 0.9, 0.8, 1.0); // Pastel mint green
+	}
+	if (p_class_name == "MeshInstance3D") {
+		return Color(0.7, 0.85, 0.75, 1.0); // Pastel medium green
+	}
+	if (p_class_name == "Area3D") {
+		return Color(0.85, 0.9, 0.7, 1.0); // Pastel lime green
+	}
+	if (p_class_name == "Camera3D") {
+		return Color(0.8, 0.9, 0.85, 1.0); // Pastel light green
+	}
+
+	// UI nodes - Pastel oranges/yellows
+	if (p_class_name == "Control" || p_class_name.contains("UI")) {
+		return Color(1.0, 0.85, 0.7, 1.0); // Pastel peach
+	}
+	if (p_class_name == "Label" || p_class_name == "RichTextLabel") {
+		return Color(1.0, 0.9, 0.75, 1.0); // Pastel cream
+	}
+	if (p_class_name == "Button" || p_class_name.contains("Button")) {
+		return Color(1.0, 0.8, 0.65, 1.0); // Pastel apricot
+	}
+	if (p_class_name == "Panel" || p_class_name == "Container") {
+		return Color(1.0, 0.9, 0.7, 1.0); // Pastel light peach
+	}
+
+	// Resource nodes - Pastel pinks
+	if (p_class_name == "Resource" || p_class_name == "Timer") {
+		return Color(1.0, 0.75, 0.85, 1.0); // Pastel rose
+	}
+
+	// Audio nodes - Pastel purples
+	if (p_class_name.contains("Audio") || p_class_name.contains("Sound")) {
+		return Color(0.85, 0.75, 0.95, 1.0); // Pastel lavender
+	}
+
+	// Collision/Physics nodes - Pastel reds
+	if (p_class_name.contains("Collision") || p_class_name.contains("Shape")) {
+		return Color(1.0, 0.75, 0.75, 1.0); // Pastel coral
+	}
+
+	// Light nodes - Pastel yellow
+	if (p_class_name.contains("Light")) {
+		return Color(1.0, 0.95, 0.8, 1.0); // Pastel light yellow
+	}
+
+	// Default - Pastel neutral
+	return Color(0.92, 0.92, 0.92, 1.0);
+}
+void SignalizeDock::_connect_all_node_signals() {
+	// First pass: collect all receiver methods for each node
+	// Now tracks the actual target object that owns the method
+	HashMap<ObjectID, List<ReceiverMethodInfo>> receiver_methods_list;
+
+	// Get the scene
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		return;
+	}
+
+	Node *scene_root = editor_node->get_edited_scene();
+	if (!scene_root) {
+		return;
+	}
+
+	// Collect all nodes in the scene
+	List<Node *> all_nodes;
+	_collect_all_nodes(scene_root, all_nodes);
+
+	// First, find all signals and add their receiver methods to the appropriate graph nodes
+	for (Node *emitter_node : all_nodes) {
+		if (!emitter_node) {
+			continue;
+		}
+
+		// Skip if this emitter is not in our graph
+		ObjectID emitter_id = emitter_node->get_instance_id();
+		if (!node_graph_nodes.has(emitter_id)) {
+			continue;
+		}
+
+		List<MethodInfo> signals;
+		emitter_node->get_signal_list(&signals);
+
+		for (const MethodInfo &sig : signals) {
+			List<Object::Connection> conns;
+			emitter_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target_obj = conn.callable.get_object();
+				if (!target_obj) {
+					continue;
+				}
+
+				ObjectID target_id = target_obj->get_instance_id();
+
+				// Skip if the target is not in our graph
+				if (!node_graph_nodes.has(target_id)) {
+					continue;
+				}
+
+				String method_name = conn.callable.get_method();
+				if (method_name.is_empty()) {
+					continue;
+				}
+
+				// Add this method to the target's receiver list
+				if (!receiver_methods_list.has(target_id)) {
+					receiver_methods_list[target_id] = List<ReceiverMethodInfo>();
+				}
+
+				// Check if already added
+				bool already_added = false;
+				for (const ReceiverMethodInfo &info : receiver_methods_list[target_id]) {
+					if (info.method_name == method_name) {
+						already_added = true;
+						break;
+					}
+				}
+
+				if (!already_added) {
+					ReceiverMethodInfo info;
+					info.target_id = target_id;  // The object that owns the method
+					info.method_name = method_name;
+					receiver_methods_list[target_id].push_back(info);
+				}
+			}
+		}
+	}
+
+	// Second pass: collect all emitter signals for each node
+	HashMap<ObjectID, List<String>> emitter_signals_list;
+
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		Object *obj = ObjectDB::get_instance(kv.key);
+		if (!obj) {
+			continue;
+		}
+
+		Node *node = Object::cast_to<Node>(obj);
+		if (node) {
+			ObjectID node_id = node->get_instance_id();
+
+			List<MethodInfo> signals;
+			node->get_signal_list(&signals);
+
+			List<String> node_emitter_signals;
+			for (const MethodInfo &sig : signals) {
+				List<Object::Connection> conns;
+				node->get_signal_connection_list(StringName(sig.name), &conns);
+
+				// Only include this signal if it has at least one connection to a node in our graph
+				bool has_connection_in_graph = false;
+				for (const Object::Connection &conn : conns) {
+					Object *target_obj = conn.callable.get_object();
+					if (!target_obj) {
+						continue;
+					}
+					ObjectID target_id = target_obj->get_instance_id();
+					if (node_graph_nodes.has(target_id)) {
+						has_connection_in_graph = true;
+						break;
+					}
+				}
+
+				if (has_connection_in_graph) {
+					node_emitter_signals.push_back(sig.name);
+				}
+			}
+
+			emitter_signals_list[node_id] = node_emitter_signals;
+		}
+	}
+
+	// Third pass: add all labels BEFORE adding to GraphEdit
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		ObjectID node_id = kv.key;
+		GraphNode *gn = kv.value;
+
+		// Add receiver labels first
+		if (receiver_methods_list.has(node_id)) {
+			for (const ReceiverMethodInfo &info : receiver_methods_list[node_id]) {
+				// Create a horizontal container for label + button
+				HBoxContainer *hbox = memnew(HBoxContainer);
+				gn->add_child(hbox);
+
+				String function_text = vformat("- %s", info.method_name);
+				Label *function_label = memnew(Label(function_text));
+				function_label->set_h_size_flags(SIZE_EXPAND_FILL);
+				function_label->set_modulate(Color(1, 1, 1, 1)); // Pure white to counteract node tint
+				hbox->add_child(function_label);
+
+				Button *open_button = memnew(Button);
+				open_button->set_text("Open");
+				// Pass the target object ID (which owns the script) and method name
+				open_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_open_function_button_pressed).bind(info.target_id, info.method_name));
+				hbox->add_child(open_button);
+			}
+		}
+
+		// Then add emitter labels
+		if (emitter_signals_list.has(node_id)) {
+			for (const String &sig_name : emitter_signals_list[node_id]) {
+				String signal_text = vformat("- %s", sig_name);
+				Label *signal_label = memnew(Label(signal_text));
+				signal_label->set_modulate(Color(1, 1, 1, 1)); // Pure white to counteract node tint
+				gn->add_child(signal_label);
+			}
+		}
+	}
+
+	// Fourth pass: add all GraphNodes to GraphEdit BEFORE configuring slots
+	// This is required because set_slot() needs the node to be in the graph first
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		GraphNode *gn = kv.value;
+		if (gn->get_parent() == nullptr) {
+			graph_edit->add_child(gn);
+		}
+	}
+
+	// Fifth pass: NOW configure all slots after nodes are in the GraphEdit
+	// NOTE: In Godot 4.x, child indices start at 0 (first child we added)
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		ObjectID node_id = kv.key;
+		GraphNode *gn = kv.value;
+
+		int current_child_idx = 0;
+
+		// Configure input slots for receiver labels first
+		if (receiver_methods_list.has(node_id)) {
+			int slot_idx = 0;
+			for (const ReceiverMethodInfo &info : receiver_methods_list[node_id]) {
+				gn->set_slot(current_child_idx, true, 0, Color(1.0, 0.8, 0.6), false, 0, Color());
+
+				if (!function_to_slot.has(node_id)) {
+					function_to_slot[node_id] = HashMap<String, int>();
+				}
+				function_to_slot[node_id][info.method_name] = slot_idx;
+				slot_idx++;
+				current_child_idx++;
+			}
+		}
+
+		// Configure output slots for emitter labels (after receiver labels)
+		if (emitter_signals_list.has(node_id)) {
+			int slot_idx = 0;
+			for (const String &sig_name : emitter_signals_list[node_id]) {
+				gn->set_slot(current_child_idx, false, 0, Color(), true, 0, custom_connection_color);
+
+				if (!signal_to_slot.has(node_id)) {
+					signal_to_slot[node_id] = HashMap<String, int>();
+				}
+				signal_to_slot[node_id][sig_name] = slot_idx;
+				slot_idx++;
+				current_child_idx++;
+			}
+		}
+	}
+
+	// Sixth pass: collect all connections for pending_connections list
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		Object *obj = ObjectDB::get_instance(kv.key);
+		if (!obj) {
+			continue;
+		}
+
+		Node *node = Object::cast_to<Node>(obj);
+		if (node) {
+			ObjectID node_id = node->get_instance_id();
+			List<MethodInfo> signals;
+			node->get_signal_list(&signals);
+
+			for (const MethodInfo &sig : signals) {
+				List<Object::Connection> conns;
+				node->get_signal_connection_list(StringName(sig.name), &conns);
+
+				for (const Object::Connection &conn : conns) {
+					Object *target_obj = conn.callable.get_object();
+					if (!target_obj) {
+						continue;
+					}
+
+					String method_name = conn.callable.get_method();
+					if (method_name.is_empty()) {
+						continue;
+					}
+
+					ObjectID target_id = target_obj->get_instance_id();
+
+					if (!signal_to_slot.has(node_id) || !signal_to_slot[node_id].has(sig.name)) {
+						continue;
+					}
+					if (!function_to_slot.has(target_id) || !function_to_slot[target_id].has(method_name)) {
+						continue;
+					}
+
+					int from_slot = signal_to_slot[node_id][sig.name];
+					int to_slot = function_to_slot[target_id][method_name];
+
+					ConnectionSlot conn_slot;
+					conn_slot.emitter_id = node_id;
+					conn_slot.signal_name = sig.name;
+					conn_slot.receiver_id = target_id;
+					conn_slot.method_name = method_name;
+					conn_slot.from_slot = from_slot;
+					conn_slot.to_slot = to_slot;
+					pending_connections.push_back(conn_slot);
+				}
+			}
+		}
+	}
+
+	// Finally create the visual connections
+	call_deferred("_create_visual_connections");
+
+	// NOTE: Runtime signal tracking disabled for performance
+	// This would connect to all signals on all nodes to track emissions
+	// _connect_runtime_signal_tracking(); // DISABLED: Only enable when live tracking is needed
+}
+
+void SignalizeDock::_cleanup_runtime_signal_tracking() {
+	// Disconnect all runtime tracking connections
+	if (runtime_signal_connections.is_empty()) {
+		return; // Nothing to clean up
+	}
+
+
+	// Get the scene root
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		return;
+	}
+
+	Node *scene_root = editor_node->get_edited_scene();
+	if (!scene_root) {
+		// Scene is gone, just clear the tracking data
+		runtime_signal_connections.clear();
+		return;
+	}
+
+
+	// Disconnect all tracked signals
+	for (const KeyValue<ObjectID, HashMap<String, int>> &node_entry : runtime_signal_connections) {
+		Object *obj = ObjectDB::get_instance(node_entry.key);
+		if (!obj) {
+			continue; // Object no longer exists
+		}
+
+		Node *node = Object::cast_to<Node>(obj);
+		if (!node) {
+			continue;
+		}
+
+		for (const KeyValue<String, int> &sig_entry : node_entry.value) {
+			const String &sig_name = sig_entry.key;
+
+			// Create the callable we used to connect
+			Callable callable = callable_mp(this, &SignalizeDock::_on_signal_fired).bind(node, sig_name);
+
+			// Check if we're connected
+			if (node->is_connected(sig_name, callable)) {
+				node->disconnect(sig_name, callable);
+			}
+		}
+	}
+
+	// Clear the tracking data
+	runtime_signal_connections.clear();
+
+	}
+
+void SignalizeDock::_connect_runtime_signal_tracking() {
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		return;
+	}
+
+	Node *scene_root = nullptr;
+	bool is_runtime = false;
+
+	// Get the edited scene as a reference
+	Node *edited_scene = editor_node->get_edited_scene();
+	String edited_scene_name = edited_scene ? String(edited_scene->get_name()) : String();
+	String edited_scene_class = edited_scene ? edited_scene->get_class() : String();
+
+	// First, try to get the runtime scene (running game)
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+	if (scene_tree) {
+		Node *root = scene_tree->get_root();
+		if (root) {
+			// Helper function to recursively search for a matching scene
+			std::function<Node*(Node*, int)> search_recursive = [&](Node *node, int depth) -> Node* {
+				if (!node || depth > 10) { // Limit recursion depth
+					return nullptr;
+				}
+
+				// Skip EditorNode
+				EditorNode *editor_check = Object::cast_to<EditorNode>(node);
+				if (editor_check) {
+					return nullptr;
+				}
+
+				String node_name = String(node->get_name());
+				String node_class = node->get_class();
+
+				// Skip UI dialogs and popups
+				if (node_class.contains("Dialog") || node_class.contains("Popup") ||
+					node_class.contains("Window") || node_class.contains("Menu") ||
+					node_class.contains("Panel") || node_class.contains("Button") ||
+					node_name.begins_with("_editor_") || node_name.contains("__editor")) {
+					return nullptr;
+				}
+
+				// Check if this matches the edited scene class and has signal connections
+				if (node_class == edited_scene_class && _node_has_connections(node)) {
+					return node;
+				}
+
+				// Recursively search children
+				for (int i = 0; i < node->get_child_count(); i++) {
+					Node *result = search_recursive(node->get_child(i), depth + 1);
+					if (result) {
+						return result;
+					}
+				}
+
+				return nullptr;
+			};
+
+			// Search recursively through the root's children
+			for (int i = 0; i < root->get_child_count(); i++) {
+				Node *found = search_recursive(root->get_child(i), 0);
+				if (found) {
+					scene_root = found;
+					is_runtime = true;
+					break;
+				}
+			}
+		}
+	}
+
+	// If no runtime scene found, use the edited scene
+	if (!scene_root) {
+		scene_root = edited_scene;
+		is_runtime = false;
+		if (!scene_root) {
+			return;
+		}
+	}
+
+	// Update the tracking flag
+	tracking_runtime_scene = is_runtime;
+
+	// Collect all nodes in the scene
+	List<Node *> all_nodes;
+	_collect_all_nodes(scene_root, all_nodes);
+
+
+	// For each node, connect to its signals
+	for (Node *node : all_nodes) {
+		if (!node) {
+			continue;
+		}
+
+		ObjectID node_id = node->get_instance_id();
+
+		// Get all signals from this node
+		List<MethodInfo> signals;
+		node->get_signal_list(&signals);
+
+		for (const MethodInfo &sig : signals) {
+			// Check if this signal has any connections (editor or runtime)
+			List<Object::Connection> conns;
+			node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			if (conns.is_empty()) {
+				continue; // Skip signals without connections
+			}
+
+			// Connect to this signal for tracking
+			// Use bind to pass the node and signal name to our callback
+			Callable callable = callable_mp(this, &SignalizeDock::_on_signal_fired).bind(node, sig.name);
+
+			Error err = node->connect(sig.name, callable);
+			if (err == OK) {
+				// Store the connection info so we can track it
+				if (!runtime_signal_connections.has(node_id)) {
+					runtime_signal_connections[node_id] = HashMap<String, int>();
+				}
+				runtime_signal_connections[node_id][sig.name] = 1;
+
+							} else {
+				ERR_PRINT(vformat("[Signalize] Failed to connect to signal: %s.%s (error: %d)",
+					node->get_name(), sig.name, (int)err));
+			}
+		}
+	}
+
+}
+
+void SignalizeDock::_add_receiver_slots(Node *p_node) {
+	if (!p_node) {
+		return;
+	}
+
+	GraphNode **gn_ptr = node_graph_nodes.getptr(p_node->get_instance_id());
+	if (!gn_ptr || !*gn_ptr) {
+		return;
+	}
+
+	GraphNode *gn = *gn_ptr;
+	ObjectID node_id = p_node->get_instance_id();
+
+	// Find all signals where this node is a receiver
+	// We need to scan all nodes in the scene to find connections to this node
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		return;
+	}
+
+	Node *scene_root = editor_node->get_edited_scene();
+	if (!scene_root) {
+		return;
+	}
+
+	List<Node *> all_nodes;
+	_collect_all_nodes(scene_root, all_nodes);
+
+	// Track which methods this node receives, to avoid duplicates
+	// Use a list to preserve order
+	List<String> receiver_methods;
+
+	for (Node *emitter_node : all_nodes) {
+		if (!emitter_node) {
+			continue;
+		}
+
+		List<MethodInfo> signals;
+		emitter_node->get_signal_list(&signals);
+
+		for (const MethodInfo &sig : signals) {
+			List<Object::Connection> conns;
+			emitter_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target_obj = conn.callable.get_object();
+				if (!target_obj) {
+					continue;
+				}
+
+				// Check if this connection is to our node
+				if (target_obj->get_instance_id() != node_id) {
+					continue;
+				}
+
+				String method_name = conn.callable.get_method();
+				if (method_name.is_empty()) {
+					continue;
+				}
+
+				// Skip if we already added this method
+				bool already_added = false;
+				for (const String &m : receiver_methods) {
+					if (m == method_name) {
+						already_added = true;
+						break;
+					}
+				}
+				if (already_added) {
+					continue;
+				}
+
+				receiver_methods.push_back(method_name);
+			}
+		}
+	}
+
+	// Now add the labels in order
+	int input_slot_idx = 0;
+	for (const String &method_name : receiver_methods) {
+		// Add function label with input slot
+		String function_text = vformat("- %s", method_name);
+		Label *function_label = memnew(Label(function_text));
+		function_label->set_modulate(Color(1, 1, 1, 1)); // Pure white to counteract node tint
+		gn->add_child(function_label);
+
+		int child_idx = gn->get_child_count() - 1;
+		// Use type 0 for all input ports (type is for validation, not indexing)
+		gn->set_slot(child_idx, true, 0, Color(1.0, 0.8, 0.6), false, 0, Color());
+
+		// Track the slot for this method
+		// The port index is determined by the order of set_slot calls with input enabled
+		if (!function_to_slot.has(node_id)) {
+			function_to_slot[node_id] = HashMap<String, int>();
+		}
+		function_to_slot[node_id][method_name] = input_slot_idx;
+		input_slot_idx++;
+	}
+}
+
+void SignalizeDock::_add_emitter_slots(Node *p_node) {
+	if (!p_node) {
+		return;
+	}
+
+	GraphNode **gn_ptr = node_graph_nodes.getptr(p_node->get_instance_id());
+	if (!gn_ptr || !*gn_ptr) {
+		return;
+	}
+
+	GraphNode *gn = *gn_ptr;
+	ObjectID node_id = p_node->get_instance_id();
+
+	List<MethodInfo> signals;
+	p_node->get_signal_list(&signals);
+
+	// Collect all unique signals from this emitter
+	HashSet<String> emitter_signals;
+	for (const MethodInfo &sig : signals) {
+		List<Object::Connection> conns;
+		p_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+		if (conns.size() > 0) {
+			emitter_signals.insert(sig.name);
+		}
+	}
+
+	// Add signal labels with output slots sequentially
+	int output_slot_idx = 0;
+	for (const String &sig_name : emitter_signals) {
+		String signal_text = vformat("- %s", sig_name);
+		Label *signal_label = memnew(Label(signal_text));
+		signal_label->set_modulate(Color(1, 1, 1, 1)); // Pure white to counteract node tint
+		gn->add_child(signal_label);
+
+		int child_idx = gn->get_child_count() - 1;
+		// Use type 0 for all output ports (type is for validation, not indexing)
+		gn->set_slot(child_idx, false, 0, Color(), true, 0, custom_connection_color);
+
+		// Track the slot for this signal
+		// The port index is determined by the order of set_slot calls with output enabled
+		if (!signal_to_slot.has(node_id)) {
+			signal_to_slot[node_id] = HashMap<String, int>();
+		}
+		signal_to_slot[node_id][sig_name] = output_slot_idx;
+		output_slot_idx++;
+	}
+
+	// Now collect all connections from this emitter to build pending_connections
+	for (const MethodInfo &sig : signals) {
+		List<Object::Connection> conns;
+		p_node->get_signal_connection_list(StringName(sig.name), &conns);
+
+		for (const Object::Connection &conn : conns) {
+			Object *target_obj = conn.callable.get_object();
+			if (!target_obj) {
+				continue;
+			}
+
+			String method_name = conn.callable.get_method();
+			if (method_name.is_empty()) {
+				continue;
+			}
+
+			ObjectID target_id = target_obj->get_instance_id();
+
+			// Check if both nodes have the required slots
+			if (!signal_to_slot.has(node_id) || !signal_to_slot[node_id].has(sig.name)) {
+				continue;
+			}
+			if (!function_to_slot.has(target_id) || !function_to_slot[target_id].has(method_name)) {
+				continue;
+			}
+
+			// Get slot indices
+			int from_slot = signal_to_slot[node_id][sig.name];
+			int to_slot = function_to_slot[target_id][method_name];
+
+			// Add to pending connections
+			ConnectionSlot conn_slot;
+			conn_slot.emitter_id = node_id;
+			conn_slot.signal_name = sig.name;
+			conn_slot.receiver_id = target_id;
+			conn_slot.method_name = method_name;
+			conn_slot.from_slot = from_slot;
+			conn_slot.to_slot = to_slot;
+			pending_connections.push_back(conn_slot);
+		}
+	}
+}
+
+void SignalizeDock::_create_visual_connections() {
+	// After all labels and slots are configured, create the visual connections
+	for (const ConnectionSlot &conn : pending_connections) {
+		String *emitter_name_ptr = node_graph_names.getptr(conn.emitter_id);
+		String *receiver_name_ptr = node_graph_names.getptr(conn.receiver_id);
+
+		if (emitter_name_ptr && receiver_name_ptr) {
+			graph_edit->connect_node(*emitter_name_ptr, conn.from_slot, *receiver_name_ptr, conn.to_slot);
+
+			// Set default dim state (0.05 = 5% brightness) so the glow (1.0) is very noticeable
+			graph_edit->set_connection_activity(*emitter_name_ptr, conn.from_slot, *receiver_name_ptr, conn.to_slot, 0.05);
+		}
+	}
+
+}
+
+// Simplified callback for runtime signal tracking
+void SignalizeDock::_on_signal_fired(Node *p_emitter, const String &p_signal) {
+	if (!p_emitter) {
+		return;
+	}
+
+	// Basic tracking verification - just print to console when a signal fires
+	
+	// Look up all connections for this signal and log them
+	List<Object::Connection> conns;
+	p_emitter->get_signal_connection_list(StringName(p_signal), &conns);
+
+	for (const Object::Connection &conn : conns) {
+		Object *target_obj = conn.callable.get_object();
+		if (!target_obj) {
+			continue;
+		}
+
+		String method_name = conn.callable.get_method();
+		if (method_name.is_empty()) {
+			continue;
+		}
+
+		// Log each connection that would be triggered
+		
+		// Also call the detailed callback for counting
+		_on_signal_emitted(p_emitter, p_signal, target_obj, method_name);
+	}
+}
+
+void SignalizeDock::_on_signal_emitted(Node *p_emitter, const String &p_signal, Object *p_target, const String &p_method) {
+	if (!p_emitter || !p_target) {
+		return;
+	}
+
+// Basic tracking verification - just print to console
+
+	// Build key for this specific connection
+	String key = vformat("%s|%s|%s|%s",
+						String::num_uint64((uint64_t)p_emitter->get_instance_id()),
+						p_signal,
+						String::num_uint64((uint64_t)p_target->get_instance_id()),
+						p_method);
+
+	// Update count if this connection exists
+	if (connections.has(key)) {
+		connections[key]++;
+	} else {
+		connections[key] = 1; // Initialize counter if this is the first time we see it
+	}
+}
+
+void SignalizeDock::_on_runtime_signal_emitted(ObjectID p_emitter_id, const String &p_node_name, const String &p_node_class, const String &p_signal_name, int p_count, const Array &p_connections) {
+	// LIVE MODE: Highlight connections when signals fire during gameplay
+	// Only process signals for nodes that are currently being inspected
+	if (!is_inspecting || p_emitter_id != inspected_node_id) {
+				return;
+	}
+
+	
+	// Update emission count
+	if (!node_emits.has(p_emitter_id)) {
+		node_emits[p_emitter_id] = HashMap<String, int>();
+	}
+	node_emits[p_emitter_id][p_signal_name] = node_emits[p_emitter_id].has(p_signal_name) ? node_emits[p_emitter_id][p_signal_name] + p_count : p_count;
+	_update_node_emits_label(p_emitter_id);
+
+	// Highlight each connection for this signal
+	for (int i = 0; i < p_connections.size(); i++) {
+		Array conn_data = p_connections[i];
+		if (conn_data.size() < 4) continue;
+
+		ObjectID target_id = conn_data[0];
+		String target_method = conn_data[3];
+
+		// Build connection key
+		String connection_key = vformat("%s|%s|%s|%s",
+			String::num_uint64(p_emitter_id),
+			p_signal_name,
+			String::num_uint64(target_id),
+			target_method);
+
+		// Find the matching ConnectionSlot in pending_connections
+		for (const ConnectionSlot &slot : pending_connections) {
+			if (slot.emitter_id == p_emitter_id &&
+				slot.signal_name == p_signal_name &&
+				slot.receiver_id == target_id &&
+				slot.method_name == target_method) {
+
+				// Get the graph node names
+				String *from_node_name = node_graph_names.getptr(p_emitter_id);
+				String *to_node_name = node_graph_names.getptr(target_id);
+
+				if (from_node_name && to_node_name) {
+					// Highlight the connection by setting activity to 1.0 (full brightness)
+					graph_edit->set_connection_activity(*from_node_name, slot.from_slot, *to_node_name, slot.to_slot, 1.0);
+
+
+					// Set up timer to fade back to inactive
+					// Cancel existing timer if there is one
+					if (connection_highlight_timers.has(connection_key)) {
+						Timer *old_timer = connection_highlight_timers[connection_key];
+						if (old_timer && old_timer->is_inside_tree()) {
+							old_timer->queue_free();
+						}
+					}
+
+					// Create new timer
+					Timer *fade_timer = memnew(Timer);
+					fade_timer->set_wait_time(connection_pulse_duration); // Use the configurable pulse duration
+					fade_timer->set_one_shot(true);
+					add_child(fade_timer);
+
+					// Connect timeout to fade function
+					fade_timer->connect("timeout", callable_mp(this, &SignalizeDock::_fade_connection_highlight).bind(connection_key));
+
+					connection_highlight_timers[connection_key] = fade_timer;
+					fade_timer->start();
+				}
+				break;
+			}
+		}
+	}
+}
+
+void SignalizeDock::_fade_connection_highlight(const String &p_connection_key) {
+	// Parse the connection key
+	PackedStringArray parts = p_connection_key.split("|");
+	if (parts.size() != 4) {
+		return;
+	}
+
+	ObjectID emitter_id = ObjectID(uint64_t(parts[0].to_int()));
+	String signal_name = parts[1];
+	ObjectID receiver_id = ObjectID(uint64_t(parts[2].to_int()));
+	String method_name = parts[3];
+
+	// Find the matching ConnectionSlot
+	for (const ConnectionSlot &slot : pending_connections) {
+		if (slot.emitter_id == emitter_id &&
+			slot.signal_name == signal_name &&
+			slot.receiver_id == receiver_id &&
+			slot.method_name == method_name) {
+
+			// Get the graph node names
+			String *from_node_name = node_graph_names.getptr(emitter_id);
+			String *to_node_name = node_graph_names.getptr(receiver_id);
+
+			if (from_node_name && to_node_name) {
+				// Reset to dim state (0.05 = 5% brightness)
+				graph_edit->set_connection_activity(*from_node_name, slot.from_slot, *to_node_name, slot.to_slot, 0.05);
+			}
+			break;
+		}
+	}
+
+	// Clean up timer
+	if (connection_highlight_timers.has(p_connection_key)) {
+		Timer *timer = connection_highlight_timers[p_connection_key];
+		connection_highlight_timers.erase(p_connection_key);
+		if (timer && timer->is_inside_tree()) {
+			timer->queue_free();
+		}
+	}
+}
+
+// Engine-level signal tracking implementation
+void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount) {
+	// Only track Node objects (skip other Objects like Resources, Refs, etc.)
+	Node *emitter_node = Object::cast_to<Node>(p_emitter);
+	if (!emitter_node) {
+		return; // Not a node, skip
+	}
+
+	// Get the signal viewer instance (if it exists and is tracking)
+	SignalizeDock *viewer = singleton_instance;
+	if (!viewer || !viewer->tracking_enabled) {
+		return; // Signal viewer not active or tracking disabled
+	}
+
+	// IMPORTANT: Only track signals from the node currently being inspected
+	// This prevents tracking all signals in the entire game, which causes lag
+	if (viewer->is_inspecting && viewer->inspected_node_id != ObjectID()) {
+		ObjectID emitter_id = emitter_node->get_instance_id();
+		// Only process if this is the inspected node OR if it's connected to the inspected node
+		if (emitter_id != viewer->inspected_node_id) {
+			// Check if this emitter has a connection to the inspected node
+			bool connects_to_inspected = false;
+			List<Object::Connection> conns;
+			emitter_node->get_signal_connection_list(p_signal, &conns);
+
+			for (const Object::Connection &conn : conns) {
+				Object *target = conn.callable.get_object();
+				if (target && target->get_instance_id() == viewer->inspected_node_id) {
+					connects_to_inspected = true;
+					break;
+				}
+			}
+
+			if (!connects_to_inspected) {
+				return; // Skip - not related to inspected node
+			}
+		}
+	} else {
+		// Not inspecting anything, don't track any signals
+		return;
+	}
+
+	// FILTER OUT ALL GUI/CONTROL CLASSES - Only track gameplay nodes
+	// Skip all Control-derived classes (GUI elements)
+	Control *as_control = Object::cast_to<Control>(emitter_node);
+	if (as_control) {
+		return; // Skip ALL Control nodes including VScrollBar, RichTextLabel, etc.
+	}
+
+	// Filter out internal engine noise
+	String node_name = emitter_node->get_name();
+	String node_class = emitter_node->get_class();
+	String signal_name = String(p_signal);
+
+	// Skip timer signals from gizmos/updates
+	if (signal_name == "timeout" && (
+		node_name.contains("Gizmo") || node_name.contains("Update") ||
+		(node_name.contains("Timer") && node_class.contains("Editor")))) {
+		return; // Skip editor gizmo/update timers
+	}
+
+	// Skip skeleton pose updates (fire every frame during animation)
+	if (signal_name == "pose_updated" || signal_name == "skeleton_updated") {
+		return; // Skip internal animation updates
+	}
+
+	// Skip gizmo/editor classes
+	if (node_class.contains("Editor") || node_class.contains("Gizmo")) {
+		return;
+	}
+
+	// Check if this signal has ANY connections
+	List<Object::Connection> conns;
+	p_emitter->get_signal_connection_list(p_signal, &conns);
+
+	if (conns.is_empty()) {
+		return; // No connections at all, skip this signal
+	}
+
+	// DEBUG: Log all Area3D signals
+	if (String(p_signal) == "body_entered" || String(p_signal) == "body_exited" ||
+	    String(p_signal) == "area_entered" || String(p_signal) == "area_exited") {
+
+		// Log all connection targets for debugging
+		for (const Object::Connection &conn : conns) {
+			Object *target_obj = conn.callable.get_object();
+			if (target_obj) {
+				String target_name;
+				Node *target_node = Object::cast_to<Node>(target_obj);
+				if (target_node) {
+					target_name = target_node->get_name();
+				} else {
+					target_name = "<not a node>";
+				}
+			}
+		}
+	}
+
+	ObjectID emitter_id = p_emitter->get_instance_id();
+
+	// FILTER STRATEGY:
+	// - In editor mode: Only track signals from nodes in our graph (node_graph_nodes)
+	// - In gameplay mode: Track ALL signals from game nodes, but skip editor UI nodes
+	if (viewer->tracking_runtime_scene) {
+		// GAMEPLAY MODE: Track all gameplay signals, filter out editor UI noise
+		// Check if ANY connection goes to an editor class - if so, skip this signal
+		bool has_editor_target = false;
+		for (const Object::Connection &conn : conns) {
+			Object *target_obj = conn.callable.get_object();
+			if (target_obj) {
+				String target_class = target_obj->get_class();
+				// If connected to an editor class, this is an editor signal
+				if (target_class.contains("Editor") || target_class.contains("SceneTree")) {
+					has_editor_target = true;
+					break;
+				}
+			}
+		}
+
+		if (has_editor_target) {
+			return; // Skip editor signals
+		}
+
+		// Also skip common editor UI classes from the emitter
+		String node_class = emitter_node->get_class();
+		if (node_class.contains("Editor") || node_class.contains("MenuBar") ||
+			node_class.contains("Button") || node_class.contains("LineEdit") ||
+			node_class.contains("Panel") || node_class.contains("Window") ||
+			node_class.contains("Popup") || node_class.contains("Label")) {
+			return; // Skip editor UI
+		}
+
+		// Track this gameplay signal!
+		String node_name = emitter_node->get_name();
+	} else {
+		// EDITOR MODE: Only track signals from nodes in our graph
+		if (!viewer->node_graph_nodes.has(emitter_id)) {
+			return; // Not a node we're tracking, skip
+		}
+	}
+
+	// Track this signal emission
+	// Build a unique key for this emission
+	String key = vformat("%s|%s", String::num_uint64((uint64_t)p_emitter->get_instance_id()), String(p_signal));
+
+	// Update count
+	if (viewer->connections.has(key)) {
+		viewer->connections[key]++;
+	} else {
+		viewer->connections[key] = 1;
+	}
+
+	// Print to console for now (Step 1)
+	if (!viewer->tracking_runtime_scene) {
+			}
+
+	// Look up all connections and log them too
+	for (const Object::Connection &conn : conns) {
+		Object *target_obj = conn.callable.get_object();
+		if (!target_obj) {
+			continue;
+		}
+
+		String method_name = conn.callable.get_method();
+		if (method_name.is_empty()) {
+			continue;
+		}
+
+			}
+}
+
+void SignalizeDock::_enable_signal_tracking() {
+	if (tracking_enabled) {
+		return; // Already enabled
+	}
+
+		Object::set_signal_emission_callback(_global_signal_emission_callback);
+	tracking_enabled = true;
+}
+
+void SignalizeDock::_disable_signal_tracking() {
+	if (!tracking_enabled) {
+		return; // Already disabled
+	}
+
+		Object::set_signal_emission_callback(nullptr);
+	tracking_enabled = false;
+}
+
+SignalizeDock::~SignalizeDock() {
+// Clean up - disable signal tracking when dock is destroyed
+	_disable_signal_tracking();
+
+	// Unregister message capture handlers
+	if (EngineDebugger::get_singleton()) {
+		EngineDebugger::unregister_message_capture("signal_viewer");
+		EngineDebugger::unregister_message_capture("scene");
+			}
+
+	// Clear singleton instance to prevent dangling pointer
+	singleton_instance = nullptr;
+}
+
+void SignalizeDock::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			// Update the MakeFloating icon when theme changes
+			if (make_floating_button) {
+				make_floating_button->set_button_icon(get_editor_theme_icon(SNAME("MakeFloating")));
+			}
+			// Update the ColorPicker button icon
+			if (connection_color_button) {
+				connection_color_button->set_button_icon(get_editor_theme_icon(SNAME("ColorPicker")));
+			}
+			// Update the Settings button icon
+			if (settings_button) {
+				settings_button->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
+			}
+		} break;
+	}
+}
+
+void SignalizeDock::_update_node_emits_label(ObjectID p_node_id) {
+	Label **label_ptr = node_emits_labels.getptr(p_node_id);
+	if (!label_ptr || !*label_ptr) {
+		return; // No label for this node
+	}
+
+	Label *label = *label_ptr;
+
+	// Build the emits string
+	HashMap<String, int> *emits_ptr = node_emits.getptr(p_node_id);
+	if (!emits_ptr || emits_ptr->is_empty()) {
+		label->set_text("Emits: (none)");
+		return;
+	}
+
+	HashMap<String, int> &emits = *emits_ptr;
+
+	// Collect signal names with their counts into a Vector for sorting
+	struct SignalCount {
+		String name;
+		int count;
+
+		// For sorting: higher count first, then alphabetical
+		bool operator<(const SignalCount &p_other) const {
+			if (count != p_other.count) {
+				return count > p_other.count; // Higher count first (reverse order)
+			}
+			return name < p_other.name; // Alphabetical for ties
+		}
+	};
+
+	Vector<SignalCount> signal_list;
+	signal_list.resize(emits.size());
+	int idx = 0;
+	for (const KeyValue<String, int> &kv : emits) {
+		signal_list.write[idx].name = kv.key;
+		signal_list.write[idx].count = kv.value;
+		idx++;
+	}
+
+	// Sort using the operator<
+	signal_list.sort();
+
+	// Build the string: "Emits: signal1 (5), signal2 (3)"
+	String text = "Emits: ";
+	int count = 0;
+	for (const SignalCount &sc : signal_list) {
+		if (count > 0) {
+			text += ", ";
+		}
+		text += vformat("%s (%d)", sc.name, sc.count);
+		count++;
+
+		// Limit to 5 signals to keep it readable
+		if (count >= 5) {
+			int remaining = signal_list.size() - 5;
+			if (remaining > 0) {
+				text += vformat(" +%d more", remaining);
+			}
+			break;
+		}
+	}
+
+	label->set_text(text);
+}
+
+void SignalizeDock::_update_node_receives_label(ObjectID p_node_id) {
+	Label **label_ptr = node_receives_labels.getptr(p_node_id);
+	if (!label_ptr || !*label_ptr) {
+		return; // No label for this node
+	}
+
+	Label *label = *label_ptr;
+
+	// Build the receives string
+	HashMap<String, int> *receives_ptr = node_receives.getptr(p_node_id);
+	if (!receives_ptr || receives_ptr->is_empty()) {
+		label->set_text("Receives: (none)");
+		return;
+	}
+
+	HashMap<String, int> &receives = *receives_ptr;
+
+	// Collect method names with their counts into a Vector for sorting
+	struct MethodCount {
+		String name;
+		int count;
+
+		// For sorting: higher count first, then alphabetical
+		bool operator<(const MethodCount &p_other) const {
+			if (count != p_other.count) {
+				return count > p_other.count; // Higher count first (reverse order)
+			}
+			return name < p_other.name; // Alphabetical for ties
+		}
+	};
+
+	Vector<MethodCount> method_list;
+	method_list.resize(receives.size());
+	int idx = 0;
+	for (const KeyValue<String, int> &kv : receives) {
+		method_list.write[idx].name = kv.key;
+		method_list.write[idx].count = kv.value;
+		idx++;
+	}
+
+	// Sort using the operator<
+	method_list.sort();
+
+	// Build the string: "Receives: method1 (5), method2 (3)"
+	String text = "Receives: ";
+	int count = 0;
+	for (const MethodCount &mc : method_list) {
+		if (count > 0) {
+			text += ", ";
+		}
+		text += vformat("%s (%d)", mc.name, mc.count);
+		count++;
+
+		// Limit to 5 methods to keep it readable
+		if (count >= 5) {
+			int remaining = method_list.size() - 5;
+			if (remaining > 0) {
+				text += vformat(" +%d more", remaining);
+			}
+			break;
+		}
+	}
+
+	label->set_text(text);
+}
+
+void SignalizeDock::_update_connection_labels() {
+	// Update all graph node connection labels with current counts
+}
+
+// Callbacks for play/stop button presses
+void SignalizeDock::_on_play_pressed() {
+		// Start timer to periodically check if game is running
+	if (game_start_check_timer) {
+				game_start_check_timer->start();
+			} else {
+		ERR_PRINT("[Signalize] ERROR: Timer is null!");
+	}
+	_on_play_mode_changed(true);
+}
+
+void SignalizeDock::_on_game_start_check_timer_timeout() {
+
+	// Check if game is actually running
+	EditorInterface *editor_interface = EditorInterface::get_singleton();
+	if (!editor_interface) {
+		return;
+	}
+
+	bool is_playing = editor_interface->is_playing_scene();
+	
+	if (!is_playing) {
+		return; // Game not running yet, wait for next check
+	}
+
+	// Game is running! Try to connect via EditorDebuggerNode
+
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (debugger_node) {
+		
+		// Try to get the current debugger session
+		ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+
+		if (debugger) {
+
+			// Check if session is active before sending
+			bool session_active = debugger->is_session_active();
+			
+			if (!session_active) {
+								return; // Keep timer running to retry
+			}
+
+			// Send the start_tracking message via ScriptEditorDebugger
+			// NOTE: Must use "scene:" prefix because SceneDebugger captures that prefix
+			Array args;
+			debugger->send_message("scene:signal_viewer:start_tracking", args);
+			
+			// Stop the timer - we've successfully sent the message
+			if (game_start_check_timer) {
+				game_start_check_timer->stop();
+			}
+		} else {
+						// Don't stop the timer - keep retrying
+			return;
+		}
+	} else {
+		ERR_PRINT("[Signalize] WARNING: No EditorDebuggerNode singleton");
+	}
+
+	// Set tracking flag
+	tracking_runtime_scene = true;
+	
+	// Stop the timer - we've detected the game is running
+	if (game_start_check_timer) {
+		game_start_check_timer->stop();
+	}
+}
+
+void SignalizeDock::_on_stop_pressed() {
+		// Stop the game start check timer
+	if (game_start_check_timer) {
+		game_start_check_timer->stop();
+	}
+	_on_play_mode_changed(false);
+}
+
+void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
+	
+	// Update title label to show (Remote) when game is running
+	if (title_label) {
+		if (p_is_playing) {
+			title_label->set_text("Signalize (Remote)");
+		} else {
+			title_label->set_text("Signalize");
+		}
+	}
+
+	// Enable/disable refresh button based on game state
+	if (refresh_button) {
+		if (p_is_playing) {
+			refresh_button->set_disabled(true);
+			refresh_button->set_tooltip_text("Disabled During Gameplay");
+		} else {
+			refresh_button->set_disabled(false);
+			refresh_button->set_tooltip_text("Rebuild the signal graph from the edited scene");
+		}
+	}
+
+	if (p_is_playing) {
+		// Game started - switch to Signal Lens style mode
+		// Clear the editor graph and wait for manual node inspection
+		_clear_inspection();
+
+		// Clear the known ObjectIDs tracker
+		known_remote_object_ids.clear();
+
+		
+		// Capture the initial remote scene root ID and connect to signals
+		EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+		if (debugger_node) {
+			ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+			if (debugger) {
+				// NOTE: remote_tree_updated signal fires frequently and causes lag
+				// Disabled for on-demand inspection - only connect when live tracking is needed
+				// debugger->connect("remote_tree_updated", callable_mp(this, &SignalizeDock::_on_remote_tree_updated));
+				// 
+				// Connect to remote_objects_requested signal to detect node selection in remote tree
+				debugger->connect("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree));
+				
+				// Get the current remote scene root
+				const SceneDebuggerTree *remote_tree = debugger->get_remote_tree();
+				if (remote_tree && remote_tree->nodes.size() > 0) {
+					// The first node in the tree is typically the root
+					const List<SceneDebuggerTree::RemoteNode>::Element *first_node = remote_tree->nodes.front();
+					if (first_node) {
+						remote_scene_root_id = first_node->get().id;
+						
+						// Track all ObjectIDs in the initial scene (for detecting new nodes in scene transitions)
+						for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree->nodes.front(); E; E = E->next()) {
+							known_remote_object_ids.insert(E->get().id);
+						}
+					}
+				}
+			}
+		}
+
+			} else {
+		// Game stopped - disconnect from debugger signals to prevent lag
+		EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+		if (debugger_node) {
+			ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+			if (debugger) {
+				// Disconnect signals to stop receiving updates
+				if (debugger->is_connected("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree))) {
+					debugger->disconnect("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree));
+									}
+				// remote_tree_updated is already disabled, but if we ever enable it we should disconnect it too
+			}
+		}
+
+		// Game stopped - rebuild the editor graph
+		_clear_inspection();
+		_build_graph();
+		remote_scene_root_id = ObjectID(); // Reset root ID
+		known_remote_object_ids.clear(); // Clear tracked ObjectIDs
+			}
+}
+
+void SignalizeDock::_on_remote_tree_updated() {
+
+	// In live mode, we only track new ObjectIDs to detect scene transitions
+	// We DON'T auto-regenerate the graph - user must manually click nodes
+
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (!debugger_node) {
+		return;
+	}
+
+	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+	if (!debugger) {
+		return;
+	}
+
+	const SceneDebuggerTree *remote_tree = debugger->get_remote_tree();
+	if (!remote_tree || remote_tree->nodes.size() == 0) {
+		return;
+	}
+
+	// Check for new ObjectIDs we haven't seen before (to detect scene transitions)
+	bool has_new_object_ids = false;
+
+	for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree->nodes.front(); E; E = E->next()) {
+		ObjectID obj_id = E->get().id;
+		if (!known_remote_object_ids.has(obj_id)) {
+			// Found a new ObjectID - scene transition in progress
+			has_new_object_ids = true;
+			// Add it to our known set
+			known_remote_object_ids.insert(obj_id);
+		}
+	}
+
+	if (has_new_object_ids) {
+		// Scene transition detected - update our known ObjectIDs but DON'T clear inspection
+		// The user's current inspection is still valid unless the inspected node is actually gone
+
+		// Only clear if the inspected node is no longer in the tree
+		if (is_inspecting && inspected_node_id != ObjectID()) {
+			bool inspected_node_still_exists = false;
+			for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree->nodes.front(); E; E = E->next()) {
+				if (E->get().id == inspected_node_id) {
+					inspected_node_still_exists = true;
+					break;
+				}
+			}
+			if (!inspected_node_still_exists) {
+				_clear_inspection();
+			}
+		}
+	} else {
+		// Just property updates, no new nodes - do nothing
+	}
+}
+
+void SignalizeDock::_on_remote_tree_check_timer_timeout() {
+	remote_tree_check_count++;
+	
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (!debugger_node) {
+				return;
+	}
+
+	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+	if (!debugger) {
+				return;
+	}
+
+	const SceneDebuggerTree *remote_tree = debugger->get_remote_tree();
+	if (!remote_tree) {
+		return;
+	}
+
+	
+	if (remote_tree->nodes.size() == 0) {
+		
+		// Stop after 10 checks (5 seconds) to avoid infinite loop
+		if (remote_tree_check_count >= 10) {
+			remote_tree_check_timer->stop();
+		}
+		return;
+	}
+
+	// Tree has nodes! Investigate
+
+	int count = 0;
+	for (const SceneDebuggerTree::RemoteNode &remote_node : remote_tree->nodes) {
+		if (count >= 5) break; // Only check first 5
+
+
+		// CRITICAL TEST: Can we get this object via ObjectDB?
+		Object *obj = ObjectDB::get_instance(remote_node.id);
+		if (obj) {
+			Node *node = Object::cast_to<Node>(obj);
+			if (node) {
+
+				// Can we get its signals?
+				List<MethodInfo> signals;
+				node->get_signal_list(&signals);
+
+				// Can we connect to one?
+				if (!signals.is_empty()) {
+					const MethodInfo &first_signal = signals.front()->get();
+
+					// Try connecting - will this work?!
+					obj->connect(first_signal.name, Callable(this, "_on_test_signal"));
+				}
+			}
+		} else {
+		}
+
+		count++;
+	}
+
+	
+	// Stop checking - we got our answer
+	remote_tree_check_timer->stop();
+}
+
+// Per-node inspection: Button handler to inspect currently selected node
+void SignalizeDock::_on_inspect_selected_button_pressed() {
+	// Check if game is actually running by checking if there's an active debugger session
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	ScriptEditorDebugger *debugger = nullptr;
+
+	// Only proceed with remote inspection if debugger exists AND has an active session
+	if (debugger_node) {
+		debugger = debugger_node->get_current_debugger();
+	}
+
+	if (debugger && debugger->is_session_active()) {
+		// Game IS running - use remote tree inspection
+		_inspect_selected_remote_node(debugger);
+		return;
+	}
+
+	// Game is NOT running - inspect from editor scene tree
+	_inspect_selected_editor_node();
+}
+
+void SignalizeDock::_inspect_selected_editor_node() {
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		ERR_PRINT("[Signalize] No EditorNode available");
+		return;
+	}
+
+	EditorSelection *editor_selection = editor_node->get_editor_selection();
+	if (!editor_selection) {
+		return;
+	}
+
+	// Get the selected node(s)
+	const List<Node *> &selected_nodes = editor_selection->get_top_selected_node_list();
+	if (selected_nodes.is_empty()) {
+				return;
+	}
+
+	// For now, just inspect the first selected node
+	Node *selected_node = selected_nodes.front()->get();
+	if (!selected_node) {
+				return;
+	}
+
+	
+	// Build graph for just this node
+	_build_graph_for_single_node(selected_node);
+}
+
+void SignalizeDock::_inspect_selected_remote_node(ScriptEditorDebugger *debugger) {
+
+	// Get the actual Tree widget (not the data structure)
+	const Tree *remote_tree_widget = debugger->get_editor_remote_tree();
+	if (!remote_tree_widget) {
+				return;
+	}
+
+	// Get the selected item from the tree
+	TreeItem *selected = const_cast<Tree *>(remote_tree_widget)->get_selected();
+	if (!selected) {
+				return;
+	}
+
+	// Debug: Print what we got
+	
+	// Get the metadata from the selected item
+	// EditorDebuggerTree stores ObjectID in column 0 metadata
+	Variant metadata = selected->get_metadata(0);
+	
+	if (metadata.get_type() != Variant::INT) {
+		
+		// Fallback: Try to match by name from SceneDebuggerTree
+		const SceneDebuggerTree *remote_tree_data = debugger->get_remote_tree();
+		if (remote_tree_data && !remote_tree_data->nodes.is_empty()) {
+			String selected_name = selected->get_text(0);
+			
+			// Search through all nodes for a matching name
+			for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree_data->nodes.front(); E; E = E->next()) {
+				const SceneDebuggerTree::RemoteNode &node = E->get();
+				if (node.name == selected_name) {
+					
+					// Build the path
+					String node_path_str = "/root/" + node.name;
+
+					_inspect_remote_node(node.id, node_path_str);
+					return;
+				}
+			}
+		}
+		return;
+	}
+
+	ObjectID node_id = ObjectID(uint64_t(int64_t(metadata)));
+	if (node_id.is_null()) {
+				return;
+	}
+
+	// Get the node name from the tree item
+	String node_name = selected->get_text(0);
+
+	// Build the path by walking up the tree hierarchy
+	String node_path_str;
+	TreeItem *current = selected;
+	while (current) {
+		String text = current->get_text(0);
+		if (!text.is_empty()) {
+			if (!node_path_str.is_empty()) {
+				node_path_str = text + "/" + node_path_str;
+			} else {
+				node_path_str = text;
+			}
+		}
+		current = current->get_parent();
+	}
+
+	// Prepend /root if needed
+	if (!node_path_str.begins_with("/root")) {
+		node_path_str = "/root/" + node_path_str;
+	}
+
+
+	// Request signal data for this node from the game process
+	_inspect_remote_node(node_id, node_path_str);
+}
+
+// Per-node inspection: Send request to game process for signal data
+void SignalizeDock::_inspect_remote_node(ObjectID p_node_id, const String &p_node_path) {
+	// Check if game is running
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (!debugger_node) {
+		return;
+	}
+
+	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+	if (!debugger) {
+				return;
+	}
+
+	// Send message to game process requesting signal data for this node
+	Array args;
+	args.append((int64_t)p_node_id);  // Node ID - pass as integer, not string!
+	args.append(p_node_path);  // Node path
+
+
+	// Send with "scene:" prefix to reach SceneDebugger handlers
+	// Pass args directly (not wrapped), as the handler expects: [node_id, node_path]
+	debugger->_put_msg("scene:signal_viewer_request_node_data", args);
+
+
+	// Update inspection state
+	inspected_node_id = p_node_id;
+	inspected_node_path = p_node_path;
+	is_inspecting = true;
+
+	// Enable global signal tracking ONLY for this node during gameplay
+	// This allows connections to light up when this node's signals fire
+	if (!tracking_enabled) {
+		_enable_signal_tracking();
+			}
+}
+
+// Per-node inspection: Handle signal data received from game process
+void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
+	// Data format: [node_id, node_name, node_class, [{signal_name, count, [[target_id, target_name, target_class, target_method], ...]}, ...]]
+	if (p_data.size() < 4) {
+				return;
+	}
+
+	
+	// Clear previous graph VISUALS but preserve inspection state
+	// We need to clear the graph nodes to rebuild them, but keep is_inspecting=true
+	List<GraphNode *> nodes_to_delete;
+	for (int i = 0; i < graph_edit->get_child_count(); i++) {
+		Node *child = graph_edit->get_child(i);
+		GraphNode *gn = Object::cast_to<GraphNode>(child);
+		if (gn) {
+			nodes_to_delete.push_back(gn);
+		}
+	}
+
+	for (GraphNode *gn : nodes_to_delete) {
+		if (gn->get_parent()) {
+			gn->get_parent()->remove_child(gn);
+		}
+		memdelete(gn);
+	}
+
+	// Clear all tracking data EXCEPT inspection state
+	node_graph_nodes.clear();
+	node_graph_names.clear();
+	node_colors.clear();
+	node_emits_labels.clear();
+	node_receives_labels.clear();
+	node_emits.clear();
+	node_receives.clear();
+	signal_to_slot.clear();
+	function_to_slot.clear();
+	next_emitter_slot_idx.clear();
+	next_receiver_slot_idx.clear();
+	num_input_ports.clear();
+	num_output_ports.clear();
+	pending_connections.clear();
+
+	// Parse data
+	ObjectID node_id = p_data[0];
+	String node_name = p_data[1];
+	String node_class = p_data[2];
+	Array signal_data = p_data[3];  // Array of signal info dictionaries
+
+	// Track signal emissions for this node
+	if (!node_emits.has(node_id)) {
+		node_emits[node_id] = HashMap<String, int>();
+	}
+
+	// First pass: Collect all receiver methods for each node (like local graph)
+	HashMap<ObjectID, List<ReceiverMethodInfo>> receiver_methods_list;
+
+	for (int i = 0; i < signal_data.size(); i++) {
+		Array sig_info = signal_data[i];
+		if (sig_info.size() < 3) continue;
+
+		String signal_name = sig_info[0];
+		int count = sig_info[1];
+		Array connections = sig_info[2];
+
+		// Track emission count
+		node_emits[node_id][signal_name] = count;
+
+		// Collect all target methods
+		for (int j = 0; j < connections.size(); j++) {
+			Array conn_data = connections[j];
+			if (conn_data.size() < 4) continue;
+
+			ObjectID target_id = conn_data[0];
+			String target_name = conn_data[1];
+			String target_class = conn_data[2];
+			String target_method = conn_data[3];
+
+			// Add to receiver methods list
+			if (!receiver_methods_list.has(target_id)) {
+				receiver_methods_list[target_id] = List<ReceiverMethodInfo>();
+			}
+
+			// Check if already added
+			bool already_added = false;
+			for (const ReceiverMethodInfo &info : receiver_methods_list[target_id]) {
+				if (info.method_name == target_method) {
+					already_added = true;
+					break;
+				}
+			}
+
+			if (!already_added) {
+				ReceiverMethodInfo info;
+				info.target_id = target_id;
+				info.method_name = target_method;
+				receiver_methods_list[target_id].push_back(info);
+			}
+		}
+	}
+
+	// Second pass: Collect all emitter signals for each node
+	HashMap<ObjectID, List<String>> emitter_signals_list;
+
+	// Main node emits signals
+	List<String> main_node_signals;
+	for (int i = 0; i < signal_data.size(); i++) {
+		Array sig_info = signal_data[i];
+		if (sig_info.size() < 3) continue;
+
+		String signal_name = sig_info[0];
+		Array connections = sig_info[2];
+
+		// Only add if there are connections
+		if (connections.size() > 0) {
+			main_node_signals.push_back(signal_name);
+		}
+	}
+	emitter_signals_list[node_id] = main_node_signals;
+
+	// Third pass: Create all graph nodes (but don't add to GraphEdit yet)
+	// Create main node
+	GraphNode *main_node = memnew(GraphNode);
+	String main_node_graph_name = vformat("GraphNode_%s", String::num_uint64((uint64_t)node_id));
+	main_node->set_title(vformat("%s (%s)", node_name, node_class));
+	main_node->set_position_offset(Vector2(100, 100));
+	main_node->set_name(main_node_graph_name);
+
+	// Use the same color as editor mode (actual editor icon color)
+	Color node_color = _get_editor_node_icon_color_by_class(node_class);
+	Ref<StyleBoxFlat> sb_colored = main_node->get_theme_stylebox(SNAME("titlebar"), SNAME("GraphNode"))->duplicate();
+	sb_colored->set_bg_color(node_color);
+	main_node->add_theme_style_override(SNAME("titlebar"), sb_colored);
+
+	Ref<StyleBoxFlat> sb_colored_selected = main_node->get_theme_stylebox(SNAME("titlebar_selected"), SNAME("GraphNode"))->duplicate();
+	sb_colored_selected->set_bg_color(node_color.lightened(0.2));
+	main_node->add_theme_style_override(SNAME("titlebar_selected"), sb_colored_selected);
+
+	HBoxContainer *titlebar = main_node->get_titlebar_hbox();
+	if (titlebar) {
+		for (int i = 0; i < titlebar->get_child_count(); i++) {
+			Label *title_label = Object::cast_to<Label>(titlebar->get_child(i));
+			if (title_label) {
+				title_label->add_theme_color_override("font_color", Color(0, 0, 0, 1));
+				break;
+			}
+		}
+	}
+
+	node_colors[node_id] = node_color;
+	node_graph_nodes[node_id] = main_node;
+	node_graph_names[node_id] = main_node_graph_name;
+
+	// Create target nodes
+	for (const KeyValue<ObjectID, List<ReceiverMethodInfo>> &KV : receiver_methods_list) {
+		ObjectID target_id = KV.key;
+
+		// Skip if this is the main node (it can have both emits and receives)
+		if (target_id == node_id) {
+			continue;
+		}
+
+		// Find target info from signal data
+		String target_name;
+		String target_class;
+		for (int i = 0; i < signal_data.size(); i++) {
+			Array sig_info = signal_data[i];
+			if (sig_info.size() < 3) continue;
+			Array connections = sig_info[2];
+			for (int j = 0; j < connections.size(); j++) {
+				Array conn_data = connections[j];
+				if (conn_data.size() < 4) continue;
+				if (ObjectID(uint64_t(int64_t(conn_data[0]))) == target_id) {
+					target_name = conn_data[1];
+					target_class = conn_data[2];
+					break;
+				}
+			}
+			if (!target_name.is_empty()) break;
+		}
+
+		GraphNode *target_gn = memnew(GraphNode);
+		String target_graph_name = vformat("GraphNode_%s", String::num_uint64((uint64_t)target_id));
+		target_gn->set_title(vformat("%s (%s)", target_name, target_class));
+		target_gn->set_name(target_graph_name);
+		target_gn->set_position_offset(Vector2(400, 100 + node_graph_nodes.size() * 150));
+
+		Color target_color = _get_editor_node_icon_color_by_class(target_class);
+		Ref<StyleBoxFlat> target_sb = target_gn->get_theme_stylebox(SNAME("titlebar"), SNAME("GraphNode"))->duplicate();
+		target_sb->set_bg_color(target_color);
+		target_gn->add_theme_style_override(SNAME("titlebar"), target_sb);
+
+		Ref<StyleBoxFlat> target_sb_selected = target_gn->get_theme_stylebox(SNAME("titlebar_selected"), SNAME("GraphNode"))->duplicate();
+		target_sb_selected->set_bg_color(target_color.lightened(0.2));
+		target_gn->add_theme_style_override(SNAME("titlebar_selected"), target_sb_selected);
+
+		HBoxContainer *target_titlebar = target_gn->get_titlebar_hbox();
+		if (target_titlebar) {
+			for (int i = 0; i < target_titlebar->get_child_count(); i++) {
+				Label *title_label = Object::cast_to<Label>(target_titlebar->get_child(i));
+				if (title_label) {
+					title_label->add_theme_color_override("font_color", Color(0, 0, 0, 1));
+					break;
+				}
+			}
+		}
+
+		node_colors[target_id] = target_color;
+		node_graph_nodes[target_id] = target_gn;
+		node_graph_names[target_id] = target_graph_name;
+	}
+
+	// Fourth pass: Add all labels and configure slots BEFORE adding to GraphEdit
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		ObjectID obj_id = kv.key;
+		GraphNode *gn = kv.value;
+
+		// Add receiver labels first (input slots on left)
+		if (receiver_methods_list.has(obj_id)) {
+			for (const ReceiverMethodInfo &info : receiver_methods_list[obj_id]) {
+				// Create hbox with label + button
+				HBoxContainer *hbox = memnew(HBoxContainer);
+				gn->add_child(hbox);
+
+				String function_text = vformat("- %s", info.method_name);
+				Label *function_label = memnew(Label(function_text));
+				function_label->set_h_size_flags(SIZE_EXPAND_FILL);
+				function_label->set_modulate(Color(1, 1, 1, 1));
+				hbox->add_child(function_label);
+
+				Button *open_button = memnew(Button);
+				open_button->set_text("Open");
+				open_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_open_function_button_pressed).bind(info.target_id, info.method_name));
+				hbox->add_child(open_button);
+			}
+		}
+
+		// Then add emitter labels (output slots on right)
+		if (emitter_signals_list.has(obj_id)) {
+			for (const String &sig_name : emitter_signals_list[obj_id]) {
+				String signal_text = vformat("- %s", sig_name);
+				Label *signal_label = memnew(Label(signal_text));
+				signal_label->set_modulate(Color(1, 1, 1, 1));
+				gn->add_child(signal_label);
+			}
+		}
+	}
+
+	// Fifth pass: Configure all slots using child indices
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		ObjectID obj_id = kv.key;
+		GraphNode *gn = kv.value;
+
+		int current_child_idx = 0;
+
+		// Configure input slots for receiver labels first
+		if (receiver_methods_list.has(obj_id)) {
+			int slot_idx = 0;
+			for (const ReceiverMethodInfo &info : receiver_methods_list[obj_id]) {
+				gn->set_slot(current_child_idx, true, 0, Color(1.0, 0.8, 0.6), false, 0, Color());
+
+				if (!function_to_slot.has(obj_id)) {
+					function_to_slot[obj_id] = HashMap<String, int>();
+				}
+				function_to_slot[obj_id][info.method_name] = slot_idx;
+				slot_idx++;
+				current_child_idx++;
+			}
+		}
+
+		// Configure output slots for emitter labels (after receiver labels)
+		if (emitter_signals_list.has(obj_id)) {
+			int slot_idx = 0;
+			for (const String &sig_name : emitter_signals_list[obj_id]) {
+				gn->set_slot(current_child_idx, false, 0, Color(), true, 0, custom_connection_color);
+
+				if (!signal_to_slot.has(obj_id)) {
+					signal_to_slot[obj_id] = HashMap<String, int>();
+				}
+				signal_to_slot[obj_id][sig_name] = slot_idx;
+				slot_idx++;
+				current_child_idx++;
+			}
+		}
+	}
+
+	// Sixth pass: NOW add all GraphNodes to GraphEdit after slots are configured
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		GraphNode *gn = kv.value;
+		if (gn->get_parent() == nullptr) {
+			graph_edit->add_child(gn);
+		}
+	}
+
+	// Seventh pass: Create pending connections
+	for (int i = 0; i < signal_data.size(); i++) {
+		Array sig_info = signal_data[i];
+		if (sig_info.size() < 3) continue;
+
+		String signal_name = sig_info[0];
+		Array connections = sig_info[2];
+
+		if (!signal_to_slot.has(node_id) || !signal_to_slot[node_id].has(signal_name)) {
+			continue;
+		}
+		int from_slot = signal_to_slot[node_id][signal_name];
+
+		for (int j = 0; j < connections.size(); j++) {
+			Array conn_data = connections[j];
+			if (conn_data.size() < 4) continue;
+
+			ObjectID target_id = conn_data[0];
+			String target_method = conn_data[3];
+
+			if (!function_to_slot.has(target_id) || !function_to_slot[target_id].has(target_method)) {
+				continue;
+			}
+			int to_slot = function_to_slot[target_id][target_method];
+
+			ConnectionSlot conn_slot;
+			conn_slot.emitter_id = node_id;
+			conn_slot.signal_name = signal_name;
+			conn_slot.receiver_id = target_id;
+			conn_slot.method_name = target_method;
+			conn_slot.from_slot = from_slot;
+			conn_slot.to_slot = to_slot;
+			pending_connections.push_back(conn_slot);
+
+		}
+	}
+
+	// Update labels
+	for (const KeyValue<ObjectID, GraphNode *> &kv : node_graph_nodes) {
+		ObjectID obj_id = kv.key;
+		if (node_emits.has(obj_id)) {
+			_update_node_emits_label(obj_id);
+		}
+		if (node_receives.has(obj_id)) {
+			_update_node_receives_label(obj_id);
+		}
+	}
+
+	// Create visual connections
+	call_deferred("_create_visual_connections");
+
+}
+
+// Per-node inspection: Clear current inspection
+void SignalizeDock::_clear_inspection() {
+
+	// Clear all graph nodes
+	List<GraphNode *> nodes_to_delete;
+	for (int i = 0; i < graph_edit->get_child_count(); i++) {
+		Node *child = graph_edit->get_child(i);
+		GraphNode *gn = Object::cast_to<GraphNode>(child);
+		if (gn) {
+			nodes_to_delete.push_back(gn);
+		}
+	}
+
+	for (GraphNode *gn : nodes_to_delete) {
+		if (gn->get_parent()) {
+			gn->get_parent()->remove_child(gn);
+		}
+		memdelete(gn);
+	}
+
+	// Clear tracking data
+	node_graph_nodes.clear();
+	node_graph_names.clear();
+	node_colors.clear();
+	node_emits_labels.clear();
+	node_receives_labels.clear();
+	node_emits.clear();
+	node_receives.clear();
+	signal_to_slot.clear();
+	function_to_slot.clear();
+	next_emitter_slot_idx.clear();
+	next_receiver_slot_idx.clear();
+	num_input_ports.clear();
+	num_output_ports.clear();
+	pending_connections.clear();
+
+	// Disable global signal tracking when inspection is cleared
+	// This stops tracking all signals when no node is being inspected
+	if (tracking_enabled) {
+		_disable_signal_tracking();
+			}
+
+	// Clear inspection state
+	inspected_node_id = ObjectID();
+	inspected_node_path = "";
+	is_inspecting = false;
+}
+
+// Called by inspector plugin when a node is inspected in the Remote tree
+void SignalizeDock::_on_node_inspected_in_remote_tree(ObjectID p_node_id, const String &p_node_path) {
+
+	// Don't auto-inspect if we're already manually inspecting a node
+	// This prevents automatic inspections (from clicking into the game) from overriding manual inspections
+	if (is_inspecting) {
+		return;
+	}
+
+	// Only auto-inspect if game is running
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (!debugger_node) {
+				return;
+	}
+
+	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+	if (!debugger) {
+				return;
+	}
+
+	// Auto-inspect this node
+	_inspect_remote_node(p_node_id, p_node_path);
+}
+
+// Called when a node is clicked in the remote tree
+void SignalizeDock::_on_remote_object_selected_in_tree(const Array &p_object_ids) {
+	
+	if (p_object_ids.is_empty()) {
+				return;
+	}
+
+	// Get the first selected object ID
+	ObjectID selected_id = ObjectID(uint64_t(int64_t(p_object_ids[0])));
+	
+	// Get the node from the ObjectDB
+	Object *obj = ObjectDB::get_instance(selected_id);
+	if (!obj) {
+				return;
+	}
+
+	Node *node = Object::cast_to<Node>(obj);
+	if (!node) {
+				return;
+	}
+
+	// Get the node path
+	NodePath node_path = node->get_path();
+	String node_path_str = node_path.operator String();
+	String node_name = node->get_name();
+
+
+	// Only inspect if game is running
+	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+	if (!debugger_node) {
+				return;
+	}
+
+	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+	if (!debugger) {
+				return;
+	}
+
+	// Inspect this node
+		_inspect_remote_node(selected_id, node_path_str);
+}
+
+// Message capture handler - receives signal emissions from game
+Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {
+	// Debug: Print all scene messages to understand the flow
+	if (p_msg.begins_with("inspect") || p_msg.contains("selected") || p_msg.contains("remote")) {
+			}
+
+	if (p_msg == "signal_viewer:signal_emitted") {
+		r_captured = true;
+
+		// Parse the signal emission data from the game
+		if (p_args.size() >= 5) {
+			// p_args[0] is ObjectID (uint64 as int/Variant)
+			ObjectID emitter_id = ObjectID(uint64_t(int64_t(p_args[0])));
+			String node_name = p_args[1];
+			String node_class = p_args[2];
+			String signal_name = p_args[3];
+			Array connections = p_args[4];
+
+			// Print to console (Step 1)
+			
+			// Log connections
+			for (int i = 0; i < connections.size(); i++) {
+				Array conn_data = connections[i];
+				if (conn_data.size() >= 3) {
+					String target_class = conn_data[1];
+					String method_name = conn_data[2];
+									}
+			}
+
+			// Update the graph visualization
+			SignalizeDock *viewer = singleton_instance;
+			if (viewer) {
+				viewer->_on_runtime_signal_emitted(emitter_id, node_name, node_class, signal_name, 1, connections);
+			}
+		}
+
+		return OK;
+	}
+
+	if (p_msg == "signal_viewer:node_signal_data") {
+		r_captured = true;
+
+		// Handle node signal data response from game
+		// Get the singleton instance and call the handler
+		SignalizeDock *viewer = singleton_instance;
+		if (viewer) {
+			viewer->_on_node_signal_data_received(p_args);
+		}
+
+		return OK;
+	}
+
+	// Capture inspect_objects to detect when nodes are clicked in remote tree
+	// (registered for "scene" prefix, so p_msg is "inspect_objects" not "scene:inspect_objects")
+	if (p_msg == "inspect_objects") {
+		
+		// Don't capture this message - let the normal debugger handle it
+		// But we can inspect what's being selected
+		if (p_args.size() > 0) {
+			Array object_ids = p_args[0];
+			if (!object_ids.is_empty()) {
+				ObjectID selected_id = ObjectID(uint64_t(int64_t(object_ids[0])));
+
+				
+				// Get the singleton and trigger inspection
+				SignalizeDock *viewer = singleton_instance;
+				if (viewer) {
+					// Check if game is running (live mode)
+					EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+					if (debugger_node) {
+						ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+						if (debugger) {
+							// Game is running - inspect this node
+							// Get node info
+							Object *obj = ObjectDB::get_instance(selected_id);
+							if (obj) {
+								Node *node = Object::cast_to<Node>(obj);
+								if (node) {
+									NodePath node_path = node->get_path();
+									String node_path_str = node_path.operator String();
+																		viewer->_inspect_remote_node(selected_id, node_path_str);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	r_captured = false;
+	return ERR_UNAVAILABLE;
+}

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -167,7 +167,11 @@ SignalizeDock::SignalizeDock() {
 	}
 
 	// Build initial graph from edited scene (only works when game is not running)
-	_build_graph();
+	// Only build if a scene is already open (might not be during editor initialization)
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (editor_node && EditorNode::get_editor_data().get_edited_scene_count() > 0) {
+		_build_graph();
+	}
 }
 
 void SignalizeDock::_on_test_signal() {

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -1,31 +1,63 @@
+/**************************************************************************/
+/*  signalize_dock.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2024-present Redot Engine contributors                   */
+/*                                          (see REDOT_AUTHORS.md)        */
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
 #include "signalize_dock.h"
 
-#include "editor/editor_node.h"
-#include "editor/editor_interface.h"
-#include "editor/settings/editor_settings.h"
-#include "editor/inspector/editor_inspector.h"
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/debugger/script_editor_debugger.h"
-#include "editor/run/editor_run_bar.h"
-#include "editor/script/script_editor_plugin.h"
-#include "scene/debugger/scene_debugger.h"
-#include "scene/gui/tree.h"
 #include "core/debugger/engine_debugger.h"
-#include "core/object/script_language.h"
-#include "core/object/script_instance.h"
-#include "core/variant/callable.h"
 #include "core/input/input_event.h"
 #include "core/object/class_db.h"
+#include "core/object/script_instance.h"
+#include "core/object/script_language.h"
+#include "core/templates/hash_set.h"
+#include "core/variant/callable.h"
+#include "editor/debugger/editor_debugger_node.h"
+#include "editor/debugger/script_editor_debugger.h"
+#include "editor/editor_interface.h"
+#include "editor/editor_node.h"
+#include "editor/gui/window_wrapper.h"
+#include "editor/inspector/editor_inspector.h"
+#include "editor/run/editor_run_bar.h"
+#include "editor/script/script_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
+#include "scene/debugger/scene_debugger.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/color_picker.h"
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
-#include "scene/gui/color_picker.h"
-#include "scene/gui/spin_box.h"
 #include "scene/gui/option_button.h"
-#include "scene/resources/style_box_flat.h"
-#include "scene/gui/box_container.h"
+#include "scene/gui/spin_box.h"
+#include "scene/gui/tree.h"
 #include "scene/main/timer.h"
-#include "editor/gui/window_wrapper.h"
-#include "core/templates/hash_set.h"
+#include "scene/resources/style_box_flat.h"
 
 // Static member initialization
 SignalizeDock *SignalizeDock::singleton_instance = nullptr;
@@ -273,7 +305,6 @@ void SignalizeDock::_on_connection_color_changed(const Color &p_color) {
 		editor_settings->save();
 	}
 
-	
 	// Note: We don't rebuild the graph here because:
 	// 1. Rebuilding triggers the color_changed signal again, creating an infinite loop
 	// 2. The new color will be applied automatically when the graph is next rebuilt for any reason
@@ -388,7 +419,7 @@ void SignalizeDock::_on_open_function_button_pressed(ObjectID p_node_id, const S
 	}
 
 	if (!success) {
-			}
+	}
 }
 
 void SignalizeDock::_build_graph() {
@@ -401,7 +432,7 @@ void SignalizeDock::_build_graph() {
 		}
 	}
 
-// Cleanup old runtime tracking connections before rebuilding
+	// Cleanup old runtime tracking connections before rebuilding
 	_cleanup_runtime_signal_tracking();
 
 	EditorNode *editor_node = EditorNode::get_singleton();
@@ -416,7 +447,6 @@ void SignalizeDock::_build_graph() {
 		return;
 	}
 
-	
 	// First pass: collect all nodes that participate in signal connections
 	// ONLY include nodes that BOTH emit signals AND have their targets also included
 	// This ensures all nodes in the graph will have visible connections
@@ -426,7 +456,7 @@ void SignalizeDock::_build_graph() {
 	_collect_all_nodes(scene_root, all_nodes);
 
 	// Build a set of all nodes in the scene for quick lookup
-	HashMap<ObjectID, Node*> node_lookup;
+	HashMap<ObjectID, Node *> node_lookup;
 	for (Node *node : all_nodes) {
 		node_lookup[node->get_instance_id()] = node;
 	}
@@ -525,14 +555,13 @@ void SignalizeDock::_build_graph() {
 		}
 	}
 
-
 	// Fourth pass: create the signal connections
 	_connect_all_node_signals();
 
 	// Log graph build result (level 1 - Quiet)
 	if (should_log(1)) {
 		print_line(vformat("[Signalize] Graph built: %d nodes, %d connections",
-			node_graph_nodes.size(), connections.size()));
+				node_graph_nodes.size(), connections.size()));
 	}
 
 	// Auto-arrange the graph nodes for better visualization
@@ -544,7 +573,7 @@ void SignalizeDock::_build_graph() {
 			kv.value->set_position_offset(saved_node_positions[kv.key]);
 		}
 	}
-	}
+}
 void SignalizeDock::_collect_all_nodes(Node *p_node, List<Node *> &r_list) {
 	if (!p_node) {
 		return;
@@ -566,7 +595,6 @@ void SignalizeDock::_build_graph_for_single_node(Node *p_node) {
 		return;
 	}
 
-	
 	// Clear previous graph
 	_clear_inspection();
 
@@ -737,7 +765,7 @@ void SignalizeDock::_build_graph_for_single_node(Node *p_node) {
 	// Log single-node graph build result (level 2 - Normal, inspector updates)
 	if (should_log(2)) {
 		print_line(vformat("[Signalize] Built graph for node %s: %d nodes, %d connections",
-			node_name, node_graph_nodes.size(), pending_connections.size()));
+				node_name, node_graph_nodes.size(), pending_connections.size()));
 	}
 }
 
@@ -1043,7 +1071,7 @@ void SignalizeDock::_connect_all_node_signals() {
 
 				if (!already_added) {
 					ReceiverMethodInfo info;
-					info.target_id = target_id;  // The object that owns the method
+					info.target_id = target_id; // The object that owns the method
 					info.method_name = method_name;
 					receiver_methods_list[target_id].push_back(info);
 				}
@@ -1247,7 +1275,6 @@ void SignalizeDock::_cleanup_runtime_signal_tracking() {
 		return; // Nothing to clean up
 	}
 
-
 	// Get the scene root
 	EditorNode *editor_node = EditorNode::get_singleton();
 	if (!editor_node) {
@@ -1260,7 +1287,6 @@ void SignalizeDock::_cleanup_runtime_signal_tracking() {
 		runtime_signal_connections.clear();
 		return;
 	}
-
 
 	// Disconnect all tracked signals
 	for (const KeyValue<ObjectID, HashMap<String, int>> &node_entry : runtime_signal_connections) {
@@ -1289,8 +1315,7 @@ void SignalizeDock::_cleanup_runtime_signal_tracking() {
 
 	// Clear the tracking data
 	runtime_signal_connections.clear();
-
-	}
+}
 
 void SignalizeDock::_connect_runtime_signal_tracking() {
 	EditorNode *editor_node = EditorNode::get_singleton();
@@ -1312,7 +1337,7 @@ void SignalizeDock::_connect_runtime_signal_tracking() {
 		Node *root = scene_tree->get_root();
 		if (root) {
 			// Helper function to recursively search for a matching scene
-			std::function<Node*(Node*, int)> search_recursive = [&](Node *node, int depth) -> Node* {
+			std::function<Node *(Node *, int)> search_recursive = [&](Node *node, int depth) -> Node * {
 				if (!node || depth > 10) { // Limit recursion depth
 					return nullptr;
 				}
@@ -1328,9 +1353,9 @@ void SignalizeDock::_connect_runtime_signal_tracking() {
 
 				// Skip UI dialogs and popups
 				if (node_class.contains("Dialog") || node_class.contains("Popup") ||
-					node_class.contains("Window") || node_class.contains("Menu") ||
-					node_class.contains("Panel") || node_class.contains("Button") ||
-					node_name.begins_with("_editor_") || node_name.contains("__editor")) {
+						node_class.contains("Window") || node_class.contains("Menu") ||
+						node_class.contains("Panel") || node_class.contains("Button") ||
+						node_name.begins_with("_editor_") || node_name.contains("__editor")) {
 					return nullptr;
 				}
 
@@ -1378,7 +1403,6 @@ void SignalizeDock::_connect_runtime_signal_tracking() {
 	List<Node *> all_nodes;
 	_collect_all_nodes(scene_root, all_nodes);
 
-
 	// For each node, connect to its signals
 	for (Node *node : all_nodes) {
 		if (!node) {
@@ -1412,13 +1436,12 @@ void SignalizeDock::_connect_runtime_signal_tracking() {
 				}
 				runtime_signal_connections[node_id][sig.name] = 1;
 
-							} else {
+			} else {
 				ERR_PRINT(vformat("[Signalize] Failed to connect to signal: %s.%s (error: %d)",
-					node->get_name(), sig.name, (int)err));
+						node->get_name(), sig.name, (int)err));
 			}
 		}
 	}
-
 }
 
 void SignalizeDock::_add_receiver_slots(Node *p_node) {
@@ -1625,7 +1648,6 @@ void SignalizeDock::_create_visual_connections() {
 			graph_edit->set_connection_activity(*emitter_name_ptr, conn.from_slot, *receiver_name_ptr, conn.to_slot, 0.05);
 		}
 	}
-
 }
 
 // Simplified callback for runtime signal tracking
@@ -1635,7 +1657,7 @@ void SignalizeDock::_on_signal_fired(Node *p_emitter, const String &p_signal) {
 	}
 
 	// Basic tracking verification - just print to console when a signal fires
-	
+
 	// Look up all connections for this signal and log them
 	List<Object::Connection> conns;
 	p_emitter->get_signal_connection_list(StringName(p_signal), &conns);
@@ -1652,7 +1674,7 @@ void SignalizeDock::_on_signal_fired(Node *p_emitter, const String &p_signal) {
 		}
 
 		// Log each connection that would be triggered
-		
+
 		// Also call the detailed callback for counting
 		_on_signal_emitted(p_emitter, p_signal, target_obj, method_name);
 	}
@@ -1663,14 +1685,14 @@ void SignalizeDock::_on_signal_emitted(Node *p_emitter, const String &p_signal, 
 		return;
 	}
 
-// Basic tracking verification - just print to console
+	// Basic tracking verification - just print to console
 
 	// Build key for this specific connection
 	String key = vformat("%s|%s|%s|%s",
-						String::num_uint64((uint64_t)p_emitter->get_instance_id()),
-						p_signal,
-						String::num_uint64((uint64_t)p_target->get_instance_id()),
-						p_method);
+			String::num_uint64((uint64_t)p_emitter->get_instance_id()),
+			p_signal,
+			String::num_uint64((uint64_t)p_target->get_instance_id()),
+			p_method);
 
 	// Update count if this connection exists
 	if (connections.has(key)) {
@@ -1684,10 +1706,9 @@ void SignalizeDock::_on_runtime_signal_emitted(ObjectID p_emitter_id, const Stri
 	// LIVE MODE: Highlight connections when signals fire during gameplay
 	// Only process signals for nodes that are currently being inspected
 	if (!is_inspecting || p_emitter_id != inspected_node_id) {
-				return;
+		return;
 	}
 
-	
 	// Update emission count
 	if (!node_emits.has(p_emitter_id)) {
 		node_emits[p_emitter_id] = HashMap<String, int>();
@@ -1698,25 +1719,26 @@ void SignalizeDock::_on_runtime_signal_emitted(ObjectID p_emitter_id, const Stri
 	// Highlight each connection for this signal
 	for (int i = 0; i < p_connections.size(); i++) {
 		Array conn_data = p_connections[i];
-		if (conn_data.size() < 4) continue;
+		if (conn_data.size() < 4) {
+			continue;
+		}
 
 		ObjectID target_id = conn_data[0];
 		String target_method = conn_data[3];
 
 		// Build connection key
 		String connection_key = vformat("%s|%s|%s|%s",
-			String::num_uint64(p_emitter_id),
-			p_signal_name,
-			String::num_uint64(target_id),
-			target_method);
+				String::num_uint64(p_emitter_id),
+				p_signal_name,
+				String::num_uint64(target_id),
+				target_method);
 
 		// Find the matching ConnectionSlot in pending_connections
 		for (const ConnectionSlot &slot : pending_connections) {
 			if (slot.emitter_id == p_emitter_id &&
-				slot.signal_name == p_signal_name &&
-				slot.receiver_id == target_id &&
-				slot.method_name == target_method) {
-
+					slot.signal_name == p_signal_name &&
+					slot.receiver_id == target_id &&
+					slot.method_name == target_method) {
 				// Get the graph node names
 				String *from_node_name = node_graph_names.getptr(p_emitter_id);
 				String *to_node_name = node_graph_names.getptr(target_id);
@@ -1724,7 +1746,6 @@ void SignalizeDock::_on_runtime_signal_emitted(ObjectID p_emitter_id, const Stri
 				if (from_node_name && to_node_name) {
 					// Highlight the connection by setting activity to 1.0 (full brightness)
 					graph_edit->set_connection_activity(*from_node_name, slot.from_slot, *to_node_name, slot.to_slot, 1.0);
-
 
 					// Set up timer to fade back to inactive
 					// Cancel existing timer if there is one
@@ -1768,10 +1789,9 @@ void SignalizeDock::_fade_connection_highlight(const String &p_connection_key) {
 	// Find the matching ConnectionSlot
 	for (const ConnectionSlot &slot : pending_connections) {
 		if (slot.emitter_id == emitter_id &&
-			slot.signal_name == signal_name &&
-			slot.receiver_id == receiver_id &&
-			slot.method_name == method_name) {
-
+				slot.signal_name == signal_name &&
+				slot.receiver_id == receiver_id &&
+				slot.method_name == method_name) {
 			// Get the graph node names
 			String *from_node_name = node_graph_names.getptr(emitter_id);
 			String *to_node_name = node_graph_names.getptr(receiver_id);
@@ -1849,9 +1869,7 @@ void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const St
 	String signal_name = String(p_signal);
 
 	// Skip timer signals from gizmos/updates
-	if (signal_name == "timeout" && (
-		node_name.contains("Gizmo") || node_name.contains("Update") ||
-		(node_name.contains("Timer") && node_class.contains("Editor")))) {
+	if (signal_name == "timeout" && (node_name.contains("Gizmo") || node_name.contains("Update") || (node_name.contains("Timer") && node_class.contains("Editor")))) {
 		return; // Skip editor gizmo/update timers
 	}
 
@@ -1875,8 +1893,7 @@ void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const St
 
 	// DEBUG: Log all Area3D signals
 	if (String(p_signal) == "body_entered" || String(p_signal) == "body_exited" ||
-	    String(p_signal) == "area_entered" || String(p_signal) == "area_exited") {
-
+			String(p_signal) == "area_entered" || String(p_signal) == "area_exited") {
 		// Log all connection targets for debugging
 		for (const Object::Connection &conn : conns) {
 			Object *target_obj = conn.callable.get_object();
@@ -1920,9 +1937,9 @@ void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const St
 		// Also skip common editor UI classes from the emitter
 		String node_class = emitter_node->get_class();
 		if (node_class.contains("Editor") || node_class.contains("MenuBar") ||
-			node_class.contains("Button") || node_class.contains("LineEdit") ||
-			node_class.contains("Panel") || node_class.contains("Window") ||
-			node_class.contains("Popup") || node_class.contains("Label")) {
+				node_class.contains("Button") || node_class.contains("LineEdit") ||
+				node_class.contains("Panel") || node_class.contains("Window") ||
+				node_class.contains("Popup") || node_class.contains("Label")) {
 			return; // Skip editor UI
 		}
 
@@ -1948,7 +1965,7 @@ void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const St
 
 	// Print to console for now (Step 1)
 	if (!viewer->tracking_runtime_scene) {
-			}
+	}
 
 	// Look up all connections and log them too
 	for (const Object::Connection &conn : conns) {
@@ -1961,8 +1978,7 @@ void SignalizeDock::_global_signal_emission_callback(Object *p_emitter, const St
 		if (method_name.is_empty()) {
 			continue;
 		}
-
-			}
+	}
 }
 
 void SignalizeDock::_enable_signal_tracking() {
@@ -1970,7 +1986,7 @@ void SignalizeDock::_enable_signal_tracking() {
 		return; // Already enabled
 	}
 
-		Object::set_signal_emission_callback(_global_signal_emission_callback);
+	Object::set_signal_emission_callback(_global_signal_emission_callback);
 	tracking_enabled = true;
 }
 
@@ -1979,19 +1995,19 @@ void SignalizeDock::_disable_signal_tracking() {
 		return; // Already disabled
 	}
 
-		Object::set_signal_emission_callback(nullptr);
+	Object::set_signal_emission_callback(nullptr);
 	tracking_enabled = false;
 }
 
 SignalizeDock::~SignalizeDock() {
-// Clean up - disable signal tracking when dock is destroyed
+	// Clean up - disable signal tracking when dock is destroyed
 	_disable_signal_tracking();
 
 	// Unregister message capture handlers
 	if (EngineDebugger::get_singleton()) {
 		EngineDebugger::unregister_message_capture("signal_viewer");
 		EngineDebugger::unregister_message_capture("scene");
-			}
+	}
 
 	// Clear singleton instance to prevent dangling pointer
 	singleton_instance = nullptr;
@@ -2154,17 +2170,16 @@ void SignalizeDock::_update_connection_labels() {
 
 // Callbacks for play/stop button presses
 void SignalizeDock::_on_play_pressed() {
-		// Start timer to periodically check if game is running
+	// Start timer to periodically check if game is running
 	if (game_start_check_timer) {
-				game_start_check_timer->start();
-			} else {
+		game_start_check_timer->start();
+	} else {
 		ERR_PRINT("[Signalize] ERROR: Timer is null!");
 	}
 	_on_play_mode_changed(true);
 }
 
 void SignalizeDock::_on_game_start_check_timer_timeout() {
-
 	// Check if game is actually running
 	EditorInterface *editor_interface = EditorInterface::get_singleton();
 	if (!editor_interface) {
@@ -2172,7 +2187,7 @@ void SignalizeDock::_on_game_start_check_timer_timeout() {
 	}
 
 	bool is_playing = editor_interface->is_playing_scene();
-	
+
 	if (!is_playing) {
 		return; // Game not running yet, wait for next check
 	}
@@ -2181,30 +2196,28 @@ void SignalizeDock::_on_game_start_check_timer_timeout() {
 
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 	if (debugger_node) {
-		
 		// Try to get the current debugger session
 		ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
 
 		if (debugger) {
-
 			// Check if session is active before sending
 			bool session_active = debugger->is_session_active();
-			
+
 			if (!session_active) {
-								return; // Keep timer running to retry
+				return; // Keep timer running to retry
 			}
 
 			// Send the start_tracking message via ScriptEditorDebugger
 			// NOTE: Must use "scene:" prefix because SceneDebugger captures that prefix
 			Array args;
 			debugger->send_message("scene:signal_viewer:start_tracking", args);
-			
+
 			// Stop the timer - we've successfully sent the message
 			if (game_start_check_timer) {
 				game_start_check_timer->stop();
 			}
 		} else {
-						// Don't stop the timer - keep retrying
+			// Don't stop the timer - keep retrying
 			return;
 		}
 	} else {
@@ -2213,7 +2226,7 @@ void SignalizeDock::_on_game_start_check_timer_timeout() {
 
 	// Set tracking flag
 	tracking_runtime_scene = true;
-	
+
 	// Stop the timer - we've detected the game is running
 	if (game_start_check_timer) {
 		game_start_check_timer->stop();
@@ -2221,7 +2234,7 @@ void SignalizeDock::_on_game_start_check_timer_timeout() {
 }
 
 void SignalizeDock::_on_stop_pressed() {
-		// Stop the game start check timer
+	// Stop the game start check timer
 	if (game_start_check_timer) {
 		game_start_check_timer->stop();
 	}
@@ -2229,7 +2242,6 @@ void SignalizeDock::_on_stop_pressed() {
 }
 
 void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
-	
 	// Update title label to show (Remote) when game is running
 	if (title_label) {
 		if (p_is_playing) {
@@ -2258,7 +2270,6 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 		// Clear the known ObjectIDs tracker
 		known_remote_object_ids.clear();
 
-		
 		// Capture the initial remote scene root ID and connect to signals
 		EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 		if (debugger_node) {
@@ -2267,10 +2278,10 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 				// NOTE: remote_tree_updated signal fires frequently and causes lag
 				// Disabled for on-demand inspection - only connect when live tracking is needed
 				// debugger->connect("remote_tree_updated", callable_mp(this, &SignalizeDock::_on_remote_tree_updated));
-				// 
+				//
 				// Connect to remote_objects_requested signal to detect node selection in remote tree
 				debugger->connect("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree));
-				
+
 				// Get the current remote scene root
 				const SceneDebuggerTree *remote_tree = debugger->get_remote_tree();
 				if (remote_tree && remote_tree->nodes.size() > 0) {
@@ -2278,7 +2289,7 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 					const List<SceneDebuggerTree::RemoteNode>::Element *first_node = remote_tree->nodes.front();
 					if (first_node) {
 						remote_scene_root_id = first_node->get().id;
-						
+
 						// Track all ObjectIDs in the initial scene (for detecting new nodes in scene transitions)
 						for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree->nodes.front(); E; E = E->next()) {
 							known_remote_object_ids.insert(E->get().id);
@@ -2288,7 +2299,7 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 			}
 		}
 
-			} else {
+	} else {
 		// Game stopped - disconnect from debugger signals to prevent lag
 		EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 		if (debugger_node) {
@@ -2297,7 +2308,7 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 				// Disconnect signals to stop receiving updates
 				if (debugger->is_connected("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree))) {
 					debugger->disconnect("remote_objects_requested", callable_mp(this, &SignalizeDock::_on_remote_object_selected_in_tree));
-									}
+				}
 				// remote_tree_updated is already disabled, but if we ever enable it we should disconnect it too
 			}
 		}
@@ -2307,11 +2318,10 @@ void SignalizeDock::_on_play_mode_changed(bool p_is_playing) {
 		_build_graph();
 		remote_scene_root_id = ObjectID(); // Reset root ID
 		known_remote_object_ids.clear(); // Clear tracked ObjectIDs
-			}
+	}
 }
 
 void SignalizeDock::_on_remote_tree_updated() {
-
 	// In live mode, we only track new ObjectIDs to detect scene transitions
 	// We DON'T auto-regenerate the graph - user must manually click nodes
 
@@ -2367,15 +2377,15 @@ void SignalizeDock::_on_remote_tree_updated() {
 
 void SignalizeDock::_on_remote_tree_check_timer_timeout() {
 	remote_tree_check_count++;
-	
+
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 	if (!debugger_node) {
-				return;
+		return;
 	}
 
 	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
 	if (!debugger) {
-				return;
+		return;
 	}
 
 	const SceneDebuggerTree *remote_tree = debugger->get_remote_tree();
@@ -2383,9 +2393,7 @@ void SignalizeDock::_on_remote_tree_check_timer_timeout() {
 		return;
 	}
 
-	
 	if (remote_tree->nodes.size() == 0) {
-		
 		// Stop after 10 checks (5 seconds) to avoid infinite loop
 		if (remote_tree_check_count >= 10) {
 			remote_tree_check_timer->stop();
@@ -2397,15 +2405,15 @@ void SignalizeDock::_on_remote_tree_check_timer_timeout() {
 
 	int count = 0;
 	for (const SceneDebuggerTree::RemoteNode &remote_node : remote_tree->nodes) {
-		if (count >= 5) break; // Only check first 5
-
+		if (count >= 5) {
+			break; // Only check first 5
+		}
 
 		// CRITICAL TEST: Can we get this object via ObjectDB?
 		Object *obj = ObjectDB::get_instance(remote_node.id);
 		if (obj) {
 			Node *node = Object::cast_to<Node>(obj);
 			if (node) {
-
 				// Can we get its signals?
 				List<MethodInfo> signals;
 				node->get_signal_list(&signals);
@@ -2424,7 +2432,6 @@ void SignalizeDock::_on_remote_tree_check_timer_timeout() {
 		count++;
 	}
 
-	
 	// Stop checking - we got our answer
 	remote_tree_check_timer->stop();
 }
@@ -2465,52 +2472,48 @@ void SignalizeDock::_inspect_selected_editor_node() {
 	// Get the selected node(s)
 	const List<Node *> &selected_nodes = editor_selection->get_top_selected_node_list();
 	if (selected_nodes.is_empty()) {
-				return;
+		return;
 	}
 
 	// For now, just inspect the first selected node
 	Node *selected_node = selected_nodes.front()->get();
 	if (!selected_node) {
-				return;
+		return;
 	}
 
-	
 	// Build graph for just this node
 	_build_graph_for_single_node(selected_node);
 }
 
 void SignalizeDock::_inspect_selected_remote_node(ScriptEditorDebugger *debugger) {
-
 	// Get the actual Tree widget (not the data structure)
 	const Tree *remote_tree_widget = debugger->get_editor_remote_tree();
 	if (!remote_tree_widget) {
-				return;
+		return;
 	}
 
 	// Get the selected item from the tree
 	TreeItem *selected = const_cast<Tree *>(remote_tree_widget)->get_selected();
 	if (!selected) {
-				return;
+		return;
 	}
 
 	// Debug: Print what we got
-	
+
 	// Get the metadata from the selected item
 	// EditorDebuggerTree stores ObjectID in column 0 metadata
 	Variant metadata = selected->get_metadata(0);
-	
+
 	if (metadata.get_type() != Variant::INT) {
-		
 		// Fallback: Try to match by name from SceneDebuggerTree
 		const SceneDebuggerTree *remote_tree_data = debugger->get_remote_tree();
 		if (remote_tree_data && !remote_tree_data->nodes.is_empty()) {
 			String selected_name = selected->get_text(0);
-			
+
 			// Search through all nodes for a matching name
 			for (const List<SceneDebuggerTree::RemoteNode>::Element *E = remote_tree_data->nodes.front(); E; E = E->next()) {
 				const SceneDebuggerTree::RemoteNode &node = E->get();
 				if (node.name == selected_name) {
-					
 					// Build the path
 					String node_path_str = "/root/" + node.name;
 
@@ -2524,7 +2527,7 @@ void SignalizeDock::_inspect_selected_remote_node(ScriptEditorDebugger *debugger
 
 	ObjectID node_id = ObjectID(uint64_t(int64_t(metadata)));
 	if (node_id.is_null()) {
-				return;
+		return;
 	}
 
 	// Get the node name from the tree item
@@ -2550,7 +2553,6 @@ void SignalizeDock::_inspect_selected_remote_node(ScriptEditorDebugger *debugger
 		node_path_str = "/root/" + node_path_str;
 	}
 
-
 	// Request signal data for this node from the game process
 	_inspect_remote_node(node_id, node_path_str);
 }
@@ -2565,19 +2567,17 @@ void SignalizeDock::_inspect_remote_node(ObjectID p_node_id, const String &p_nod
 
 	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
 	if (!debugger) {
-				return;
+		return;
 	}
 
 	// Send message to game process requesting signal data for this node
 	Array args;
-	args.append((int64_t)p_node_id);  // Node ID - pass as integer, not string!
-	args.append(p_node_path);  // Node path
-
+	args.append((int64_t)p_node_id); // Node ID - pass as integer, not string!
+	args.append(p_node_path); // Node path
 
 	// Send with "scene:" prefix to reach SceneDebugger handlers
 	// Pass args directly (not wrapped), as the handler expects: [node_id, node_path]
 	debugger->_put_msg("scene:signal_viewer_request_node_data", args);
-
 
 	// Update inspection state
 	inspected_node_id = p_node_id;
@@ -2588,17 +2588,16 @@ void SignalizeDock::_inspect_remote_node(ObjectID p_node_id, const String &p_nod
 	// This allows connections to light up when this node's signals fire
 	if (!tracking_enabled) {
 		_enable_signal_tracking();
-			}
+	}
 }
 
 // Per-node inspection: Handle signal data received from game process
 void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 	// Data format: [node_id, node_name, node_class, [{signal_name, count, [[target_id, target_name, target_class, target_method], ...]}, ...]]
 	if (p_data.size() < 4) {
-				return;
+		return;
 	}
 
-	
 	// Clear previous graph VISUALS but preserve inspection state
 	// We need to clear the graph nodes to rebuild them, but keep is_inspecting=true
 	List<GraphNode *> nodes_to_delete;
@@ -2637,7 +2636,7 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 	ObjectID node_id = p_data[0];
 	String node_name = p_data[1];
 	String node_class = p_data[2];
-	Array signal_data = p_data[3];  // Array of signal info dictionaries
+	Array signal_data = p_data[3]; // Array of signal info dictionaries
 
 	// Track signal emissions for this node
 	if (!node_emits.has(node_id)) {
@@ -2649,7 +2648,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 
 	for (int i = 0; i < signal_data.size(); i++) {
 		Array sig_info = signal_data[i];
-		if (sig_info.size() < 3) continue;
+		if (sig_info.size() < 3) {
+			continue;
+		}
 
 		String signal_name = sig_info[0];
 		int count = sig_info[1];
@@ -2661,7 +2662,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 		// Collect all target methods
 		for (int j = 0; j < connections.size(); j++) {
 			Array conn_data = connections[j];
-			if (conn_data.size() < 4) continue;
+			if (conn_data.size() < 4) {
+				continue;
+			}
 
 			ObjectID target_id = conn_data[0];
 			String target_name = conn_data[1];
@@ -2698,7 +2701,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 	List<String> main_node_signals;
 	for (int i = 0; i < signal_data.size(); i++) {
 		Array sig_info = signal_data[i];
-		if (sig_info.size() < 3) continue;
+		if (sig_info.size() < 3) {
+			continue;
+		}
 
 		String signal_name = sig_info[0];
 		Array connections = sig_info[2];
@@ -2757,18 +2762,24 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 		String target_class;
 		for (int i = 0; i < signal_data.size(); i++) {
 			Array sig_info = signal_data[i];
-			if (sig_info.size() < 3) continue;
+			if (sig_info.size() < 3) {
+				continue;
+			}
 			Array connections = sig_info[2];
 			for (int j = 0; j < connections.size(); j++) {
 				Array conn_data = connections[j];
-				if (conn_data.size() < 4) continue;
+				if (conn_data.size() < 4) {
+					continue;
+				}
 				if (ObjectID(uint64_t(int64_t(conn_data[0]))) == target_id) {
 					target_name = conn_data[1];
 					target_class = conn_data[2];
 					break;
 				}
 			}
-			if (!target_name.is_empty()) break;
+			if (!target_name.is_empty()) {
+				break;
+			}
 		}
 
 		GraphNode *target_gn = memnew(GraphNode);
@@ -2887,7 +2898,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 	// Seventh pass: Create pending connections
 	for (int i = 0; i < signal_data.size(); i++) {
 		Array sig_info = signal_data[i];
-		if (sig_info.size() < 3) continue;
+		if (sig_info.size() < 3) {
+			continue;
+		}
 
 		String signal_name = sig_info[0];
 		Array connections = sig_info[2];
@@ -2899,7 +2912,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 
 		for (int j = 0; j < connections.size(); j++) {
 			Array conn_data = connections[j];
-			if (conn_data.size() < 4) continue;
+			if (conn_data.size() < 4) {
+				continue;
+			}
 
 			ObjectID target_id = conn_data[0];
 			String target_method = conn_data[3];
@@ -2917,7 +2932,6 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 			conn_slot.from_slot = from_slot;
 			conn_slot.to_slot = to_slot;
 			pending_connections.push_back(conn_slot);
-
 		}
 	}
 
@@ -2934,12 +2948,10 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 
 	// Create visual connections
 	call_deferred("_create_visual_connections");
-
 }
 
 // Per-node inspection: Clear current inspection
 void SignalizeDock::_clear_inspection() {
-
 	// Clear all graph nodes
 	List<GraphNode *> nodes_to_delete;
 	for (int i = 0; i < graph_edit->get_child_count(); i++) {
@@ -2977,7 +2989,7 @@ void SignalizeDock::_clear_inspection() {
 	// This stops tracking all signals when no node is being inspected
 	if (tracking_enabled) {
 		_disable_signal_tracking();
-			}
+	}
 
 	// Clear inspection state
 	inspected_node_id = ObjectID();
@@ -2987,7 +2999,6 @@ void SignalizeDock::_clear_inspection() {
 
 // Called by inspector plugin when a node is inspected in the Remote tree
 void SignalizeDock::_on_node_inspected_in_remote_tree(ObjectID p_node_id, const String &p_node_path) {
-
 	// Don't auto-inspect if we're already manually inspecting a node
 	// This prevents automatic inspections (from clicking into the game) from overriding manual inspections
 	if (is_inspecting) {
@@ -2997,12 +3008,12 @@ void SignalizeDock::_on_node_inspected_in_remote_tree(ObjectID p_node_id, const 
 	// Only auto-inspect if game is running
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 	if (!debugger_node) {
-				return;
+		return;
 	}
 
 	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
 	if (!debugger) {
-				return;
+		return;
 	}
 
 	// Auto-inspect this node
@@ -3011,23 +3022,22 @@ void SignalizeDock::_on_node_inspected_in_remote_tree(ObjectID p_node_id, const 
 
 // Called when a node is clicked in the remote tree
 void SignalizeDock::_on_remote_object_selected_in_tree(const Array &p_object_ids) {
-	
 	if (p_object_ids.is_empty()) {
-				return;
+		return;
 	}
 
 	// Get the first selected object ID
 	ObjectID selected_id = ObjectID(uint64_t(int64_t(p_object_ids[0])));
-	
+
 	// Get the node from the ObjectDB
 	Object *obj = ObjectDB::get_instance(selected_id);
 	if (!obj) {
-				return;
+		return;
 	}
 
 	Node *node = Object::cast_to<Node>(obj);
 	if (!node) {
-				return;
+		return;
 	}
 
 	// Get the node path
@@ -3035,27 +3045,26 @@ void SignalizeDock::_on_remote_object_selected_in_tree(const Array &p_object_ids
 	String node_path_str = node_path.operator String();
 	String node_name = node->get_name();
 
-
 	// Only inspect if game is running
 	EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
 	if (!debugger_node) {
-				return;
+		return;
 	}
 
 	ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
 	if (!debugger) {
-				return;
+		return;
 	}
 
 	// Inspect this node
-		_inspect_remote_node(selected_id, node_path_str);
+	_inspect_remote_node(selected_id, node_path_str);
 }
 
 // Message capture handler - receives signal emissions from game
 Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {
 	// Debug: Print all scene messages to understand the flow
 	if (p_msg.begins_with("inspect") || p_msg.contains("selected") || p_msg.contains("remote")) {
-			}
+	}
 
 	if (p_msg == "signal_viewer:signal_emitted") {
 		r_captured = true;
@@ -3070,14 +3079,14 @@ Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String 
 			Array connections = p_args[4];
 
 			// Print to console (Step 1)
-			
+
 			// Log connections
 			for (int i = 0; i < connections.size(); i++) {
 				Array conn_data = connections[i];
 				if (conn_data.size() >= 3) {
 					String target_class = conn_data[1];
 					String method_name = conn_data[2];
-									}
+				}
 			}
 
 			// Update the graph visualization
@@ -3106,7 +3115,6 @@ Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String 
 	// Capture inspect_objects to detect when nodes are clicked in remote tree
 	// (registered for "scene" prefix, so p_msg is "inspect_objects" not "scene:inspect_objects")
 	if (p_msg == "inspect_objects") {
-		
 		// Don't capture this message - let the normal debugger handle it
 		// But we can inspect what's being selected
 		if (p_args.size() > 0) {
@@ -3114,7 +3122,6 @@ Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String 
 			if (!object_ids.is_empty()) {
 				ObjectID selected_id = ObjectID(uint64_t(int64_t(object_ids[0])));
 
-				
 				// Get the singleton and trigger inspection
 				SignalizeDock *viewer = singleton_instance;
 				if (viewer) {
@@ -3131,7 +3138,7 @@ Error SignalizeDock::_capture_signal_viewer_messages(void *p_user, const String 
 								if (node) {
 									NodePath node_path = node->get_path();
 									String node_path_str = node_path.operator String();
-																		viewer->_inspect_remote_node(selected_id, node_path_str);
+									viewer->_inspect_remote_node(selected_id, node_path_str);
 								}
 							}
 						}

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -518,10 +518,10 @@ void SignalizeDock::_build_graph() {
 
 						// Check if target has a script with this method
 						bool has_script_method = false;
-						ScriptInstance *script_instance = target_node->get_script_instance();
-						if (script_instance) {
+						ScriptInstance *script_inst = target_node->get_script_instance();
+						if (script_inst) {
 							// Check if this method exists in the script
-							has_script_method = script_instance->has_method(StringName(method_name));
+							has_script_method = script_inst->has_method(StringName(method_name));
 						}
 
 						// Only include if it's a real user connection (to a script method)
@@ -633,8 +633,8 @@ void SignalizeDock::_build_graph_for_single_node(Node *p_node) {
 			}
 
 			// Filter: Only include connections to script methods
-			ScriptInstance *script_instance = target_node->get_script_instance();
-			if (!script_instance || !script_instance->has_method(StringName(target_method))) {
+			ScriptInstance *script_inst = target_node->get_script_instance();
+			if (!script_inst || !script_inst->has_method(StringName(target_method))) {
 				continue; // Skip internal engine connections
 			}
 
@@ -710,8 +710,8 @@ void SignalizeDock::_build_graph_for_single_node(Node *p_node) {
 					}
 
 					// Filter: Only include if p_node has this method in a script
-					ScriptInstance *script_instance = p_node->get_script_instance();
-					if (!script_instance || !script_instance->has_method(StringName(target_method))) {
+					ScriptInstance *script_inst = p_node->get_script_instance();
+					if (!script_inst || !script_inst->has_method(StringName(target_method))) {
 						continue; // Skip internal engine connections
 					}
 
@@ -2801,9 +2801,9 @@ void SignalizeDock::_on_node_signal_data_received(const Array &p_data) {
 		HBoxContainer *target_titlebar = target_gn->get_titlebar_hbox();
 		if (target_titlebar) {
 			for (int i = 0; i < target_titlebar->get_child_count(); i++) {
-				Label *title_label = Object::cast_to<Label>(target_titlebar->get_child(i));
-				if (title_label) {
-					title_label->add_theme_color_override("font_color", Color(0, 0, 0, 1));
+				Label *title_lbl = Object::cast_to<Label>(target_titlebar->get_child(i));
+				if (title_lbl) {
+					title_lbl->add_theme_color_override("font_color", Color(0, 0, 0, 1));
 					break;
 				}
 			}

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -33,8 +33,8 @@
 #include "signalize_dock.h"
 
 #include "core/debugger/engine_debugger.h"
-#include "core/io/file_access.h"
 #include "core/input/input_event.h"
+#include "core/io/file_access.h"
 #include "core/object/class_db.h"
 #include "core/object/script_instance.h"
 #include "core/object/script_language.h"
@@ -548,8 +548,8 @@ void SignalizeDock::_build_graph() {
 
 						// Only filter connections TO specific internal node types (unless it's a self-connection)
 						if (target_node != node &&
-							(target_class.contains("PhysicalBoneSimulator3D") ||
-							 target_class.contains("BoneAttachment3D"))) {
+								(target_class.contains("PhysicalBoneSimulator3D") ||
+										target_class.contains("BoneAttachment3D"))) {
 							is_internal = true;
 						}
 

--- a/editor/docks/signalize_dock.cpp
+++ b/editor/docks/signalize_dock.cpp
@@ -33,6 +33,7 @@
 #include "signalize_dock.h"
 
 #include "core/debugger/engine_debugger.h"
+#include "core/io/file_access.h"
 #include "core/input/input_event.h"
 #include "core/object/class_db.h"
 #include "core/object/script_instance.h"
@@ -98,11 +99,12 @@ SignalizeDock::SignalizeDock() {
 	search_box->connect("text_changed", callable_mp(this, &SignalizeDock::_on_search_changed));
 	top_bar->add_child(search_box);
 
-	refresh_button = memnew(Button);
-	refresh_button->set_text("Build Graph");
-	refresh_button->set_tooltip_text("Rebuild the signal graph from the edited scene");
-	refresh_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_refresh_pressed));
-	top_bar->add_child(refresh_button);
+	// TODO: Temporarily disabled - Build Graph functionality needs refinement
+	// refresh_button = memnew(Button);
+	// refresh_button->set_text("Build Graph");
+	// refresh_button->set_tooltip_text("Rebuild the signal graph from the edited scene");
+	// refresh_button->connect("pressed", callable_mp(this, &SignalizeDock::_on_refresh_pressed));
+	// top_bar->add_child(refresh_button);
 
 	// Per-node inspection: Add button to inspect selected remote node
 	Button *inspect_button = memnew(Button);
@@ -372,6 +374,19 @@ void SignalizeDock::_on_verbosity_changed(int p_level) {
 		editor_settings->set("signalize/verbosity_level", verbosity_level);
 		editor_settings->save();
 	}
+
+	// If runtime tracking is active, send the updated verbosity to the game
+	if (tracking_runtime_scene) {
+		EditorDebuggerNode *debugger_node = EditorDebuggerNode::get_singleton();
+		if (debugger_node) {
+			ScriptEditorDebugger *debugger = debugger_node->get_current_debugger();
+			if (debugger) {
+				Array args;
+				args.append(verbosity_level);
+				debugger->send_message("scene:signal_viewer:set_verbosity", args);
+			}
+		}
+	}
 }
 
 void SignalizeDock::_on_open_function_button_pressed(ObjectID p_node_id, const String &p_method_name) {
@@ -500,37 +515,61 @@ void SignalizeDock::_build_graph() {
 
 	// Now collect all emitters AND their receivers
 	HashMap<ObjectID, bool> final_nodes;
+	int total_connections_checked = 0;
+	int total_signals_checked = 0;
+
 	for (Node *node : all_nodes) {
 		List<MethodInfo> signals;
 		node->get_signal_list(&signals);
+		total_signals_checked += signals.size();
 
 		for (const MethodInfo &sig : signals) {
 			List<Object::Connection> conns;
 			node->get_signal_connection_list(StringName(sig.name), &conns);
+			total_connections_checked += conns.size();
+
+			if (should_log(2) && conns.size() > 0) {
+				print_line(vformat("[Signalize] Node '%s' has signal '%s' with %d connections",
+						node->get_name(), sig.name, conns.size()));
+			}
 
 			for (const Object::Connection &conn : conns) {
 				Object *target = conn.callable.get_object();
 				if (target) {
 					Node *target_node = Object::cast_to<Node>(target);
-					if (target_node && target_node != node && node_lookup.has(target_node->get_instance_id())) {
-						// Filter out internal engine connections that aren't user-created
+					// Check if target is in our scene (either same node or different node in scene)
+					if (target_node && (target_node == node || node_lookup.has(target_node->get_instance_id()))) {
 						String method_name = conn.callable.get_method();
+						String node_class = node->get_class();
+						String target_class = target_node->get_class();
 
-						// Check if target has a script with this method
-						bool has_script_method = false;
-						ScriptInstance *script_inst = target_node->get_script_instance();
-						if (script_inst) {
-							// Check if this method exists in the script
-							has_script_method = script_inst->has_method(StringName(method_name));
+						// Filter out only the most obvious internal engine connections
+						bool is_internal = false;
+
+						// Only filter connections TO specific internal node types (unless it's a self-connection)
+						if (target_node != node &&
+							(target_class.contains("PhysicalBoneSimulator3D") ||
+							 target_class.contains("BoneAttachment3D"))) {
+							is_internal = true;
 						}
 
-						// Only include if it's a real user connection (to a script method)
-						if (!has_script_method) {
-							// This is an internal engine connection, skip it
+						if (is_internal) {
+							// Skip internal engine connections entirely
+							if (should_log(3)) {
+								print_line(vformat("[Signalize]   Skipping internal connection: %s.%s -> %s.%s",
+										node->get_name(), sig.name,
+										target_node->get_name(), method_name));
+							}
 							continue;
 						}
 
-						// This is a valid user-created connection within the scene
+						// This is a user-created connection
+						if (should_log(2)) {
+							print_line(vformat("[Signalize]   Found connection: %s.%s -> %s.%s",
+									node->get_name(), sig.name,
+									target_node->get_name(), method_name));
+						}
+
 						ObjectID emitter_id = node->get_instance_id();
 						ObjectID receiver_id = target_node->get_instance_id();
 
@@ -541,6 +580,16 @@ void SignalizeDock::_build_graph() {
 				}
 			}
 		}
+	}
+
+	// Second pass: find script-based connections that haven't been established yet
+	// These are connections defined in scripts using connect() calls
+	// that only exist when the game is running
+	if (should_log(1)) {
+		print_line("[Signalize] Scanning scripts for connect() calls...");
+	}
+	for (Node *node : all_nodes) {
+		_find_script_connections(node, node_lookup, final_nodes);
 	}
 
 	// Convert set to list
@@ -587,6 +636,179 @@ void SignalizeDock::_collect_all_nodes(Node *p_node, List<Node *> &r_list) {
 		if (child) {
 			_collect_all_nodes(child, r_list);
 		}
+	}
+}
+
+void SignalizeDock::_find_script_connections(Node *p_node, const HashMap<ObjectID, Node *> &p_node_lookup, HashMap<ObjectID, bool> &r_final_nodes) {
+	if (!p_node) {
+		return;
+	}
+
+	// Get the script attached to this node
+	Ref<Script> node_script = p_node->get_script();
+	if (!node_script.is_valid()) {
+		if (should_log(3)) {
+			print_line(vformat("[Signalize] Node '%s' has no script", p_node->get_name()));
+		}
+		return; // No script, no script-based connections
+	}
+
+	// Get the script source code
+	String script_path = node_script->get_path();
+	if (script_path.is_empty()) {
+		if (should_log(3)) {
+			print_line(vformat("[Signalize] Node '%s' script has no path (built-in?)", p_node->get_name()));
+		}
+		return; // Built-in script or no path
+	}
+
+	if (should_log(2)) {
+		print_line(vformat("[Signalize] Checking script for node '%s': %s", p_node->get_name(), script_path));
+	}
+
+	// Read the script file
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(script_path, FileAccess::READ, &err);
+	if (file.is_null()) {
+		if (should_log(2)) {
+			print_line(vformat("[Signalize] Could not read script: %s (error: %d)", script_path, err));
+		}
+		return;
+	}
+
+	String source = file->get_as_text();
+	file->close();
+
+	if (should_log(2)) {
+		print_line(vformat("[Signalize] Script has %d characters, scanning for connect()...", source.length()));
+	}
+
+	// Find all connect() calls in the script
+	// Look for patterns like:
+	// - signal_name.connect(node_path, "method_name")
+	// - signal_name.connect(Callable(node_path, "method_name"))
+	// - node_reference.signal.connect(self, "method")
+
+	Vector<String> lines = source.split("\n");
+	int connect_calls_found = 0;
+
+	for (const String &line : lines) {
+		String trimmed = line.strip_edges();
+
+		// Skip comments
+		if (trimmed.begins_with("#")) {
+			continue;
+		}
+
+		// Look for connect() calls
+		int connect_pos = trimmed.find(".connect(");
+		if (connect_pos == -1) {
+			continue;
+		}
+
+		connect_calls_found++;
+		if (should_log(2)) {
+			print_line(vformat("[Signalize] Found connect() call line %d: %s", connect_calls_found, trimmed));
+		}
+
+		// Try to extract the signal name and target
+		// Extract what's between .connect( and the matching )
+		int paren_start = trimmed.find("(", connect_pos);
+		if (paren_start == -1) {
+			continue;
+		}
+
+		// Find the matching closing paren
+		int depth = 0;
+		int paren_end = -1;
+		for (int i = paren_start; i < trimmed.length(); i++) {
+			if (trimmed[i] == '(') {
+				depth++;
+			} else if (trimmed[i] == ')') {
+				depth--;
+				if (depth == 0) {
+					paren_end = i;
+					break;
+				}
+			}
+		}
+
+		if (paren_end == -1) {
+			if (should_log(3)) {
+				print_line(vformat("[Signalize] Could not find matching closing paren"));
+			}
+			continue;
+		}
+
+		// Extract the arguments string
+		String args = trimmed.substr(paren_start + 1, paren_end - paren_start - 1);
+
+		if (should_log(3)) {
+			print_line(vformat("[Signalize] Connect() args: %s", args));
+		}
+
+		// Now look for potential targets in the arguments
+		// Common patterns:
+		// - self (connects to the same node)
+		// - $NodePath (absolute or relative path)
+		// - %NodePath (unique node path)
+		// - variable names (we can't resolve these statically)
+
+		// Check for "self" first
+		if (args.contains("self") || args.contains("\"self\"")) {
+			// Connection to self - both emitter and receiver are the same node
+			ObjectID emitter_id = p_node->get_instance_id();
+			r_final_nodes[emitter_id] = true;
+
+			if (should_log(2)) {
+				print_line(vformat("[Signalize] Found self-connection in script for node '%s'", p_node->get_name()));
+			}
+		}
+
+		// Look for node paths in quotes
+		Vector<String> quoted_strings;
+		int quote_start = -1;
+		for (int i = 0; i < args.length(); i++) {
+			if ((args[i] == '"' || args[i] == '\'') && quote_start == -1) {
+				quote_start = i;
+			} else if ((args[i] == '"' || args[i] == '\'') && quote_start != -1) {
+				String quoted = args.substr(quote_start, i - quote_start + 1);
+				quoted_strings.append(quoted);
+				quote_start = -1;
+			}
+		}
+
+		for (const String &quoted : quoted_strings) {
+			// Remove quotes
+			String unquoted = quoted.substr(1, quoted.length() - 2);
+
+			if (should_log(3)) {
+				print_line(vformat("[Signalize] Checking quoted string: %s", unquoted));
+			}
+
+			// Check if it's a node path
+			if (unquoted.begins_with("$") || unquoted.begins_with("%") || unquoted.contains("/")) {
+				NodePath node_path(unquoted);
+				Node *target = p_node->get_node(node_path);
+
+				if (target && p_node_lookup.has(target->get_instance_id())) {
+					ObjectID emitter_id = p_node->get_instance_id();
+					ObjectID receiver_id = target->get_instance_id();
+
+					r_final_nodes[emitter_id] = true;
+					r_final_nodes[receiver_id] = true;
+
+					if (should_log(2)) {
+						print_line(vformat("[Signalize] Found script connection: %s -> %s",
+								p_node->get_name(), target->get_name()));
+					}
+				}
+			}
+		}
+	}
+
+	if (should_log(2) && connect_calls_found == 0) {
+		print_line(vformat("[Signalize] No connect() calls found in script for '%s'", p_node->get_name()));
 	}
 }
 
@@ -2211,6 +2433,7 @@ void SignalizeDock::_on_game_start_check_timer_timeout() {
 			// Send the start_tracking message via ScriptEditorDebugger
 			// NOTE: Must use "scene:" prefix because SceneDebugger captures that prefix
 			Array args;
+			args.append(verbosity_level); // Pass verbosity level to runtime
 			debugger->send_message("scene:signal_viewer:start_tracking", args);
 
 			// Stop the timer - we've successfully sent the message

--- a/editor/docks/signalize_dock.h
+++ b/editor/docks/signalize_dock.h
@@ -1,14 +1,46 @@
+/**************************************************************************/
+/*  signalize_dock.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2024-present Redot Engine contributors                   */
+/*                                          (see REDOT_AUTHORS.md)        */
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
 #pragma once
 
-#include "scene/gui/graph_edit.h"
 #include "scene/gui/button.h"
+#include "scene/gui/graph_edit.h"
 #include "scene/gui/line_edit.h"
 #include "scene/main/node.h"
 
 #include "core/object/object_id.h"
 #include "core/templates/hash_map.h"
-#include "core/templates/list.h"
 #include "core/templates/hash_set.h"
+#include "core/templates/list.h"
 
 // Forward declarations
 class SignalizeInspectorPlugin;
@@ -50,16 +82,16 @@ private:
 	// Track graph nodes and their positions
 	HashMap<ObjectID, GraphNode *> node_graph_nodes;
 	HashMap<ObjectID, String> node_graph_names;
-	HashMap<ObjectID, Color> node_colors;  // Track color for each node
-	HashMap<ObjectID, Vector2> saved_node_positions;  // Track manually positioned nodes
+	HashMap<ObjectID, Color> node_colors; // Track color for each node
+	HashMap<ObjectID, Vector2> saved_node_positions; // Track manually positioned nodes
 
 	// Track labels for each node to update signal info
-	HashMap<ObjectID, Label *> node_emits_labels;  // Shows "Emits: signal1 (5), signal2 (3)"
+	HashMap<ObjectID, Label *> node_emits_labels; // Shows "Emits: signal1 (5), signal2 (3)"
 	HashMap<ObjectID, Label *> node_receives_labels; // Shows "Receives: method1 (2), method2 (1)"
 
 	// Track which signals/methods each node has (for updating labels)
-	HashMap<ObjectID, HashMap<String, int>> node_emits;     // node_id -> signal_name -> count
-	HashMap<ObjectID, HashMap<String, int>> node_receives;  // node_id -> method_name -> count
+	HashMap<ObjectID, HashMap<String, int>> node_emits; // node_id -> signal_name -> count
+	HashMap<ObjectID, HashMap<String, int>> node_receives; // node_id -> method_name -> count
 
 	// Track signal emissions using String key: "emitter_id|signal|target_id|method" -> count
 	HashMap<String, int> connections;
@@ -71,7 +103,7 @@ private:
 	// Track next available port slot index for each node (sequential from 0)
 	HashMap<ObjectID, int> next_emitter_slot_idx;
 	HashMap<ObjectID, int> next_receiver_slot_idx;
-	HashMap<ObjectID, int> num_input_ports;  // Track how many input ports each node has
+	HashMap<ObjectID, int> num_input_ports; // Track how many input ports each node has
 	HashMap<ObjectID, int> num_output_ports; // Track how many output ports each node has
 
 	// Track connections to make: emitter_id, signal_name, target_id, method_name -> from_slot, to_slot
@@ -87,7 +119,7 @@ private:
 
 	// Track receiver method with its actual target object (for opening scripts)
 	struct ReceiverMethodInfo {
-		ObjectID target_id;  // The object that actually owns the method/script
+		ObjectID target_id; // The object that actually owns the method/script
 		String method_name;
 	};
 

--- a/editor/docks/signalize_dock.h
+++ b/editor/docks/signalize_dock.h
@@ -1,0 +1,311 @@
+#pragma once
+
+#include "scene/gui/graph_edit.h"
+#include "scene/gui/button.h"
+#include "scene/gui/line_edit.h"
+#include "scene/main/node.h"
+
+#include "core/object/object_id.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/list.h"
+#include "core/templates/hash_set.h"
+
+// Forward declarations
+class SignalizeInspectorPlugin;
+class WindowWrapper;
+class ScriptEditorDebugger;
+class EditorDebuggerNode;
+class ColorPickerButton;
+class AcceptDialog;
+
+class SignalizeDock : public VBoxContainer {
+	GDCLASS(SignalizeDock, VBoxContainer);
+
+	friend class SignalizeInspectorPlugin; // Allow inspector plugin to access private methods
+
+private:
+	GraphEdit *graph_edit = nullptr;
+	Button *refresh_button = nullptr;
+	LineEdit *search_box = nullptr;
+	Node *selected_node = nullptr;
+	Button *tool_button = nullptr; // Reference to the bottom panel button
+	Button *make_floating_button = nullptr; // Button to make window floating
+	WindowWrapper *window_wrapper = nullptr; // Wrapper for floating window support
+	ColorPickerButton *connection_color_button = nullptr; // Color picker for connection lines
+	Color custom_connection_color = Color(0.5, 0.1, 0.1); // Default dark red
+	Button *settings_button = nullptr; // Settings button
+	float connection_pulse_duration = 0.3; // Duration of connection highlight in seconds
+	AcceptDialog *settings_dialog = nullptr; // Settings popup dialog
+
+	// Verbosity control: 0=Silent, 1=Quiet, 2=Normal, 3=Verbose
+	int verbosity_level = 0; // Default to Silent (no console spam)
+
+	// Helper to check if we should log at a given verbosity level
+	bool should_log(int p_level) const { return verbosity_level >= p_level; }
+
+	VBoxContainer *content_container = nullptr; // Holds the actual UI, can be reparented
+	bool is_floating = false; // Track floating state
+	Label *title_label = nullptr; // Reference to title label to update with (Remote)
+
+	// Track graph nodes and their positions
+	HashMap<ObjectID, GraphNode *> node_graph_nodes;
+	HashMap<ObjectID, String> node_graph_names;
+	HashMap<ObjectID, Color> node_colors;  // Track color for each node
+	HashMap<ObjectID, Vector2> saved_node_positions;  // Track manually positioned nodes
+
+	// Track labels for each node to update signal info
+	HashMap<ObjectID, Label *> node_emits_labels;  // Shows "Emits: signal1 (5), signal2 (3)"
+	HashMap<ObjectID, Label *> node_receives_labels; // Shows "Receives: method1 (2), method2 (1)"
+
+	// Track which signals/methods each node has (for updating labels)
+	HashMap<ObjectID, HashMap<String, int>> node_emits;     // node_id -> signal_name -> count
+	HashMap<ObjectID, HashMap<String, int>> node_receives;  // node_id -> method_name -> count
+
+	// Track signal emissions using String key: "emitter_id|signal|target_id|method" -> count
+	HashMap<String, int> connections;
+
+	// Track which slot index corresponds to each signal/method
+	HashMap<ObjectID, HashMap<String, int>> signal_to_slot; // emitter_id -> signal_name -> slot_idx
+	HashMap<ObjectID, HashMap<String, int>> function_to_slot; // receiver_id -> method_name -> slot_idx
+
+	// Track next available port slot index for each node (sequential from 0)
+	HashMap<ObjectID, int> next_emitter_slot_idx;
+	HashMap<ObjectID, int> next_receiver_slot_idx;
+	HashMap<ObjectID, int> num_input_ports;  // Track how many input ports each node has
+	HashMap<ObjectID, int> num_output_ports; // Track how many output ports each node has
+
+	// Track connections to make: emitter_id, signal_name, target_id, method_name -> from_slot, to_slot
+	struct ConnectionSlot {
+		ObjectID emitter_id;
+		String signal_name;
+		ObjectID receiver_id;
+		String method_name;
+		int from_slot;
+		int to_slot;
+	};
+	List<ConnectionSlot> pending_connections;
+
+	// Track receiver method with its actual target object (for opening scripts)
+	struct ReceiverMethodInfo {
+		ObjectID target_id;  // The object that actually owns the method/script
+		String method_name;
+	};
+
+	void _build_graph();
+	void _collect_all_nodes(Node *p_node, List<Node *> &r_list);
+	bool _node_has_connections(Node *p_node);
+	void _create_graph_node(Node *p_node, int p_depth, int p_index);
+	Color _get_editor_node_icon_color(Node *p_node); // Get actual icon color from editor
+	Color _get_editor_node_icon_color_by_class(const String &p_class_name); // Get icon color by class name
+	Color _get_node_type_color(const String &p_class_name);
+	void _connect_all_node_signals();
+	void _cleanup_runtime_signal_tracking(); // STEP 1: Disconnect old tracking connections
+	void _connect_runtime_signal_tracking(); // STEP 1: Connect to signals for runtime tracking
+	void _add_receiver_slots(Node *p_node);
+	void _add_emitter_slots(Node *p_node);
+	void _create_visual_connections();
+
+	// Track which functions we've added to each receiver to avoid duplicates
+	HashMap<ObjectID, HashSet<String>> receiver_functions;
+
+	// Track runtime signal connections so we can disconnect them later
+	HashMap<ObjectID, HashMap<String, int>> runtime_signal_connections; // emitter_id -> signal_name -> connection_count
+
+	// Track which scene tree we're connected to (editor or runtime)
+	bool tracking_runtime_scene = false;
+
+	// STEP 1: Engine-level signal tracking hook
+	static void _global_signal_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount);
+	void _enable_signal_tracking();
+	void _disable_signal_tracking();
+	bool tracking_enabled = false;
+
+	// Static instance pointer for the global callback to access
+	static SignalizeDock *singleton_instance;
+
+	// Track play mode state to detect changes
+	bool was_playing_last_frame = false;
+
+	// Track remote scene root to detect actual scene changes (not just property updates)
+	ObjectID remote_scene_root_id;
+
+	// Track all ObjectIDs we've seen in the remote scene tree
+	// When new ObjectIDs appear (new nodes instantiated), clear and regenerate
+	HashSet<ObjectID> known_remote_object_ids;
+
+	// Per-node inspection: Track currently inspected node
+	ObjectID inspected_node_id;
+	String inspected_node_path;
+	bool is_inspecting = false;
+
+	// STEP 1: Timer for retrying start_tracking message until game is running
+	Timer *game_start_check_timer = nullptr;
+	void _on_game_start_check_timer_timeout();
+
+	// STEP 1: Timer for checking remote tree population
+	Timer *remote_tree_check_timer = nullptr;
+	void _on_remote_tree_check_timer_timeout();
+	int remote_tree_check_count = 0;
+
+	// Highlight timers for fading signal connection highlights
+	HashMap<String, Timer *> connection_highlight_timers;
+	void _fade_connection_highlight(const String &p_connection_key);
+
+	// Runtime tracking callback (simplified for Step 1)
+	void _on_signal_fired(Node *p_emitter, const String &p_signal);
+	void _on_signal_emitted(Node *p_emitter, const String &p_signal, Object *p_target, const String &p_method);
+	void _on_test_signal(); // Test handler for investigating remote node access
+	void _on_refresh_pressed();
+	void _on_make_floating_pressed(); // Toggle floating window
+	void _on_inspect_selected_button_pressed(); // Inspect currently selected remote node
+	void _on_search_changed(const String &p_text);
+	void _on_connection_color_changed(const Color &p_color); // Connection color picker changed
+	void _on_settings_pressed(); // Open settings dialog
+	void _on_pulse_duration_changed(double p_value); // Handle pulse duration spinbox change
+	void _on_verbosity_changed(int p_level); // Handle verbosity dropdown change
+	void _on_open_function_button_pressed(ObjectID p_node_id, const String &p_method_name); // Open script to function
+	void _update_node_emits_label(ObjectID p_node_id); // Update the "Emits" label with signal counts
+	void _update_node_receives_label(ObjectID p_node_id); // Update the "Receives" label with method counts
+	void _update_connection_labels();
+
+	// Per-node inspection methods
+	void _inspect_selected_editor_node(); // Inspect selected node in editor (game not running)
+	void _inspect_selected_remote_node(ScriptEditorDebugger *debugger); // Inspect selected node in remote tree (game running)
+	void _inspect_remote_node(ObjectID p_node_id, const String &p_node_path); // Request signal data for a node
+	void _clear_inspection(); // Clear current inspection and graph
+	void _on_node_inspected_in_remote_tree(ObjectID p_node_id, const String &p_node_path); // Called by inspector plugin when node is inspected
+
+	void _build_graph_for_single_node(Node *p_node); // Build graph for a single node in editor mode
+	void _on_remote_object_selected_in_tree(const Array &p_object_ids); // Called when node is clicked in remote tree
+
+	// Inspector plugin instance
+	SignalizeInspectorPlugin *inspector_plugin = nullptr;
+
+	// STEP 1: Handle play mode changes to rebuild graph with remote nodes
+	void _on_play_pressed();
+	void _on_stop_pressed();
+	void _on_play_mode_changed(bool p_is_playing);
+	void _on_remote_tree_updated(); // Called when remote scene tree changes
+
+	// STEP 1: Debugger message capture handler - receives signal emissions from game
+	static Error _capture_signal_viewer_messages(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
+
+	// Message constants
+	static const String MESSAGE_SIGNAL_EMITTED;
+	static const String MESSAGE_NODE_SIGNAL_DATA;
+
+	// Destructor to ensure we clean up tracking
+	~SignalizeDock();
+
+	void _notification(int p_what); // Handle theme changes to update icon
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("_on_play_mode_changed", "is_playing"), &SignalizeDock::_on_play_mode_changed);
+		ClassDB::bind_method(D_METHOD("_on_refresh_pressed"), &SignalizeDock::_on_refresh_pressed);
+		ClassDB::bind_method(D_METHOD("_on_make_floating_pressed"), &SignalizeDock::_on_make_floating_pressed);
+		ClassDB::bind_method(D_METHOD("_on_search_changed", "text"), &SignalizeDock::_on_search_changed);
+		ClassDB::bind_method(D_METHOD("_on_connection_color_changed", "color"), &SignalizeDock::_on_connection_color_changed);
+		ClassDB::bind_method(D_METHOD("_on_settings_pressed"), &SignalizeDock::_on_settings_pressed);
+		ClassDB::bind_method(D_METHOD("_on_pulse_duration_changed", "value"), &SignalizeDock::_on_pulse_duration_changed);
+		ClassDB::bind_method(D_METHOD("_on_verbosity_changed", "level"), &SignalizeDock::_on_verbosity_changed);
+		ClassDB::bind_method(D_METHOD("_on_signal_fired", "emitter", "signal"), &SignalizeDock::_on_signal_fired);
+		ClassDB::bind_method(D_METHOD("_on_signal_emitted", "emitter", "signal", "target", "method"), &SignalizeDock::_on_signal_emitted);
+		ClassDB::bind_method(D_METHOD("_on_test_signal"), &SignalizeDock::_on_test_signal);
+		ClassDB::bind_method(D_METHOD("_on_remote_tree_updated"), &SignalizeDock::_on_remote_tree_updated);
+		ClassDB::bind_method(D_METHOD("_on_remote_object_selected_in_tree", "object_ids"), &SignalizeDock::_on_remote_object_selected_in_tree);
+		ClassDB::bind_method(D_METHOD("_create_visual_connections"), &SignalizeDock::_create_visual_connections);
+		ClassDB::bind_method(D_METHOD("_fade_connection_highlight", "connection_key"), &SignalizeDock::_fade_connection_highlight);
+	}
+
+public:
+	// Singleton accessor for receiving runtime signal updates
+	static SignalizeDock *get_singleton() { return singleton_instance; }
+
+	// Set reference to the bottom panel button (for updating icon/badge if needed)
+	void set_tool_button(Button *p_button) { tool_button = p_button; }
+
+	// Called when a runtime signal is emitted from the game process
+	void _on_runtime_signal_emitted(ObjectID p_emitter_id, const String &p_node_name, const String &p_node_class, const String &p_signal_name, int p_count, const Array &p_connections);
+
+	// Called when signal data is received from game process (made public for ScriptEditorDebugger)
+	void _on_node_signal_data_received(const Array &p_data);
+
+	SignalizeDock();
+};
+
+#include "editor/inspector/editor_inspector.h"
+
+// Inspector plugin to detect when nodes are inspected in the Remote tree
+// This allows us to automatically show signal data when user double-clicks a node
+class SignalizeInspectorPlugin : public EditorInspectorPlugin {
+	GDCLASS(SignalizeInspectorPlugin, EditorInspectorPlugin);
+
+private:
+	SignalizeDock *signal_viewer_dock = nullptr;
+
+public:
+	void set_signal_viewer_dock(SignalizeDock *p_dock) {
+		signal_viewer_dock = p_dock;
+	}
+
+	// This is called when any object is inspected in the editor (including Remote tree)
+	virtual bool can_handle(Object *p_object) override {
+		if (!signal_viewer_dock) {
+			return false;
+		}
+
+		// Only handle Node objects
+		Node *node = Object::cast_to<Node>(p_object);
+		if (!node) {
+			return false;
+		}
+
+		// Check if this node has a "Node/path" property (indicates it's from Remote tree)
+		// Actually, let's just handle ALL nodes and check in parse_begin
+		return true;
+	}
+
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override {
+		// We don't want to modify property display, just detect when a node is being inspected
+		return false;
+	}
+
+	// Called when parsing of an object begins (node is being inspected)
+	virtual void parse_begin(Object *p_object) override {
+		if (!signal_viewer_dock || !p_object) {
+			return;
+		}
+
+		Node *node = Object::cast_to<Node>(p_object);
+		if (!node) {
+			return;
+		}
+
+		// Get node info
+		ObjectID node_id = node->get_instance_id();
+		NodePath node_path_obj = node->get_path();
+		String node_path = node_path_obj.operator String();
+		String node_name = node->get_name();
+
+		// Log inspector update (level 2 - Normal) with shortened path
+		if (signal_viewer_dock->should_log(2)) {
+			// Strip editor UI hierarchy, show only scene path
+			String short_path = node_path;
+			if (node_path.contains("/@EditorNode@")) {
+				// Extract just the scene portion after @SubViewport@
+				int subview_idx = node_path.find("/@SubViewport@");
+				if (subview_idx != -1) {
+					short_path = node_path.substr(subview_idx + 15); // Skip "/@SubViewport@"
+				}
+			}
+			print_line(vformat("[Signalize Inspector] Node inspected: %s (path: %s)", node_name, short_path));
+		}
+
+		// Notify the dock to inspect this node
+		signal_viewer_dock->_on_node_inspected_in_remote_tree(node_id, node_path);
+	}
+
+protected:
+	static void _bind_methods() {}
+};

--- a/editor/docks/signalize_dock.h
+++ b/editor/docks/signalize_dock.h
@@ -125,6 +125,7 @@ private:
 
 	void _build_graph();
 	void _collect_all_nodes(Node *p_node, List<Node *> &r_list);
+	void _find_script_connections(Node *p_node, const HashMap<ObjectID, Node *> &p_node_lookup, HashMap<ObjectID, bool> &r_final_nodes);
 	bool _node_has_connections(Node *p_node);
 	void _create_graph_node(Node *p_node, int p_depth, int p_index);
 	Color _get_editor_node_icon_color(Node *p_node); // Get actual icon color from editor

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -179,6 +179,7 @@ public:
 	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
 
 	void edit_resource(const Ref<Resource> &p_resource);
+	void edit_script_method(Script *script, const StringName &method_name);
 	void edit_node(Node *p_node);
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);
 	void open_scene_from_path(const String &scene_path, bool p_set_inherited = false);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -179,7 +179,7 @@ public:
 	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
 
 	void edit_resource(const Ref<Resource> &p_resource);
-	void edit_script_method(Script *script, const StringName &method_name);
+	void edit_script_method(Script *p_script, const StringName &p_method_name);
 	void edit_node(Node *p_node);
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);
 	void open_scene_from_path(const String &scene_path, bool p_set_inherited = false);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -208,6 +208,8 @@
 #include "editor/gui/touch_actions_panel.h"
 #endif // ANDROID_ENABLED
 
+#include "docks/signalize_dock.h"
+
 #include <cstdlib>
 
 EditorNode *EditorNode::singleton = nullptr;
@@ -8447,6 +8449,12 @@ EditorNode::EditorNode() {
 	bottom_panel = memnew(EditorBottomPanel);
 	center_split->add_child(bottom_panel);
 	center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
+
+	// Signalize
+	SignalizeDock *signalize_dock = memnew(SignalizeDock);
+	Ref<Shortcut> signalize_shortcut = ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_signalize_bottom_panel", TTRC("Toggle Signalize Bottom Panel"), KeyModifierMask::ALT | Key::S);
+	Button *signalize_button = bottom_panel->add_item(TTR("Signalize"), signalize_dock, signalize_shortcut);
+	signalize_dock->set_tool_button(signalize_button);
 
 	log = memnew(EditorLog);
 	Button *output_button = bottom_panel->add_item(TTRC("Output"), log, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_output_bottom_panel", TTRC("Toggle Output Bottom Panel"), KeyModifierMask::ALT | Key::O));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8452,7 +8452,7 @@ EditorNode::EditorNode() {
 
 	// Signalize
 	SignalizeDock *signalize_dock = memnew(SignalizeDock);
-	Ref<Shortcut> signalize_shortcut = ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_signalize_bottom_panel", TTRC("Toggle Signalize Bottom Panel"), KeyModifierMask::ALT | Key::S);
+	Ref<Shortcut> signalize_shortcut = ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_signalize_bottom_panel", TTRC("Toggle Signalize Bottom Panel"), KeyModifierMask::ALT | Key::I);
 	Button *signalize_button = bottom_panel->add_item(TTR("Signalize"), signalize_dock, signalize_shortcut);
 	signalize_dock->set_tool_button(signalize_button);
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -63,6 +63,7 @@
 #include "editor/import/3d/resource_importer_obj.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
+#include "docks/signalize_dock.h"
 #ifndef DISABLE_DEPRECATED
 #include "editor/import/resource_importer_animated_texture.h"
 #endif
@@ -146,6 +147,7 @@
 #include "editor/scene/3d/skeleton_ik_3d_editor_plugin.h"
 #endif
 
+
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");
 
@@ -153,7 +155,6 @@ void register_editor_types() {
 	ResourceSaver::set_timestamp_on_save(true);
 
 	EditorStringNames::create();
-
 	GDREGISTER_CLASS(EditorPaths);
 	GDREGISTER_CLASS(EditorPlugin);
 	GDREGISTER_CLASS(EditorTranslationParserPlugin);
@@ -272,6 +273,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
 	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
+
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 #endif

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -39,7 +39,6 @@
 #include "register_editor_types.h"
 
 #include "core/object/script_language.h"
-#include "docks/signalize_dock.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/audio/audio_stream_editor_plugin.h"
 #include "editor/audio/audio_stream_randomizer_editor_plugin.h"

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -39,6 +39,7 @@
 #include "register_editor_types.h"
 
 #include "core/object/script_language.h"
+#include "docks/signalize_dock.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/audio/audio_stream_editor_plugin.h"
 #include "editor/audio/audio_stream_randomizer_editor_plugin.h"
@@ -63,7 +64,6 @@
 #include "editor/import/3d/resource_importer_obj.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
-#include "docks/signalize_dock.h"
 #ifndef DISABLE_DEPRECATED
 #include "editor/import/resource_importer_animated_texture.h"
 #endif
@@ -146,7 +146,6 @@
 #include "editor/scene/2d/parallax_background_editor_plugin.h"
 #include "editor/scene/3d/skeleton_ik_3d_editor_plugin.h"
 #endif
-
 
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("Editor", "Register Types");

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -58,6 +58,9 @@ class ConnectionInfoDialog : public AcceptDialog {
 
 public:
 	void popup_connections(const String &p_method, const Vector<Node *> &p_nodes);
+	// Public wrappers for editor plugins / modules
+	void open_script_tab(Script *script);
+	void jump_to_method(Script *script, const StringName &method_name);
 
 	ConnectionInfoDialog();
 };

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -3066,7 +3066,7 @@ void SceneDebugger::_signal_viewer_emission_callback(Object *p_emitter, const St
 
 	// Skip common editor UI classes (though these shouldn't appear in gameplay)
 	if (node_class.contains("Editor") || node_class.contains("MenuBar") ||
-		node_class.contains("Window") || node_class.contains("Popup")) {
+			node_class.contains("Window") || node_class.contains("Popup")) {
 		return;
 	}
 
@@ -3151,7 +3151,7 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data(const Array &p_args) {
 	String node_path = p_args[1];
 
 	print_line(vformat("[Signal Viewer Game] Requesting signal data for node: %s (ID: %s)",
-		node_path, String::num_uint64((uint64_t)node_id)));
+			node_path, String::num_uint64((uint64_t)node_id)));
 
 	// Get the SignalViewerRuntime singleton
 	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -3188,8 +3188,15 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data_by_path(const Array &p
 		return ERR_UNAVAILABLE;
 	}
 
-	// Get the node from the scene tree
-	Node *node = scene_tree->get_current_scene()->get_node(node_path);
+	// Get the current scene and validate it exists
+	Node *current_scene = scene_tree->get_current_scene();
+	if (!current_scene) {
+		print_line("[Signal Viewer Game] ERROR: No current scene");
+		return ERR_UNAVAILABLE;
+	}
+
+	// Get the node from the scene tree using get_node_or_null for safety
+	Node *node = current_scene->get_node_or_null(node_path);
 	if (!node) {
 		print_line(vformat("[Signal Viewer Game] ERROR: Node not found at path: %s", node_path_str));
 		return ERR_UNAVAILABLE;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -566,9 +566,10 @@ void SceneDebugger::_init_message_handlers() {
 #endif
 	message_handlers["rq_screenshot"] = _msg_rq_screenshot;
 
-	// STEP 1: Signal Viewer - Register signal tracking message handlers
+	// Signal Viewer - Register signal tracking message handlers
 	message_handlers["signal_viewer:start_tracking"] = _msg_signal_viewer_start_tracking;
 	message_handlers["signal_viewer:stop_tracking"] = _msg_signal_viewer_stop_tracking;
+	message_handlers["signal_viewer:set_verbosity"] = _msg_signal_viewer_set_verbosity;
 	message_handlers["signal_viewer:request_node_data"] = _msg_signal_viewer_request_node_data;
 	message_handlers["signal_viewer:request_node_data_by_path"] = _msg_signal_viewer_request_node_data_by_path;
 	// Note: When sent from ScriptEditorDebugger with "scene:" prefix, it gets stripped to just "signal_viewer_request_node_data"
@@ -3040,7 +3041,7 @@ void RuntimeNodeSelect::_reset_camera_3d() {
 }
 #endif // _3D_DISABLED
 
-// STEP 1: Signal Viewer - Implementation
+// Signal Viewer - Implementation
 
 // Static member initialization
 bool SceneDebugger::signal_viewer_tracking_enabled = false;
@@ -3097,23 +3098,21 @@ void SceneDebugger::_signal_viewer_emission_callback(Object *p_emitter, const St
 
 // Message handler: Start tracking signals
 Error SceneDebugger::_msg_signal_viewer_start_tracking(const Array &p_args) {
-	print_line("[Signal Viewer Game] _msg_signal_viewer_start_tracking called!");
-
 	if (signal_viewer_tracking_enabled) {
-		print_line("[Signal Viewer Game] Already enabled, skipping");
 		return OK; // Already enabled
 	}
 
 	// Create or get the SignalViewerRuntime singleton
-	print_line("[Signal Viewer Game] Creating SignalViewerRuntime singleton...");
 	SignalViewerRuntime *runtime = SignalViewerRuntime::create_singleton();
 	if (runtime) {
-		print_line("[Signal Viewer Game] Starting tracking...");
+		// Extract verbosity level from arguments if provided
+		int verbosity = 0; // Default to silent
+		if (p_args.size() > 0) {
+			verbosity = p_args[0];
+		}
+		runtime->set_verbosity(verbosity);
 		runtime->start_tracking();
 		signal_viewer_tracking_enabled = true;
-		print_line("[Signal Viewer Game] Signal tracking enabled");
-	} else {
-		print_line("[Signal Viewer Game] ERROR: Failed to create SignalViewerRuntime!");
 	}
 
 	return OK;
@@ -3127,22 +3126,45 @@ Error SceneDebugger::_msg_signal_viewer_stop_tracking(const Array &p_args) {
 
 	// Stop tracking via SignalViewerRuntime
 	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
+	if (runtime && runtime->should_log(2)) {
+		print_line("[Signal Viewer Game] Signal tracking disabled");
+	}
 	if (runtime) {
 		runtime->stop_tracking();
 	}
 	signal_viewer_tracking_enabled = false;
 
-	print_line("[Signal Viewer Game] Signal tracking disabled");
+	return OK;
+}
+
+// Message handler: Set verbosity level
+Error SceneDebugger::_msg_signal_viewer_set_verbosity(const Array &p_args) {
+	if (p_args.size() < 1) {
+		return ERR_INVALID_PARAMETER;
+	}
+
+	// Get the SignalViewerRuntime singleton
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
+	if (!runtime) {
+		return ERR_UNAVAILABLE;
+	}
+
+	// Set the verbosity level
+	int verbosity = p_args[0];
+	runtime->set_verbosity(verbosity);
 
 	return OK;
 }
 
 // Message handler: Request signal data for a specific node
 Error SceneDebugger::_msg_signal_viewer_request_node_data(const Array &p_args) {
-	print_line("[Signal Viewer Game] _msg_signal_viewer_request_node_data called!");
+	// Get the SignalViewerRuntime singleton to check verbosity
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
 
 	if (p_args.size() < 2) {
-		print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_id and node_path");
+		if (runtime && runtime->should_log(1)) {
+			print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_id and node_path");
+		}
 		return ERR_INVALID_PARAMETER;
 	}
 
@@ -3150,11 +3172,11 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data(const Array &p_args) {
 	ObjectID node_id = p_args[0];
 	String node_path = p_args[1];
 
-	print_line(vformat("[Signal Viewer Game] Requesting signal data for node: %s (ID: %s)",
-			node_path, String::num_uint64((uint64_t)node_id)));
+	if (runtime && runtime->should_log(1)) {
+		print_line(vformat("[Signal Viewer Game] Requesting signal data for node: %s (ID: %s)",
+				node_path, String::num_uint64((uint64_t)node_id)));
+	}
 
-	// Get the SignalViewerRuntime singleton
-	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
 	if (!runtime) {
 		print_line("[Signal Viewer Game] ERROR: SignalViewerRuntime not initialized");
 		return ERR_UNAVAILABLE;
@@ -3168,10 +3190,13 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data(const Array &p_args) {
 
 // Message handler: Request signal data for a node by path
 Error SceneDebugger::_msg_signal_viewer_request_node_data_by_path(const Array &p_args) {
-	print_line("[Signal Viewer Game] _msg_signal_viewer_request_node_data_by_path called!");
+	// Get the SignalViewerRuntime singleton to check verbosity
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
 
 	if (p_args.size() < 1) {
-		print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_path");
+		if (runtime && runtime->should_log(1)) {
+			print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_path");
+		}
 		return ERR_INVALID_PARAMETER;
 	}
 
@@ -3179,7 +3204,9 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data_by_path(const Array &p
 	String node_path_str = p_args[0];
 	NodePath node_path = NodePath(node_path_str);
 
-	print_line(vformat("[Signal Viewer Game] Requesting signal data for node path: %s", node_path_str));
+	if (runtime && runtime->should_log(1)) {
+		print_line(vformat("[Signal Viewer Game] Requesting signal data for node path: %s", node_path_str));
+	}
 
 	// Get the scene tree
 	SceneTree *scene_tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
@@ -3203,10 +3230,10 @@ Error SceneDebugger::_msg_signal_viewer_request_node_data_by_path(const Array &p
 	}
 
 	ObjectID node_id = node->get_instance_id();
-	print_line(vformat("[Signal Viewer Game] Found node: %s (ID: %s)", node->get_name(), String::num_uint64((uint64_t)node_id)));
+	if (runtime && runtime->should_log(1)) {
+		print_line(vformat("[Signal Viewer Game] Found node: %s (ID: %s)", node->get_name(), String::num_uint64((uint64_t)node_id)));
+	}
 
-	// Get the SignalViewerRuntime singleton
-	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
 	if (!runtime) {
 		print_line("[Signal Viewer Game] ERROR: SignalViewerRuntime not initialized");
 		return ERR_UNAVAILABLE;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -37,6 +37,7 @@
  */
 
 #include "scene_debugger.h"
+#include "signal_viewer_runtime.h"
 
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
@@ -564,6 +565,14 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["runtime_node_select_reset_camera_3d"] = _msg_runtime_node_select_reset_camera_3d;
 #endif
 	message_handlers["rq_screenshot"] = _msg_rq_screenshot;
+
+	// STEP 1: Signal Viewer - Register signal tracking message handlers
+	message_handlers["signal_viewer:start_tracking"] = _msg_signal_viewer_start_tracking;
+	message_handlers["signal_viewer:stop_tracking"] = _msg_signal_viewer_stop_tracking;
+	message_handlers["signal_viewer:request_node_data"] = _msg_signal_viewer_request_node_data;
+	message_handlers["signal_viewer:request_node_data_by_path"] = _msg_signal_viewer_request_node_data_by_path;
+	// Note: When sent from ScriptEditorDebugger with "scene:" prefix, it gets stripped to just "signal_viewer_request_node_data"
+	message_handlers["signal_viewer_request_node_data"] = _msg_signal_viewer_request_node_data;
 }
 
 void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
@@ -3030,5 +3039,176 @@ void RuntimeNodeSelect::_reset_camera_3d() {
 	SceneTree::get_singleton()->get_root()->set_camera_3d_override_perspective(camera_fov * cursor.fov_scale, camera_znear, camera_zfar);
 }
 #endif // _3D_DISABLED
+
+// STEP 1: Signal Viewer - Implementation
+
+// Static member initialization
+bool SceneDebugger::signal_viewer_tracking_enabled = false;
+
+// Signal emission callback - called by Object::emit_signal() when tracking is enabled
+void SceneDebugger::_signal_viewer_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount) {
+	// Only track Node objects
+	Node *emitter_node = Object::cast_to<Node>(p_emitter);
+	if (!emitter_node) {
+		return; // Not a node, skip
+	}
+
+	// Check if this signal has connections
+	List<Object::Connection> conns;
+	p_emitter->get_signal_connection_list(p_signal, &conns);
+	if (conns.is_empty()) {
+		return; // No connections, skip
+	}
+
+	// Filter out editor UI noise
+	String node_class = emitter_node->get_class();
+	String node_name = emitter_node->get_name();
+
+	// Skip common editor UI classes (though these shouldn't appear in gameplay)
+	if (node_class.contains("Editor") || node_class.contains("MenuBar") ||
+		node_class.contains("Window") || node_class.contains("Popup")) {
+		return;
+	}
+
+	// Build message with signal emission data
+	Array msg_data;
+	msg_data.append(emitter_node->get_instance_id());
+	msg_data.append(node_name);
+	msg_data.append(node_class);
+	msg_data.append(String(p_signal));
+
+	// Add connection info
+	Array connections_array;
+	for (const Object::Connection &conn : conns) {
+		Array conn_data;
+		Object *target = conn.callable.get_object();
+		if (target) {
+			conn_data.append(target->get_instance_id());
+			conn_data.append(target->get_class());
+			conn_data.append(String(conn.callable.get_method()));
+			connections_array.append(conn_data);
+		}
+	}
+	msg_data.append(connections_array);
+
+	// Send message back to editor
+	EngineDebugger::get_singleton()->send_message("signal_viewer:signal_emitted", msg_data);
+}
+
+// Message handler: Start tracking signals
+Error SceneDebugger::_msg_signal_viewer_start_tracking(const Array &p_args) {
+	print_line("[Signal Viewer Game] _msg_signal_viewer_start_tracking called!");
+
+	if (signal_viewer_tracking_enabled) {
+		print_line("[Signal Viewer Game] Already enabled, skipping");
+		return OK; // Already enabled
+	}
+
+	// Create or get the SignalViewerRuntime singleton
+	print_line("[Signal Viewer Game] Creating SignalViewerRuntime singleton...");
+	SignalViewerRuntime *runtime = SignalViewerRuntime::create_singleton();
+	if (runtime) {
+		print_line("[Signal Viewer Game] Starting tracking...");
+		runtime->start_tracking();
+		signal_viewer_tracking_enabled = true;
+		print_line("[Signal Viewer Game] Signal tracking enabled");
+	} else {
+		print_line("[Signal Viewer Game] ERROR: Failed to create SignalViewerRuntime!");
+	}
+
+	return OK;
+}
+
+// Message handler: Stop tracking signals
+Error SceneDebugger::_msg_signal_viewer_stop_tracking(const Array &p_args) {
+	if (!signal_viewer_tracking_enabled) {
+		return OK; // Already disabled
+	}
+
+	// Stop tracking via SignalViewerRuntime
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
+	if (runtime) {
+		runtime->stop_tracking();
+	}
+	signal_viewer_tracking_enabled = false;
+
+	print_line("[Signal Viewer Game] Signal tracking disabled");
+
+	return OK;
+}
+
+// Message handler: Request signal data for a specific node
+Error SceneDebugger::_msg_signal_viewer_request_node_data(const Array &p_args) {
+	print_line("[Signal Viewer Game] _msg_signal_viewer_request_node_data called!");
+
+	if (p_args.size() < 2) {
+		print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_id and node_path");
+		return ERR_INVALID_PARAMETER;
+	}
+
+	// Parse arguments
+	ObjectID node_id = p_args[0];
+	String node_path = p_args[1];
+
+	print_line(vformat("[Signal Viewer Game] Requesting signal data for node: %s (ID: %s)",
+		node_path, String::num_uint64((uint64_t)node_id)));
+
+	// Get the SignalViewerRuntime singleton
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
+	if (!runtime) {
+		print_line("[Signal Viewer Game] ERROR: SignalViewerRuntime not initialized");
+		return ERR_UNAVAILABLE;
+	}
+
+	// Send signal data for this node
+	runtime->send_node_signal_data(node_id);
+
+	return OK;
+}
+
+// Message handler: Request signal data for a node by path
+Error SceneDebugger::_msg_signal_viewer_request_node_data_by_path(const Array &p_args) {
+	print_line("[Signal Viewer Game] _msg_signal_viewer_request_node_data_by_path called!");
+
+	if (p_args.size() < 1) {
+		print_line("[Signal Viewer Game] ERROR: Invalid arguments, expected node_path");
+		return ERR_INVALID_PARAMETER;
+	}
+
+	// Parse arguments
+	String node_path_str = p_args[0];
+	NodePath node_path = NodePath(node_path_str);
+
+	print_line(vformat("[Signal Viewer Game] Requesting signal data for node path: %s", node_path_str));
+
+	// Get the scene tree
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+	if (!scene_tree) {
+		print_line("[Signal Viewer Game] ERROR: No SceneTree");
+		return ERR_UNAVAILABLE;
+	}
+
+	// Get the node from the scene tree
+	Node *node = scene_tree->get_current_scene()->get_node(node_path);
+	if (!node) {
+		print_line(vformat("[Signal Viewer Game] ERROR: Node not found at path: %s", node_path_str));
+		return ERR_UNAVAILABLE;
+	}
+
+	ObjectID node_id = node->get_instance_id();
+	print_line(vformat("[Signal Viewer Game] Found node: %s (ID: %s)", node->get_name(), String::num_uint64((uint64_t)node_id)));
+
+	// Get the SignalViewerRuntime singleton
+	SignalViewerRuntime *runtime = SignalViewerRuntime::get_singleton();
+	if (!runtime) {
+		print_line("[Signal Viewer Game] ERROR: SignalViewerRuntime not initialized");
+		return ERR_UNAVAILABLE;
+	}
+
+	// Send signal data for this node
+	runtime->send_node_signal_data(node_id);
+
+	return OK;
+}
 
 #endif // DEBUG_ENABLED

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -132,7 +132,7 @@ private:
 #endif
 	static Error _msg_rq_screenshot(const Array &p_args);
 
-	// STEP 1: Signal Viewer - Track signal emissions during gameplay
+	// Signal Viewer: Track signal emissions during gameplay
 	static Error _msg_signal_viewer_start_tracking(const Array &p_args);
 	static Error _msg_signal_viewer_stop_tracking(const Array &p_args);
 	static Error _msg_signal_viewer_request_node_data(const Array &p_args);

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -135,6 +135,7 @@ private:
 	// Signal Viewer: Track signal emissions during gameplay
 	static Error _msg_signal_viewer_start_tracking(const Array &p_args);
 	static Error _msg_signal_viewer_stop_tracking(const Array &p_args);
+	static Error _msg_signal_viewer_set_verbosity(const Array &p_args);
 	static Error _msg_signal_viewer_request_node_data(const Array &p_args);
 	static Error _msg_signal_viewer_request_node_data_by_path(const Array &p_args);
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -132,6 +132,15 @@ private:
 #endif
 	static Error _msg_rq_screenshot(const Array &p_args);
 
+	// STEP 1: Signal Viewer - Track signal emissions during gameplay
+	static Error _msg_signal_viewer_start_tracking(const Array &p_args);
+	static Error _msg_signal_viewer_stop_tracking(const Array &p_args);
+	static Error _msg_signal_viewer_request_node_data(const Array &p_args);
+	static Error _msg_signal_viewer_request_node_data_by_path(const Array &p_args);
+
+	static bool signal_viewer_tracking_enabled;
+	static void _signal_viewer_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount);
+
 public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
 	static void add_to_cache(const String &p_filename, Node *p_node);

--- a/scene/debugger/signal_viewer_runtime.cpp
+++ b/scene/debugger/signal_viewer_runtime.cpp
@@ -266,10 +266,10 @@ void SignalViewerRuntime::_send_batch_updates() {
 
 		String node_name = node->get_name();
 		String node_class = node->get_class();
-		Array connections = signal_connections.has(key) ? signal_connections[key] : Array();
+		Array conns = signal_connections.has(key) ? signal_connections[key] : Array();
 
 		// Send the update with accumulated count
-		_send_signal_update(key, emitter_id, node_name, node_class, signal_name, count, connections);
+		_send_signal_update(key, emitter_id, node_name, node_class, signal_name, count, conns);
 	}
 
 	// Clear all counts after sending

--- a/scene/debugger/signal_viewer_runtime.cpp
+++ b/scene/debugger/signal_viewer_runtime.cpp
@@ -26,8 +26,8 @@
 /* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
 /* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
 /* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
-/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
-/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
 #include "signal_viewer_runtime.h"
@@ -105,9 +105,7 @@ void SignalViewerRuntime::_signal_emission_callback(Object *p_emitter, const Str
 
 	// Filter out internal engine noise - gizmo timers, skeleton pose updates, etc.
 	// Skip timer signals (unless they're user-created gameplay timers)
-	if (signal_name == "timeout" && (
-		node_name.contains("Gizmo") || node_name.contains("Update") ||
-		node_name.contains("Timer") && node_class.contains("Editor"))) {
+	if (signal_name == "timeout" && (node_name.contains("Gizmo") || node_name.contains("Update") || node_name.contains("Timer") && node_class.contains("Editor"))) {
 		return; // Skip editor gizmo/update timers
 	}
 
@@ -123,23 +121,23 @@ void SignalViewerRuntime::_signal_emission_callback(Object *p_emitter, const Str
 
 	// Filter out Skeleton3D and PhysicalBone completely
 	if (node_class == "Skeleton3D" || node_class == "Skeleton3D3D" ||
-		node_class == "PhysicalBone" || node_class == "PhysicalBoneSimulator3D") {
+			node_class == "PhysicalBone" || node_class == "PhysicalBoneSimulator3D") {
 		return;
 	}
 
 	// Additional filtering by class name for robustness
 	// Skip all common GUI/Control classes and editor internals
 	if (node_class == "VScrollBar" || node_class == "HScrollBar" ||
-		node_class == "ScrollBar" || node_class == "RichTextLabel" ||
-		node_class == "Label" || node_class == "Button" ||
-		node_class == "LineEdit" || node_class == "TextEdit" ||
-		node_class == "Panel" || node_class == "Popup" ||
-		node_class == "Window" || node_class == "Dialog" ||
-		node_class.contains("Editor") || node_class.contains("Gizmo") ||
-		node_class.contains("Menu") || node_class.contains("Theme") ||
-		node_class.contains("StyleBox") || node_class.contains("Tree") ||
-		node_class.contains("ItemList") || node_class.contains("Option") ||
-		node_class.contains("Check")) {
+			node_class == "ScrollBar" || node_class == "RichTextLabel" ||
+			node_class == "Label" || node_class == "Button" ||
+			node_class == "LineEdit" || node_class == "TextEdit" ||
+			node_class == "Panel" || node_class == "Popup" ||
+			node_class == "Window" || node_class == "Dialog" ||
+			node_class.contains("Editor") || node_class.contains("Gizmo") ||
+			node_class.contains("Menu") || node_class.contains("Theme") ||
+			node_class.contains("StyleBox") || node_class.contains("Tree") ||
+			node_class.contains("ItemList") || node_class.contains("Option") ||
+			node_class.contains("Check")) {
 		return;
 	}
 
@@ -354,7 +352,7 @@ void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
 		signal_data_array.append(sig_info);
 
 		print_line(vformat("[Signal Viewer Runtime] Signal: %s (count: %d, connections: %d)",
-			signal_name, count, connections_array.size()));
+				signal_name, count, connections_array.size()));
 	}
 
 	// Send the data back to editor

--- a/scene/debugger/signal_viewer_runtime.cpp
+++ b/scene/debugger/signal_viewer_runtime.cpp
@@ -1,0 +1,384 @@
+/**************************************************************************/
+/*  signal_viewer_runtime.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2024-present Redot Engine contributors                   */
+/*                                          (see REDOT_AUTHORS.md)        */
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/**************************************************************************/
+
+#include "signal_viewer_runtime.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "core/os/os.h"
+#include "scene/gui/control.h"
+#include "scene/main/node.h"
+
+#ifdef DEBUG_ENABLED
+
+// Static member initialization
+SignalViewerRuntime *SignalViewerRuntime::singleton = nullptr;
+
+SignalViewerRuntime *SignalViewerRuntime::create_singleton() {
+	if (singleton) {
+		return singleton; // Already exists
+	}
+	singleton = memnew(SignalViewerRuntime);
+	return singleton;
+}
+
+void SignalViewerRuntime::destroy_singleton() {
+	if (singleton) {
+		memdelete(singleton);
+		singleton = nullptr;
+	}
+}
+
+SignalViewerRuntime::SignalViewerRuntime() {
+	// Don't set singleton here - use create_singleton() instead
+}
+
+SignalViewerRuntime::~SignalViewerRuntime() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+	if (tracking_enabled) {
+		stop_tracking();
+	}
+}
+
+void SignalViewerRuntime::_signal_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount) {
+	// Only track Node objects
+	Node *emitter_node = Object::cast_to<Node>(p_emitter);
+	if (!emitter_node) {
+		return; // Not a node, skip
+	}
+
+	// Check if this signal has connections
+	List<Object::Connection> conns;
+	p_emitter->get_signal_connection_list(p_signal, &conns);
+	if (conns.is_empty()) {
+		return; // No connections, skip this signal
+	}
+
+	// Get the singleton and check if we should track this
+	SignalViewerRuntime *runtime = get_singleton();
+	if (!runtime || !runtime->tracking_enabled) {
+		return;
+	}
+
+	String node_class = emitter_node->get_class();
+	String node_name = emitter_node->get_name();
+	String signal_name = String(p_signal);
+
+	// NOTE: Control node filter disabled to support signal showcases/demos
+	// In production games, you may want to re-enable this to reduce UI noise
+	// FILTER OUT ALL GUI/CONTROL CLASSES - Only track gameplay nodes
+	// Skip all Control-derived classes (GUI elements) - check both by cast and by name
+	// Control *as_control = Object::cast_to<Control>(emitter_node);
+	// if (as_control) {
+	// 	return; // Skip ALL Control nodes
+	// }
+
+	// Filter out internal engine noise - gizmo timers, skeleton pose updates, etc.
+	// Skip timer signals (unless they're user-created gameplay timers)
+	if (signal_name == "timeout" && (
+		node_name.contains("Gizmo") || node_name.contains("Update") ||
+		node_name.contains("Timer") && node_class.contains("Editor"))) {
+		return; // Skip editor gizmo/update timers
+	}
+
+	// Skip skeleton pose updates (fire every frame during animation)
+	if (signal_name == "pose_updated" || signal_name == "skeleton_updated") {
+		return; // Skip internal animation updates
+	}
+
+	// Skip bone list changes (skeleton animation system noise)
+	if (signal_name == "bone_list_changed") {
+		return;
+	}
+
+	// Filter out Skeleton3D and PhysicalBone completely
+	if (node_class == "Skeleton3D" || node_class == "Skeleton3D3D" ||
+		node_class == "PhysicalBone" || node_class == "PhysicalBoneSimulator3D") {
+		return;
+	}
+
+	// Additional filtering by class name for robustness
+	// Skip all common GUI/Control classes and editor internals
+	if (node_class == "VScrollBar" || node_class == "HScrollBar" ||
+		node_class == "ScrollBar" || node_class == "RichTextLabel" ||
+		node_class == "Label" || node_class == "Button" ||
+		node_class == "LineEdit" || node_class == "TextEdit" ||
+		node_class == "Panel" || node_class == "Popup" ||
+		node_class == "Window" || node_class == "Dialog" ||
+		node_class.contains("Editor") || node_class.contains("Gizmo") ||
+		node_class.contains("Menu") || node_class.contains("Theme") ||
+		node_class.contains("StyleBox") || node_class.contains("Tree") ||
+		node_class.contains("ItemList") || node_class.contains("Option") ||
+		node_class.contains("Check")) {
+		return;
+	}
+
+	// DEBUG: Only print after filtering (much less spam)
+	print_line(vformat("[Signal Viewer Runtime] Tracking: %s.%s", node_name, signal_name));
+
+	// Create a unique key for this signal
+	String key = vformat("%s:%s", emitter_node->get_instance_id(), signal_name);
+
+	// Increment the emission count
+	if (!runtime->signal_emission_counts.has(key)) {
+		runtime->signal_emission_counts[key] = 0;
+
+		// First time seeing this signal - collect and store connection info
+		Array connections_array;
+		for (const Object::Connection &conn : conns) {
+			Array conn_data;
+			Object *target = conn.callable.get_object();
+			if (target) {
+				conn_data.append(target->get_instance_id());
+
+				// Get the target node's name if it's a Node, otherwise use class
+				Node *target_node = Object::cast_to<Node>(target);
+				if (target_node) {
+					conn_data.append(target_node->get_name()); // Use actual node name
+					conn_data.append(target_node->get_class());
+				} else {
+					conn_data.append(target->get_class()); // Use class as name for non-Node objects
+					conn_data.append(target->get_class());
+				}
+
+				conn_data.append(String(conn.callable.get_method()));
+				connections_array.append(conn_data);
+			}
+		}
+		runtime->signal_connections[key] = connections_array;
+	}
+	runtime->signal_emission_counts[key]++;
+
+	// Get current time
+	uint64_t current_time = OS::get_singleton()->get_ticks_msec();
+
+	// Check if we should send an update (rate limiting)
+	bool should_send = false;
+	if (!runtime->signal_last_sent_time.has(key)) {
+		// First time seeing this signal - send immediately
+		should_send = true;
+	} else {
+		uint64_t last_sent = runtime->signal_last_sent_time[key];
+		if (current_time - last_sent >= RATE_LIMIT_MS) {
+			should_send = true;
+		}
+	}
+
+	// Also check if we need to do a batch update
+	if (current_time - runtime->last_batch_update_time >= BATCH_UPDATE_INTERVAL_MS) {
+		runtime->_send_batch_updates();
+		runtime->last_batch_update_time = current_time;
+	}
+
+	// Send update if rate limit allows
+	if (should_send) {
+		int count = runtime->signal_emission_counts[key];
+		Array connections = runtime->signal_connections.has(key) ? runtime->signal_connections[key] : Array();
+		runtime->_send_signal_update(key, emitter_node->get_instance_id(), node_name, node_class, signal_name, count, connections);
+		runtime->signal_last_sent_time[key] = current_time;
+		runtime->signal_emission_counts[key] = 0; // Reset count after sending
+	}
+}
+
+void SignalViewerRuntime::_send_signal_update(const String &p_key, ObjectID p_emitter_id, const String &p_node_name, const String &p_node_class, const String &p_signal_name, int p_count, const Array &p_connections) {
+	// Build message with signal emission data
+	Array msg_data;
+	msg_data.append(p_emitter_id);
+	msg_data.append(p_node_name);
+	msg_data.append(p_node_class);
+	msg_data.append(p_signal_name);
+	msg_data.append(p_count);
+	msg_data.append(p_connections); // Add connection info
+
+	// Send message back to editor via EngineDebugger
+	EngineDebugger *ed = EngineDebugger::get_singleton();
+	if (ed) {
+		print_line(vformat("[Signal Viewer Runtime] Sending update: %s.%s (count: %d, connections: %d)", p_node_name, p_signal_name, p_count, p_connections.size()));
+		ed->send_message("signal_viewer:signal_emitted", msg_data);
+	}
+}
+
+void SignalViewerRuntime::_send_batch_updates() {
+	// Send all accumulated signals that haven't been sent recently
+	EngineDebugger *ed = EngineDebugger::get_singleton();
+	if (!ed || signal_emission_counts.is_empty()) {
+		return;
+	}
+
+	print_line(vformat("[Signal Viewer Runtime] Sending batch updates for %d signals", signal_emission_counts.size()));
+
+	// Note: We'll send updates for signals that have counts but haven't been sent recently
+	// For simplicity, we just reset all counts here. A more sophisticated approach would
+	// send all pending counts in a single message.
+	signal_emission_counts.clear();
+}
+
+void SignalViewerRuntime::start_tracking() {
+	if (tracking_enabled) {
+		return; // Already tracking
+	}
+
+	// Register the signal emission callback with Object class
+	Object::set_signal_emission_callback(_signal_emission_callback);
+	tracking_enabled = true;
+
+	print_line("[Signal Viewer Runtime] Signal tracking enabled");
+}
+
+void SignalViewerRuntime::stop_tracking() {
+	if (!tracking_enabled) {
+		return; // Already not tracking
+	}
+
+	// Unregister the callback
+	Object::set_signal_emission_callback(nullptr);
+	tracking_enabled = false;
+
+	print_line("[Signal Viewer Runtime] Signal tracking disabled");
+}
+
+void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
+	// Get the node from ObjectDB
+	Object *obj = ObjectDB::get_instance(p_node_id);
+	if (!obj) {
+		print_line(vformat("[Signal Viewer Runtime] Node not found: %s", String::num_uint64((uint64_t)p_node_id)));
+		return;
+	}
+
+	Node *node = Object::cast_to<Node>(obj);
+	if (!node) {
+		print_line("[Signal Viewer Runtime] Object is not a Node");
+		return;
+	}
+
+	// Get node info
+	String node_name = node->get_name();
+	String node_class = node->get_class();
+
+	print_line(vformat("[Signal Viewer Runtime] Collecting signal data for: %s (%s)", node_name, node_class));
+
+	// Collect all signal data for this node
+	Array signal_data_array;
+
+	// Get all signals from this node
+	List<MethodInfo> signals;
+	node->get_signal_list(&signals);
+
+	for (const MethodInfo &sig : signals) {
+		String signal_name = sig.name;
+
+		// Get connections for this signal
+		List<Object::Connection> conns;
+		node->get_signal_connection_list(StringName(signal_name), &conns);
+
+		if (conns.is_empty()) {
+			continue; // Skip signals without connections
+		}
+
+		// Build connection data
+		Array connections_array;
+		for (const Object::Connection &conn : conns) {
+			Object *target_obj = conn.callable.get_object();
+			if (!target_obj) {
+				continue;
+			}
+
+			ObjectID target_id = target_obj->get_instance_id();
+			String target_name;
+			String target_class;
+
+			// Get target node info
+			Node *target_node = Object::cast_to<Node>(target_obj);
+			if (target_node) {
+				target_name = target_node->get_name();
+				target_class = target_node->get_class();
+			} else {
+				target_name = target_obj->get_class();
+				target_class = target_obj->get_class();
+			}
+
+			String target_method = conn.callable.get_method();
+
+			// Build connection data array: [target_id, target_name, target_class, target_method]
+			Array conn_data;
+			conn_data.append(target_id);
+			conn_data.append(target_name);
+			conn_data.append(target_class);
+			conn_data.append(target_method);
+			connections_array.append(conn_data);
+		}
+
+		// Check if we have tracking data for this signal
+		String key = vformat("%s:%s", String::num_uint64((uint64_t)p_node_id), signal_name);
+		int count = 0;
+		if (signal_emission_counts.has(key)) {
+			count = signal_emission_counts[key];
+		}
+
+		// Build signal info array: [signal_name, count, connections_array]
+		Array sig_info;
+		sig_info.append(signal_name);
+		sig_info.append(count);
+		sig_info.append(connections_array);
+
+		signal_data_array.append(sig_info);
+
+		print_line(vformat("[Signal Viewer Runtime] Signal: %s (count: %d, connections: %d)",
+			signal_name, count, connections_array.size()));
+	}
+
+	// Send the data back to editor
+	// Format: [node_id, node_name, node_class, signal_data_array]
+	Array msg_data;
+	msg_data.append(p_node_id);
+	msg_data.append(node_name);
+	msg_data.append(node_class);
+	msg_data.append(signal_data_array);
+
+	EngineDebugger *ed = EngineDebugger::get_singleton();
+	if (ed) {
+		print_line(vformat("[Signal Viewer Runtime] Sending signal data: %s (%s)", node_name, node_class));
+		ed->send_message("signal_viewer:node_signal_data", msg_data);
+	} else {
+		print_line("[Signal Viewer Runtime] No EngineDebugger - cannot send signal data");
+	}
+}
+
+void SignalViewerRuntime::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start_tracking"), &SignalViewerRuntime::start_tracking);
+	ClassDB::bind_method(D_METHOD("stop_tracking"), &SignalViewerRuntime::stop_tracking);
+	ClassDB::bind_method(D_METHOD("is_tracking_enabled"), &SignalViewerRuntime::is_tracking_enabled);
+	ClassDB::bind_method(D_METHOD("send_node_signal_data", "node_id"), &SignalViewerRuntime::send_node_signal_data);
+}
+
+#endif // DEBUG_ENABLED

--- a/scene/debugger/signal_viewer_runtime.cpp
+++ b/scene/debugger/signal_viewer_runtime.cpp
@@ -94,15 +94,6 @@ void SignalViewerRuntime::_signal_emission_callback(Object *p_emitter, const Str
 	String node_name = emitter_node->get_name();
 	String signal_name = String(p_signal);
 
-	// NOTE: Control node filter disabled to support signal showcases/demos
-	// In production games, you may want to re-enable this to reduce UI noise
-	// FILTER OUT ALL GUI/CONTROL CLASSES - Only track gameplay nodes
-	// Skip all Control-derived classes (GUI elements) - check both by cast and by name
-	// Control *as_control = Object::cast_to<Control>(emitter_node);
-	// if (as_control) {
-	// 	return; // Skip ALL Control nodes
-	// }
-
 	// Filter out internal engine noise - gizmo timers, skeleton pose updates, etc.
 	// Skip timer signals (unless they're user-created gameplay timers)
 	if (signal_name == "timeout" && (node_name.contains("Gizmo") || node_name.contains("Update") || (node_name.contains("Timer") && node_class.contains("Editor")))) {
@@ -141,8 +132,9 @@ void SignalViewerRuntime::_signal_emission_callback(Object *p_emitter, const Str
 		return;
 	}
 
-	// DEBUG: Only print after filtering (much less spam)
-	print_line(vformat("[Signal Viewer Runtime] Tracking: %s.%s", node_name, signal_name));
+	if (runtime->should_log(3)) { // Verbose
+		print_line(vformat("[Signal Viewer Runtime] Tracking: %s.%s", node_name, signal_name));
+	}
 
 	// Create a unique key for this signal
 	String key = vformat("%s:%s", emitter_node->get_instance_id(), signal_name);
@@ -221,7 +213,9 @@ void SignalViewerRuntime::_send_signal_update(const String &p_key, ObjectID p_em
 	// Send message back to editor via EngineDebugger
 	EngineDebugger *ed = EngineDebugger::get_singleton();
 	if (ed) {
-		print_line(vformat("[Signal Viewer Runtime] Sending update: %s.%s (count: %d, connections: %d)", p_node_name, p_signal_name, p_count, p_connections.size()));
+		if (should_log(3)) { // Verbose
+			print_line(vformat("[Signal Viewer Runtime] Sending update: %s.%s (count: %d, connections: %d)", p_node_name, p_signal_name, p_count, p_connections.size()));
+		}
 		ed->send_message("signal_viewer:signal_emitted", msg_data);
 	}
 }
@@ -233,7 +227,9 @@ void SignalViewerRuntime::_send_batch_updates() {
 		return;
 	}
 
-	print_line(vformat("[Signal Viewer Runtime] Sending batch updates for %d signals", signal_emission_counts.size()));
+	if (should_log(3)) { // Verbose
+		print_line(vformat("[Signal Viewer Runtime] Sending batch updates for %d signals", signal_emission_counts.size()));
+	}
 
 	// Iterate over all accumulated signal counts and send updates
 	for (const KeyValue<String, int> &E : signal_emission_counts) {
@@ -255,7 +251,9 @@ void SignalViewerRuntime::_send_batch_updates() {
 		Object *obj = ObjectDB::get_instance(emitter_id);
 		if (!obj) {
 			// Node was deleted, skip this entry
-			print_line(vformat("[Signal Viewer Runtime] Skipping deleted node (ID: %s)", object_id_str));
+			if (should_log(3)) { // Verbose
+				print_line(vformat("[Signal Viewer Runtime] Skipping deleted node (ID: %s)", object_id_str));
+			}
 			continue;
 		}
 
@@ -285,7 +283,9 @@ void SignalViewerRuntime::start_tracking() {
 	Object::set_signal_emission_callback(_signal_emission_callback);
 	tracking_enabled = true;
 
-	print_line("[Signal Viewer Runtime] Signal tracking enabled");
+	if (should_log(2)) { // Normal
+		print_line("[Signal Viewer Runtime] Signal tracking enabled");
+	}
 }
 
 void SignalViewerRuntime::stop_tracking() {
@@ -297,7 +297,9 @@ void SignalViewerRuntime::stop_tracking() {
 	Object::set_signal_emission_callback(nullptr);
 	tracking_enabled = false;
 
-	print_line("[Signal Viewer Runtime] Signal tracking disabled");
+	if (should_log(2)) { // Normal
+		print_line("[Signal Viewer Runtime] Signal tracking disabled");
+	}
 }
 
 void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
@@ -318,7 +320,9 @@ void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
 	String node_name = node->get_name();
 	String node_class = node->get_class();
 
-	print_line(vformat("[Signal Viewer Runtime] Collecting signal data for: %s (%s)", node_name, node_class));
+	if (should_log(1)) { // Quiet
+		print_line(vformat("[Signal Viewer Runtime] Collecting signal data for: %s (%s)", node_name, node_class));
+	}
 
 	// Collect all signal data for this node
 	Array signal_data_array;
@@ -386,8 +390,10 @@ void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
 
 		signal_data_array.append(sig_info);
 
-		print_line(vformat("[Signal Viewer Runtime] Signal: %s (count: %d, connections: %d)",
-				signal_name, count, connections_array.size()));
+		if (should_log(3)) { // Verbose
+			print_line(vformat("[Signal Viewer Runtime] Signal: %s (count: %d, connections: %d)",
+					signal_name, count, connections_array.size()));
+		}
 	}
 
 	// Send the data back to editor
@@ -400,9 +406,12 @@ void SignalViewerRuntime::send_node_signal_data(ObjectID p_node_id) {
 
 	EngineDebugger *ed = EngineDebugger::get_singleton();
 	if (ed) {
-		print_line(vformat("[Signal Viewer Runtime] Sending signal data: %s (%s)", node_name, node_class));
+		if (should_log(1)) { // Quiet
+			print_line(vformat("[Signal Viewer Runtime] Sending signal data: %s (%s)", node_name, node_class));
+		}
 		ed->send_message("signal_viewer:node_signal_data", msg_data);
 	} else {
+		// Always show errors
 		print_line("[Signal Viewer Runtime] No EngineDebugger - cannot send signal data");
 	}
 }
@@ -411,6 +420,8 @@ void SignalViewerRuntime::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start_tracking"), &SignalViewerRuntime::start_tracking);
 	ClassDB::bind_method(D_METHOD("stop_tracking"), &SignalViewerRuntime::stop_tracking);
 	ClassDB::bind_method(D_METHOD("is_tracking_enabled"), &SignalViewerRuntime::is_tracking_enabled);
+	ClassDB::bind_method(D_METHOD("set_verbosity", "level"), &SignalViewerRuntime::set_verbosity);
+	ClassDB::bind_method(D_METHOD("get_verbosity"), &SignalViewerRuntime::get_verbosity);
 	ClassDB::bind_method(D_METHOD("send_node_signal_data", "node_id"), &SignalViewerRuntime::send_node_signal_data);
 }
 

--- a/scene/debugger/signal_viewer_runtime.h
+++ b/scene/debugger/signal_viewer_runtime.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  signal_viewer_runtime.h                                            */
+/*  signal_viewer_runtime.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             REDOT ENGINE                               */
@@ -19,14 +19,14 @@
 /* the following conditions:                                              */
 /*                                                                        */
 /* The above copyright notice and this permission notice shall be         */
-/* included in all copies or substantial portions of the Software.                 */
+/* included in all copies or substantial portions of the Software.        */
 /*                                                                        */
 /* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
-/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
 /* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
 /* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
 /* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
-/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
@@ -34,8 +34,8 @@
 
 #include "core/object/class_db.h"
 #include "core/object/object.h"
-#include "core/templates/hash_set.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
 
 class SignalViewerRuntime : public Object {
 	GDCLASS(SignalViewerRuntime, Object);

--- a/scene/debugger/signal_viewer_runtime.h
+++ b/scene/debugger/signal_viewer_runtime.h
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  signal_viewer_runtime.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             REDOT ENGINE                               */
+/*                        https://redotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2024-present Redot Engine contributors                   */
+/*                                          (see REDOT_AUTHORS.md)        */
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.                 */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/templates/hash_set.h"
+#include "core/templates/hash_map.h"
+
+class SignalViewerRuntime : public Object {
+	GDCLASS(SignalViewerRuntime, Object);
+
+private:
+	static SignalViewerRuntime *singleton;
+	bool tracking_enabled = false;
+
+	// Track which nodes we're monitoring to avoid duplicate messages
+	HashSet<ObjectID> monitored_nodes;
+
+	// Track signal emission counts and last sent time for rate limiting
+	// Key: "emitter_id:signal_name" -> count
+	HashMap<String, int> signal_emission_counts;
+	// Key: "emitter_id:signal_name" -> last sent timestamp (uint64_t)
+	HashMap<String, uint64_t> signal_last_sent_time;
+	// Key: "emitter_id:signal_name" -> connections_array (targets and methods)
+	HashMap<String, Array> signal_connections;
+
+	// Minimum time between sending messages for the same signal (in milliseconds)
+	static const uint64_t RATE_LIMIT_MS = 1000; // 1 second
+
+	// Timer for periodic batch updates
+	uint64_t last_batch_update_time = 0;
+	static const uint64_t BATCH_UPDATE_INTERVAL_MS = 2000; // Send batch updates every 2 seconds
+
+	// Signal emission callback - called by Object::emit_signal() in the game process
+	static void _signal_emission_callback(Object *p_emitter, const StringName &p_signal, const Variant **p_args, int p_argcount);
+
+	// Send accumulated signal counts to editor
+	void _send_signal_update(const String &p_key, ObjectID p_emitter_id, const String &p_node_name, const String &p_node_class, const String &p_signal_name, int p_count, const Array &p_connections);
+
+	// Send all accumulated signals as a batch update
+	void _send_batch_updates();
+
+public:
+	SignalViewerRuntime();
+	~SignalViewerRuntime();
+
+	static SignalViewerRuntime *get_singleton() { return singleton; }
+
+	// Create and set the singleton (for use by SceneDebugger)
+	static SignalViewerRuntime *create_singleton();
+
+	// Destroy the singleton
+	static void destroy_singleton();
+
+	// Start tracking signal emissions
+	void start_tracking();
+
+	// Stop tracking signal emissions
+	void stop_tracking();
+
+	// Check if tracking is enabled
+	bool is_tracking_enabled() const { return tracking_enabled; }
+
+	// Handle request for node signal data (per-node inspection)
+	// Made public so SceneDebugger can call it
+	void send_node_signal_data(ObjectID p_node_id);
+
+protected:
+	static void _bind_methods();
+};

--- a/scene/debugger/signal_viewer_runtime.h
+++ b/scene/debugger/signal_viewer_runtime.h
@@ -44,6 +44,9 @@ private:
 	static SignalViewerRuntime *singleton;
 	bool tracking_enabled = false;
 
+	// Verbosity control: 0=Silent, 1=Quiet, 2=Normal, 3=Verbose
+	int verbosity_level = 0;
+
 	// Track which nodes we're monitoring to avoid duplicate messages
 	HashSet<ObjectID> monitored_nodes;
 
@@ -91,6 +94,15 @@ public:
 
 	// Check if tracking is enabled
 	bool is_tracking_enabled() const { return tracking_enabled; }
+
+	// Set verbosity level (0=Silent, 1=Quiet, 2=Normal, 3=Verbose)
+	void set_verbosity(int p_level) { verbosity_level = CLAMP(p_level, 0, 3); }
+
+	// Get current verbosity level
+	int get_verbosity() const { return verbosity_level; }
+
+	// Helper to check if we should log at a given verbosity level
+	bool should_log(int p_level) const { return verbosity_level >= p_level; }
 
 	// Handle request for node signal data (per-node inspection)
 	// Made public so SceneDebugger can call it

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -52,6 +52,7 @@
 #include "scene/animation/tween.h"
 #include "scene/audio/audio_stream_player.h"
 #include "scene/debugger/scene_debugger.h"
+#include "scene/debugger/signal_viewer_runtime.h"
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -475,6 +476,10 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CanvasModulate);
 	GDREGISTER_CLASS(ResourcePreloader);
 	GDREGISTER_CLASS(Window);
+
+#ifdef DEBUG_ENABLED
+	GDREGISTER_CLASS(SignalViewerRuntime);
+#endif
 
 	GDREGISTER_CLASS(StatusIndicator);
 


### PR DESCRIPTION
This PR adds SIgnalize, a visual tool for viewing and understanding signal connections between nodes in your Redot scenes.

  Key Features:

  1. Visual Graph View - Displays nodes as a graph showing which nodes emit signals and which receive them, with connection lines between them
  2. Editor Mode: Works when editing scenes in the editor (not playing):
    - Shows static signal connections defined in your scene
    - Can refresh/rebuild the graph with the "Build Graph" button
  3. Runtime Mode: Works while the game is running:
    - Tracks signal emissions in real-time
    - Shows which signals are actually being fired
    - Can inspect individual nodes from the remote tree
  4. Features:
    - Search/Filter: Filter which nodes to display
    - Customization: Change connection line colors
    - Floating Window: Can detach from editor as a floating window
    - Verbosity Control: Adjust how much logging is shown
    - Per-Node Inspection: Click a node in the remote tree to see its specific signals

  Use Cases:

  - Debugging complex signal flows in your scene
  - Understanding which nodes are connected to which
  - Identifying unused or redundant signals
  - Learning how existing scenes are wired together
  
  

https://github.com/user-attachments/assets/9f12327e-c483-454f-a9b1-eb5a0ae04de4





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal emission tracking (DEBUG): start/stop tracking, per-node signal data, emission counts, rate-limited updates, and connection details.
  * New "Signalize" editor panel (ALT+I) with real-time signal graph, node inspection, search, and script navigation.
  * Editor and debugger integrations to surface runtime signal data and navigate to related scripts.

* **Refactor**
  * Unified messaging so runtime signal data is forwarded consistently to the editor.

* **Documentation**
  * Added documentation for the SignalViewerRuntime API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->