### PR TITLE
Add Deepwiki badge and Remove ReX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   </a>
 </p>
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Redot-Engine/redot-engine)
+
 ## 2D and 3D cross-platform game engine
 
 **[Redot Engine LTS](https://redotengine.org) is a feature-packed, cross-platform
@@ -159,9 +161,3 @@ Follow [Redot on X/Twitter](https://x.com/Redot_Engine)!
 ## Documentation and demos
 
 The class reference is accessible from the Redot editor.
-
-## ReX Engine
-
-Looking to try out new features that aren't backwards compatible with Godot, or would you like to create new features for Redot Engine that can't be added here due to compatibility issues?
-
-Meet us over at the [ReX Engine Repo](https://github.com/redot-rex/rex-engine) Where we aim to create a modern engine using Redot Engine as a starting point, free from godots choices and shortcomings, and innovate in ways not currently possible here within Redot Engine.


### PR DESCRIPTION
Adds Deepwiki badge to enable automatic Updates on Deepwiki side

Remove ReX Repo reference as it is now defunct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a badge image/link near the top of the README header.
  * Removed the ReX Engine section and its descriptive paragraph from the documentation and demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->