### PR TITLE
GH-1178 Remove Singleton Pattern in Skeleton3D Editor 

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -201,6 +201,7 @@ void BonePropertiesEditor::_show_add_meta_dialog() {
 		add_child(add_meta_dialog);
 	}
 
+	ERR_FAIL_NULL(skeleton_editor);
 	int bone = skeleton_editor->get_selected_bone();
 	StringName dialog_title = skeleton->get_bone_name(bone);
 
@@ -210,6 +211,7 @@ void BonePropertiesEditor::_show_add_meta_dialog() {
 }
 
 void BonePropertiesEditor::_add_meta_confirm() {
+	ERR_FAIL_NULL(skeleton_editor);
 	int bone = skeleton_editor->get_selected_bone();
 	String name = add_meta_dialog->get_meta_name();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -288,7 +290,7 @@ void BonePropertiesEditor::_property_keyed(const String &p_path, bool p_advance)
 }
 
 void BonePropertiesEditor::_update_properties() {
-	if (!skeleton) {
+	if (!skeleton || !skeleton_editor) {
 		return;
 	}
 	int selected = skeleton_editor->get_selected_bone();
@@ -1164,6 +1166,9 @@ void Skeleton3DEditor::_notification(int p_what) {
 			update_joint_tree();
 		} break;
 		case NOTIFICATION_PREDELETE: {
+			if (editor_plugin) {
+				editor_plugin->skeleton_editor = nullptr;
+			}
 			if (skeleton) {
 				select_bone(-1); // Requires that the joint_tree has not been deleted.
 				_disconnect_from_skeleton();

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -246,6 +246,7 @@ class EditorInspectorPluginSkeleton : public EditorInspectorPlugin {
 
 	friend class Skeleton3DEditorPlugin;
 	friend class Skeleton3DGizmoPlugin;
+	friend class Skeleton3DEditor;
 
 	Skeleton3DEditor *skeleton_editor = nullptr;
 


### PR DESCRIPTION
Fixes #1178 But inadvertently introduces delay

- Removes erroneous singleton pattern in Skeleton3D editor where it should not be used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Editor internals switched to per-instance editor contexts for each 3D skeleton editor, improving stability and isolation.

* **Bug Fixes / UX**
  * More reliable bone selection, pose/property panels, gizmo interactions, and undo/redo behavior across multiple open skeleton editors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->