### PR TITLE
Fix various typos listed in godotengine#91521

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -379,7 +379,7 @@ bool operator==(const wchar_t *p_chr, const String &p_str) {
 	// wchar_t is 16-bit
 	return p_str == String::utf16((const char16_t *)p_chr);
 #else
-	// wchar_t is 32-bi
+	// wchar_t is 32-bit
 	return p_str == String((const char32_t *)p_chr);
 #endif
 }
@@ -393,7 +393,7 @@ bool operator!=(const wchar_t *p_chr, const String &p_str) {
 	// wchar_t is 16-bit
 	return !(p_str == String::utf16((const char16_t *)p_chr));
 #else
-	// wchar_t is 32-bi
+	// wchar_t is 32-bit
 	return !(p_str == String((const char32_t *)p_chr));
 #endif
 }

--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -47,7 +47,7 @@
 			The [FoldableGroup] associated with the container. When multiple [FoldableContainer] nodes share the same group, only one of them is allowed to be unfolded.
 		</member>
 		<member name="folded" type="bool" setter="set_folded" getter="is_folded" default="false">
-			If [code]true[/code], the container will becomes folded and will hide all its children.
+			If [code]true[/code], the container will become folded and will hide all its children.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for text shaping algorithms. If left empty, current locale is used instead.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -316,7 +316,7 @@
 			<param index="3" name="owned" type="bool" default="true" />
 			<description>
 				Finds all descendants of this node whose names match [param pattern], returning an empty [Array] if no match is found. The matching is done against node names, [i]not[/i] their paths, through [method String.match]. As such, it is case-sensitive, [code]"*"[/code] matches zero or more characters, and [code]"?"[/code] matches any single character.
-				If [param type] is not empty, only ancestors inheriting from [param type] are included (see [method Object.is_class]).
+				If [param type] is not empty, only descendants inheriting from [param type] are included (see [method Object.is_class]).
 				If [param recursive] is [code]false[/code], only this node's direct children are checked. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. Internal children are also included in the search (see [code]internal[/code] parameter in [method add_child]).
 				If [param owned] is [code]true[/code], only descendants with a valid [member owner] node are checked.
 				[b]Note:[/b] This method can be very slow. Consider storing references to the found nodes in a variable.

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -166,7 +166,7 @@
 			[b]Note:[/b] Setting this property manually may fail if a resource with the same path has already been previously loaded. If necessary, use [method take_over_path].
 		</member>
 		<member name="resource_scene_unique_id" type="String" setter="set_scene_unique_id" getter="get_scene_unique_id">
-			A unique identifier relative to the this resource's scene. If left empty, the ID is automatically generated when this resource is saved inside a [PackedScene]. If the resource is not inside a scene, this property is empty by default.
+			A unique identifier relative to this resource's scene. If left empty, the ID is automatically generated when this resource is saved inside a [PackedScene]. If the resource is not inside a scene, this property is empty by default.
 			[b]Note:[/b] When the [PackedScene] is saved, if multiple resources in the same scene use the same ID, only the earliest resource in the scene hierarchy keeps the original ID. The other resources are assigned new IDs from [method generate_scene_unique_id].
 			[b]Note:[/b] Setting this property does not emit the [signal changed] signal.
 			[b]Warning:[/b] When setting, the ID must only consist of letters, numbers, and underscores. Otherwise, it will fail and default to a randomly generated ID.

--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -760,7 +760,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	location_container = memnew(HBoxContainer);
 	location_container->hide();
 
-	location_container->add_child(memnew(Label(TTRC("Physical location"))));
+	location_container->add_child(memnew(Label(TTRC("Physical Location"))));
 
 	key_location = memnew(OptionButton);
 	key_location->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -770,7 +770,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	key_location->add_item(String(), (int)KeyLocation::LEFT);
 	key_location->add_item(String(), (int)KeyLocation::RIGHT);
 	key_location->connect(SceneStringName(item_selected), callable_mp(this, &InputEventConfigurationDialog::_key_location_selected));
-	key_location->set_accessibility_name(TTRC("Physical location"));
+	key_location->set_accessibility_name(TTRC("Physical Location"));
 
 	location_container->add_child(key_location);
 	additional_options_container->add_child(location_container);


### PR DESCRIPTION
TL;DR
- Fixes all of the currently listed typos & UI paper cuts in godotengine#91521 (except for godotengine#116481)
- Related to our codestyle


> [!NOTE]
> Contributed by 2LazyDevs 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capitalization of "Physical Location" label in settings UI

* **Documentation**
  * Fixed grammatical errors and improved clarity in class documentation
  * Enhanced property descriptions with corrected terminology and behavioral notes
  * Updated method documentation for accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->