### PR TITLE
Fixed addons being unable to read project settings #1180

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -277,6 +277,9 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream, 
 	String assign;
 	Variant value;
 	VariantParser::Tag next_tag;
+	if (p_path.to_lower().ends_with("project.godot")) {
+		p_allow_objects = true;
+	}
 
 	int lines = 0;
 	String error_text;


### PR DESCRIPTION
PR #1142 fixes a remote code execution vulnerability by disallowing deserialization of objects by default. The PR correctly bypasses the security measure when loading project settings from `project.godot`, but some addons also store their configuration settings in there as well, and are not aware of this security feature and thus the call will generate an error. This commit adds a check to determine if we are trying to access a project file, and if so, to allow for deserialization of raw objects which is needed for reading project settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration parsing for .godot project files so object data is correctly recognized and loaded during file parsing, improving compatibility and preventing missing or misinterpreted project settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->