### PR TITLE
GH-1176 Fix Resize off by 1 Error

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -969,7 +969,7 @@ TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vec
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t decomp_size = decomp.size() + 1;
+	size_t decomp_size = decomp.size();
 	ret.resize(decomp_size);
 
 	for (size_t i = 0; i < decomp_size; ++i) {
@@ -983,7 +983,7 @@ TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -997,7 +997,7 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1011,7 +1011,7 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vecto
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1025,7 +1025,7 @@ TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1039,7 +1039,7 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vect
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1053,7 +1053,7 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1067,7 +1067,7 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polygon(const Vector<Vector2> 
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1081,7 +1081,7 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polyline(const Vector<Vector2>
 
 	TypedArray<PackedVector2Array> ret;
 
-	size_t polys_size = polys.size() + 1;
+	size_t polys_size = polys.size();
 	ret.resize(polys_size);
 
 	for (size_t i = 0; i < polys_size; ++i) {
@@ -1094,7 +1094,7 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
 	Vector<Size2i> rects;
-	size_t p_rects_size = p_rects.size() + 1;
+	size_t p_rects_size = p_rects.size();
 	rects.resize(p_rects_size);
 
 	for (size_t i = 0; i < p_rects_size; i++) {
@@ -1107,7 +1107,7 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	::Geometry2D::make_atlas(rects, result, size);
 
 	Vector<Point2> r_result;
-	size_t result_size = result.size() + 1;
+	size_t result_size = result.size();
 	r_result.resize(result_size);
 
 	for (size_t i = 0; i < result_size; i++) {
@@ -1124,9 +1124,10 @@ TypedArray<Point2i> Geometry2D::bresenham_line(const Point2i &p_from, const Poin
 	Vector<Point2i> points = ::Geometry2D::bresenham_line(p_from, p_to);
 
 	TypedArray<Point2i> result;
-	result.resize(points.size());
+	size_t points_size = points.size();
+	result.resize(points_size);
 
-	for (int i = 0; i < points.size(); i++) {
+	for (size_t i = 0; i < points_size; i++) {
 		result[i] = points[i];
 	}
 


### PR DESCRIPTION
Fixes #1176 By changing a 1 to a 0

<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/f6fb707d-d479-4990-ab09-ac131e643eb5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved off-by-one sizing errors in polygon and geometry operations, improving accuracy and preventing potential edge case errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->