### PR TITLE
Setup CI to pull the class DB from the engine

### DIFF
--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -1,7 +1,6 @@
 name: Trigger Sync Class Reference
 
 on:
-  workflow_dispatch:
   pull_request:
     paths:
       - 'doc/classes/**'
@@ -11,12 +10,13 @@ on:
 jobs:
   trigger:
     name: Trigger update class reference files based on the engine revision
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - uses: passeidireto/trigger-external-workflow-action@v1.0.0
       env:
         PAYLOAD_AUTHOR: ${{ github.actor }}
       with:
-        repository: 17chuchu/redot-docs-site
+        repository: Redot-Engine/redot-docs-site
         event: sync_class_ref
         github_pat: ${{ secrets.REDOT_DOCS_SITE_PAT }}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
# New Features
Add CI to detect changes from merged pull-request then trigger CI on [redot-docs-site](https://github.com/Redot-Engine/redot-docs-site) to generate class documents. Implemented as part of [this issue](https://github.com/Redot-Engine/redot-docs-site/issues/4)


## Post merge steps

### Generate a Fine-grained personal access tokens
The CI will need a token to access CI on [redot-docs-site](https://github.com/Redot-Engine/redot-docs-site) repo. The token will need to be created by the owner or admins of [redot-docs-site](https://github.com/Redot-Engine/redot-docs-site).

1. Please head to [personal-access-tokens](https://github.com/settings/personal-access-tokens) and click **Generate new token**
2. Configure the token like so. The Token should only have access to Redot-Engine/redot-docs-site.
<img width="1051" height="1030" alt="image" src="https://github.com/user-attachments/assets/cb41247f-bf3a-42c3-8672-5b08ca557965" />
3. Create and copy the token.

### Generate a Fine-grained personal access tokens

1. Navigate to [Redot-Engine/redot-engine Action Secret Setting Page](https://github.com/Redot-Engine/redot-engine/settings/secrets/actions). 
<img width="1903" height="1197" alt="image" src="https://github.com/user-attachments/assets/99b94080-e9a7-404e-b305-38db1c7c9912" />
2. Click "New repository secret"
3. Set the secret name to "REDOT_DOCS_SITE_PAT". Add the copied token into value field. The result should look like this
<img width="996" height="201" alt="image" src="https://github.com/user-attachments/assets/0d9d5013-5c75-427d-8dbe-fe488b296e90" />


The CI should now be able to trigger sync_class_ref  CI on [redot-docs-site](https://github.com/Redot-Engine/redot-docs-site).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated sync: when class documentation changes are merged to the main branch (or a manual sync is triggered), the class reference site is refreshed and the initiating author is recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->