### PR TITLE
Cache StringNames & NodePaths

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -46,7 +47,11 @@ namespace Godot
     {
         internal godot_node_path.movable NativeValue;
 
-        private WeakReference<IDisposable>? _weakReferenceToSelf;
+        private readonly WeakReference<IDisposable>? _weakReferenceToSelf;
+
+        private static readonly ConcurrentDictionary<string, WeakReference<IDisposable>> _nodePathCache = new();
+        private readonly string? _inputString;
+        private readonly string? _outputString;
 
         ~NodePath()
         {
@@ -64,10 +69,16 @@ namespace Godot
 
         public void Dispose(bool disposing)
         {
+            // Remove from cache
+            if (_inputString is not null && _weakReferenceToSelf is not null)
+            {
+                _nodePathCache.TryRemove(new(_inputString, _weakReferenceToSelf));
+            }
+
             // Always dispose `NativeValue` even if disposing is true
             NativeValue.DangerousSelfRef.Dispose();
 
-            if (_weakReferenceToSelf != null)
+            if (_weakReferenceToSelf is not null)
             {
                 DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
             }
@@ -77,6 +88,15 @@ namespace Godot
         {
             NativeValue = (godot_node_path.movable)nativeValueToOwn;
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+            // Store input string (string passed to constructor)
+            _inputString = null;
+            // Store output string (string outputted by ToString())
+            NativeFuncs.godotsharp_node_path_as_string(out godot_string asNativeString, nativeValueToOwn);
+            using (asNativeString)
+            {
+                _outputString = Marshaling.ConvertStringToManaged(asNativeString);
+            }
         }
 
         // Explicit name to make it very clear
@@ -88,6 +108,10 @@ namespace Godot
         /// </summary>
         public NodePath()
         {
+            // Store input string (used to create NodePath)
+            _inputString = string.Empty;
+            // Store output string (outputted by ToString())
+            _outputString = string.Empty;
         }
 
         /// <summary>
@@ -121,25 +145,63 @@ namespace Godot
         /// <param name="path">A string that represents a path in a scene tree.</param>
         public NodePath(string path)
         {
-            if (!string.IsNullOrEmpty(path))
+            if (path is not null)
             {
                 NativeValue = (godot_node_path.movable)NativeFuncs.godotsharp_node_path_new_from_string(path);
                 _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+                // Store input string (used to create NodePath)
+                _inputString = path;
+                // Store output string (outputted by ToString())
+                // (Must convert to native value; NodePaths can simplify)
+                var src = (godot_node_path)NativeValue;
+                NativeFuncs.godotsharp_node_path_as_string(out godot_string asNativeString, src);
+                using (asNativeString)
+                {
+                    _outputString = Marshaling.ConvertStringToManaged(asNativeString);
+                }
             }
         }
 
         /// <summary>
-        /// Converts a string to a <see cref="NodePath"/>.
+        /// Converts a <see cref="string"/> to a <see cref="NodePath"/>.<br/>
+        /// The resulting <see cref="NodePath"/> is temporarily cached for future casts.
         /// </summary>
         /// <param name="from">The string to convert.</param>
-        public static implicit operator NodePath(string from) => new NodePath(from);
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator NodePath?(string? from)
+        {
+            if (from is null)
+                return null;
+
+            // Try get NodePath from cache
+            if (_nodePathCache.TryGetValue(from, out WeakReference<IDisposable>? cachedNodePathWeakReference))
+            {
+                if (cachedNodePathWeakReference.TryGetTarget(out IDisposable? cachedNodePath))
+                {
+                    return (NodePath)cachedNodePath;
+                }
+            }
+
+            // Create new NodePath
+            var nodePath = new NodePath(from);
+            // Add new NodePath to cache
+            if (nodePath._weakReferenceToSelf is not null)
+            {
+                _nodePathCache.TryAdd(from, nodePath._weakReferenceToSelf);
+            }
+            return nodePath;
+        }
 
         /// <summary>
-        /// Converts this <see cref="NodePath"/> to a string.
+        /// Converts a <see cref="NodePath"/> to a <see cref="string"/>.
         /// </summary>
         /// <param name="from">The <see cref="NodePath"/> to convert.</param>
-        [return: NotNullIfNotNull("from")]
-        public static implicit operator string?(NodePath? from) => from?.ToString();
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator string?(NodePath? from)
+        {
+            return from?.ToString();
+        }
 
         /// <summary>
         /// Converts this <see cref="NodePath"/> to a string.
@@ -147,13 +209,7 @@ namespace Godot
         /// <returns>A string representation of this <see cref="NodePath"/>.</returns>
         public override string ToString()
         {
-            if (IsEmpty)
-                return string.Empty;
-
-            var src = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_as_string(out godot_string dest, src);
-            using (dest)
-                return Marshaling.ConvertStringToManaged(dest);
+            return _outputString ?? string.Empty;
         }
 
         /// <summary>
@@ -337,6 +393,21 @@ namespace Godot
             var self = (godot_node_path)NativeValue;
             var otherNative = (godot_node_path)other.NativeValue;
             return NativeFuncs.godotsharp_node_path_equals(self, otherNative).ToBool();
+        }
+
+        public bool Equals([NotNullWhen(true)] string? other)
+        {
+            if (other is null)
+                return false;
+
+            // Compare native node paths
+            // (Must convert to native value; NodePaths can simplify)
+            var asNativeNodePath = (godot_node_path)NativeValue;
+            var otherAsNativeNodePath = NativeFuncs.godotsharp_node_path_new_from_string(other);
+            using (otherAsNativeNodePath)
+            {
+                return NativeFuncs.godotsharp_node_path_equals(asNativeNodePath, otherAsNativeNodePath).ToBool();
+            }
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -17,7 +18,11 @@ namespace Godot
     {
         internal godot_string_name.movable NativeValue;
 
-        private WeakReference<IDisposable>? _weakReferenceToSelf;
+        private readonly WeakReference<IDisposable>? _weakReferenceToSelf;
+
+        private static readonly ConcurrentDictionary<string, WeakReference<IDisposable>> _stringNameCache = new();
+        private readonly string? _inputString;
+        private readonly string? _outputString;
 
         ~StringName()
         {
@@ -35,10 +40,16 @@ namespace Godot
 
         public void Dispose(bool disposing)
         {
+            // Remove from cache
+            if (_inputString is not null && _weakReferenceToSelf is not null)
+            {
+                _stringNameCache.TryRemove(new(_inputString, _weakReferenceToSelf));
+            }
+
             // Always dispose `NativeValue` even if disposing is true
             NativeValue.DangerousSelfRef.Dispose();
 
-            if (_weakReferenceToSelf != null)
+            if (_weakReferenceToSelf is not null)
             {
                 DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
             }
@@ -48,6 +59,15 @@ namespace Godot
         {
             NativeValue = (godot_string_name.movable)nativeValueToOwn;
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+            // Store input string (string passed to constructor)
+            _inputString = null;
+            // Store output string (string outputted by ToString())
+            NativeFuncs.godotsharp_string_name_as_string(out godot_string asNativeString, nativeValueToOwn);
+            using (asNativeString)
+            {
+                _outputString = Marshaling.ConvertStringToManaged(asNativeString);
+            }
         }
 
         // Explicit name to make it very clear
@@ -59,6 +79,10 @@ namespace Godot
         /// </summary>
         public StringName()
         {
+            // Store input string (used to create this StringName)
+            _inputString = string.Empty;
+            // Store output string (outputted by ToString())
+            _outputString = string.Empty;
         }
 
         /// <summary>
@@ -67,25 +91,58 @@ namespace Godot
         /// <param name="name">String to construct the <see cref="StringName"/> from.</param>
         public StringName(string name)
         {
-            if (!string.IsNullOrEmpty(name))
+            if (name is not null)
             {
                 NativeValue = (godot_string_name.movable)NativeFuncs.godotsharp_string_name_new_from_string(name);
                 _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+                // Store input string (used to create this StringName)
+                _inputString = name;
+                // Store output string (string outputted by ToString())
+                // (No need to convert native value; StringNames can never change or simplify)
+                _outputString = name;
             }
         }
 
         /// <summary>
-        /// Converts a string to a <see cref="StringName"/>.
+        /// Converts a <see cref="string"/> to a <see cref="StringName"/>.<br/>
+        /// The resulting <see cref="StringName"/> is temporarily cached for future casts.
         /// </summary>
         /// <param name="from">The string to convert.</param>
-        public static implicit operator StringName(string from) => new StringName(from);
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator StringName?(string? from)
+        {
+            if (from is null)
+                return null;
+
+            // Try get StringName from cache
+            if (_stringNameCache.TryGetValue(from, out WeakReference<IDisposable>? cachedStringNameWeakReference))
+            {
+                if (cachedStringNameWeakReference.TryGetTarget(out IDisposable? cachedStringName))
+                {
+                    return (StringName)cachedStringName;
+                }
+            }
+
+            // Create new StringName
+            var stringName = new StringName(from);
+            // Add new StringName to cache
+            if (stringName._weakReferenceToSelf is not null)
+            {
+                _stringNameCache.TryAdd(from, stringName._weakReferenceToSelf);
+            }
+            return stringName;
+        }
 
         /// <summary>
-        /// Converts a <see cref="StringName"/> to a string.
+        /// Converts a <see cref="StringName"/> to a <see cref="string"/>.
         /// </summary>
         /// <param name="from">The <see cref="StringName"/> to convert.</param>
-        [return: NotNullIfNotNull("from")]
-        public static implicit operator string?(StringName? from) => from?.ToString();
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator string?(StringName? from)
+        {
+            return from?.ToString();
+        }
 
         /// <summary>
         /// Converts this <see cref="StringName"/> to a string.
@@ -93,13 +150,7 @@ namespace Godot
         /// <returns>A string representation of this <see cref="StringName"/>.</returns>
         public override string ToString()
         {
-            if (IsEmpty)
-                return string.Empty;
-
-            var src = (godot_string_name)NativeValue;
-            NativeFuncs.godotsharp_string_name_as_string(out godot_string dest, src);
-            using (dest)
-                return Marshaling.ConvertStringToManaged(dest);
+            return _outputString ?? string.Empty;
         }
 
         /// <summary>
@@ -125,6 +176,16 @@ namespace Godot
             if (other is null)
                 return false;
             return NativeValue.DangerousSelfRef == other.NativeValue.DangerousSelfRef;
+        }
+
+        public bool Equals([NotNullWhen(true)] string? other)
+        {
+            if (other is null)
+                return false;
+
+            // Compare output string (string outputted by ToString())
+            // (No need to convert native value; StringNames can never change or simplify)
+            return _outputString == other;
         }
 
         public static bool operator ==(StringName? left, in godot_string_name right)


### PR DESCRIPTION
Cherry-picked from my [pull request in godotengine/godot](https://github.com/godotengine/godot/pull/100452) at the [request](https://github.com/Redot-Engine/redot-proposals/discussions/50#discussioncomment-15596574) of @Arctis-Fireblight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string comparison methods to NodePath and StringName, enabling direct equality checks with string values.

* **Refactor**
  * Optimized string conversion performance for NodePath and StringName objects through improved internal handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->