### PR TITLE
Add `pipeline_deffered_rd.h` for the motion blur PR

### DIFF
--- a/servers/rendering/renderer_rd/pipeline_deferred_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_deferred_rd.h
@@ -126,9 +126,9 @@ public:
 
 		if (pipeline.is_valid()) {
 #ifdef DEV_ENABLED
-			ERR_FAIL_COND_MSG(!(RD::get_singleton()->render_pipeline_is_valid(pipeline) || RD::get_singleton()->compute_pipeline_is_valid(pipeline)), "`free()` must be called  manually before the dependent shader is freed.");
+			ERR_FAIL_COND_MSG(!(RD::get_singleton()->render_pipeline_is_valid(pipeline) || RD::get_singleton()->compute_pipeline_is_valid(pipeline)), "`free()` must be called manually before the dependent shader is freed.");
 #endif
-			RD::get_singleton()->free(pipeline);
+			RD::get_singleton()->free_rid(pipeline);
 			pipeline = RID();
 		}
 	}


### PR DESCRIPTION
TL;DR
- Adds `pipeline_deffered_rd.h` for the motion blur PR (#1201)

> [!NOTE]
> Contributed by 2LazyDevs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline creation now runs on background workers and supports both render and compute pipelines.
  * Added a blocking getter and a safe release flow for obtaining and freeing compiled pipelines.
* **Bug Fixes**
  * Improved lifecycle and debug checks to reduce resource leaks and use‑after‑free occurrences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->