### PR TITLE
Document that auto-exposure won't work on Mobile & Compatibility.

### DIFF
--- a/doc/classes/CameraAttributes.xml
+++ b/doc/classes/CameraAttributes.xml
@@ -14,6 +14,7 @@
 	<members>
 		<member name="auto_exposure_enabled" type="bool" setter="set_auto_exposure_enabled" getter="is_auto_exposure_enabled" default="false">
 			If [code]true[/code], enables the tonemapping auto exposure mode of the scene renderer. If [code]true[/code], the renderer will automatically determine the exposure setting to adapt to the scene's illumination and the observed light.
+			[b]Note:[/b] Auto-exposure is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 		</member>
 		<member name="auto_exposure_scale" type="float" setter="set_auto_exposure_scale" getter="get_auto_exposure_scale" default="0.4">
 			The scale of the auto exposure effect. Affects the intensity of auto exposure.

--- a/doc/classes/CameraAttributesPhysical.xml
+++ b/doc/classes/CameraAttributesPhysical.xml
@@ -8,6 +8,7 @@
 		When used in a [WorldEnvironment] it provides default settings for exposure, auto-exposure, and depth of field that will be used by all cameras without their own [CameraAttributes], including the editor camera. When used in a [Camera3D] it will override any [CameraAttributes] set in the [WorldEnvironment] and will override the [Camera3D]s [member Camera3D.far], [member Camera3D.near], [member Camera3D.fov], and [member Camera3D.keep_aspect] properties. When used in [VoxelGI] or [LightmapGI], only the exposure settings will be used.
 		The default settings are intended for use in an outdoor environment, tips for settings for use in an indoor environment can be found in each setting's documentation.
 		[b]Note:[/b] Depth of field blur is only supported in the Forward+ and Mobile rendering methods, not Compatibility.
+		[b]Note:[/b] Auto-exposure is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 	</description>
 	<tutorials>
 		<link title="Physical light and camera units">$DOCS_URL/tutorials/3d/physical_light_and_camera_units.html</link>

--- a/doc/classes/CameraAttributesPractical.xml
+++ b/doc/classes/CameraAttributesPractical.xml
@@ -6,6 +6,8 @@
 	<description>
 		Controls camera-specific attributes such as auto-exposure, depth of field, and exposure override.
 		When used in a [WorldEnvironment] it provides default settings for exposure, auto-exposure, and depth of field that will be used by all cameras without their own [CameraAttributes], including the editor camera. When used in a [Camera3D] it will override any [CameraAttributes] set in the [WorldEnvironment]. When used in [VoxelGI] or [LightmapGI], only the exposure settings will be used.
+		[b]Note:[/b] Depth of field blur is only supported in the Forward+ and Mobile rendering methods, not Compatibility.
+		[b]Note:[/b] Auto-exposure is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
TL;DR
- Godot counterpart: https://github.com/godotengine/godot/pull/114712
- Document that auto-exposure won't work on Mobile & Compatibility in `CameraAttributes`, `CameraAttributesPractical` & `CameraAtrributesPhysical`.
- Also, in `CameraAttributesPractical`, added a note which tells that depth of field only works on Forward+ & Mobile following the same note in `CameraAtrributesPhysical`.
- Small enhancement in the rendering documentation

> [!NOTE]
> Contributed by 2LazyDevs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rendering method compatibility for auto-exposure feature: supported in Forward+ only, not in Mobile or Compatibility methods.
  * Clarified rendering method compatibility for depth-of-field blur: supported in Forward+ and Mobile, not in Compatibility method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->