### PR TITLE
Clarify that `map_to_local` returns the position of the center of the cell in GridMap

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -139,7 +139,7 @@
 			<description>
 				Returns the position of a grid cell in the GridMap's local coordinate space. The returned position, for each axis, is either cell center or the cell edge closer to negative infinity, based on the values of [member cell_center_x], [member cell_center_y], [member cell_center_z]. To convert the returned value into global coordinates, use [method Node3D.to_global]. See also [method local_to_map].
 				[codeblock]
-				# All examples for: cell_size = Vector2(2.0, 3.0, 4.0)
+				# All examples for: cell_size = Vector3(2.0, 3.0, 4.0)
 
 				# cell_center_x = true, cell_center_y = true, cell_center_z = true
 				map_to_local(Vector3i(0, 0, 0)) # Returns Vector3(1.0, 1.5, 2.0)


### PR DESCRIPTION
TL;DR
- Godot counterpart: https://github.com/godotengine/godot/pull/116461
- Clarifies that `map_to_local` returns the position of the center of the cell in GridMap

> [!NOTE]
> Contributed by 2LazyDevs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded GridMap method documentation to clarify how per-axis "center vs. edge" choices affect returned coordinates, added example scenarios with expected outputs, and explained how this method relates to the inverse conversion for clearer, more predictable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->