### PR TITLE
Update the notification for Auto-exposure

### DIFF
--- a/servers/rendering/storage/camera_attributes_storage.cpp
+++ b/servers/rendering/storage/camera_attributes_storage.cpp
@@ -146,8 +146,8 @@ void RendererCameraAttributes::camera_attributes_set_auto_exposure(RID p_camera_
 		cam_attributes->auto_exposure_version = ++auto_exposure_counter;
 	}
 #ifdef DEBUG_ENABLED
-	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_enable) {
-		WARN_PRINT_ONCE_ED("Auto exposure is only available when using the Forward+ or Mobile renderers.");
+	if ((OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "mobile") && p_enable) {
+		WARN_PRINT_ONCE_ED("Auto-exposure is only available when using the Forward+ renderer.");
 	}
 #endif
 	cam_attributes->use_auto_exposure = p_enable;


### PR DESCRIPTION
TL;DR
- Godot counterpart: https://github.com/godotengine/godot/pull/114732
- Updates the notification in `servers/rendering/storage/camera_attributes_storage.cpp` (Line 147) to tell that auto-exposure only supports Forward+, not Mobile or Compatibility.

> [!NOTE]
> Contributed by 2LazyDevs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated auto-exposure warning conditions to display more accurately based on the current rendering method. The warning message has been refined to clearly communicate which renderers support auto-exposure functionality in camera settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->