### PR TITLE
GH-1199 Fix ColorPicker closing when pressing spacebar

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2415,9 +2415,6 @@ ColorPicker::~ColorPicker() {
 /////////////////
 
 void ColorPickerPopupPanel::_input_from_window(const Ref<InputEvent> &p_event) {
-	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
-		_close_pressed();
-	}
 	PopupPanel::_input_from_window(p_event);
 }
 


### PR DESCRIPTION
Fixes #1199 
Before when you press spacebar it would cause the window to be closed, now spacebar can be used in the popup window.

Pressing escape, or clicking off the colorpicker still works in closing the color picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Color picker popup no longer closes when the accept action is pressed.
  * Popup continues to close as expected when the cancel action is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->