### PR TITLE
Update `Dictionary.get` regarding the `default` argument & it's side effects

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -255,6 +255,13 @@
 			<param index="1" name="default" type="Variant" default="null" />
 			<description>
 				Returns the corresponding value for the given [param key] in the dictionary. If the [param key] does not exist, returns [param default], or [code]null[/code] if the parameter is omitted.
+				[b]Note:[/b] If the [param default] argument is computationally expensive or has unwanted side effects, consider using the [method has] method instead:
+				[codeblock]
+				# Always calls `expensive_function()`.
+				dict.get("key", expensive_function())
+				# Calls `expensive_function()` only if the key does not exist.
+				dict.get("key") if dict.has("key") else expensive_function()
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_or_add">


### PR DESCRIPTION
TL;DR
- Godot counterpart: https://github.com/godotengine/godot/pull/116129
- Updates the `Dictionary.get` documentation with a note regarding the `default` argument, the fact that it's computationally expensive & it's unwanted side effects
- Also suggest the user to use the `has()` method instead

> [!NOTE]
> Contributed by 2LazyDevs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Dictionary class documentation with comprehensive guidance on efficiently handling default values and avoiding unnecessary computation. Includes new practical examples demonstrating eager versus lazy evaluation patterns. Recommends verifying key existence before retrieval when default values are expensive to evaluate or have potential side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->