### PR TITLE
Add a setter and getter for the intensity value of ColorPicker.

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -82,6 +82,9 @@
 		<member name="hex_visible" type="bool" setter="set_hex_visible" getter="is_hex_visible" default="true">
 			If [code]true[/code], the hex color code input field is visible.
 		</member>
+		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="0.0">
+			The currently selected intensity.
+		</member>
 		<member name="old_color" type="Color" setter="set_old_color" getter="get_old_color" default="Color(0, 0, 0, 1)">
 			The currently stored old color. See also [member display_old_color].
 		</member>

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -84,6 +84,7 @@
 		</member>
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="0.0">
 			The currently selected intensity.
+			Note: [code]set_intensity[/code] clamps the value in the range [code][-10.0, 10.0][/code]
 		</member>
 		<member name="old_color" type="Color" setter="set_old_color" getter="get_old_color" default="Color(0, 0, 0, 1)">
 			The currently stored old color. See also [member display_old_color].

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -374,7 +374,9 @@ void ColorPicker::set_focus_on_picker_shape() {
 }
 
 void ColorPicker::set_intensity(float p_intensity) {
-	intensity_slider->set_value(p_intensity);
+	intensity = p_intensity;
+	_normalized_apply_intensity_to_color();
+	_update_color();
 }
 
 float ColorPicker::get_intensity() {
@@ -2091,7 +2093,7 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_recent_presets"), &ColorPicker::get_recent_presets);
 	ClassDB::bind_method(D_METHOD("set_picker_shape", "shape"), &ColorPicker::set_picker_shape);
 	ClassDB::bind_method(D_METHOD("get_picker_shape"), &ColorPicker::get_picker_shape);
-	ClassDB::bind_method(D_METHOD("set_intensity"), &ColorPicker::set_intensity);
+	ClassDB::bind_method(D_METHOD("set_intensity", "intensity"), &ColorPicker::set_intensity);
 	ClassDB::bind_method(D_METHOD("get_intensity"), &ColorPicker::get_intensity);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -34,6 +34,7 @@
 
 #include "core/io/image.h"
 #include "core/math/expression.h"
+#include "core/math/math_funcs.h"
 #include "scene/gui/color_mode.h"
 #include "scene/gui/color_picker_shape.h"
 #include "scene/gui/file_dialog.h"
@@ -374,6 +375,11 @@ void ColorPicker::set_focus_on_picker_shape() {
 }
 
 void ColorPicker::set_intensity(float p_intensity) {
+	p_intensity = CLAMP(p_intensity, this->intensity_slider->get_min(), this->intensity_slider->get_max());
+	if (Math::is_equal_approx(intensity, p_intensity)) {
+		return;
+	}
+
 	intensity = p_intensity;
 	_normalized_apply_intensity_to_color();
 	_update_color();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -373,6 +373,14 @@ void ColorPicker::set_focus_on_picker_shape() {
 	shapes[get_current_shape_index()]->grab_focus();
 }
 
+void ColorPicker::set_intensity(float p_intensity) {
+	intensity_slider->set_value(p_intensity);
+}
+
+float ColorPicker::get_intensity() {
+	return intensity;
+}
+
 void ColorPicker::_update_controls() {
 	int mode_sliders_count = modes[current_mode]->get_slider_count();
 
@@ -2083,6 +2091,8 @@ void ColorPicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_recent_presets"), &ColorPicker::get_recent_presets);
 	ClassDB::bind_method(D_METHOD("set_picker_shape", "shape"), &ColorPicker::set_picker_shape);
 	ClassDB::bind_method(D_METHOD("get_picker_shape"), &ColorPicker::get_picker_shape);
+	ClassDB::bind_method(D_METHOD("set_intensity"), &ColorPicker::set_intensity);
+	ClassDB::bind_method(D_METHOD("get_intensity"), &ColorPicker::get_intensity);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "old_color"), "set_old_color", "get_old_color");
@@ -2099,6 +2109,7 @@ void ColorPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sliders_visible"), "set_sliders_visible", "are_sliders_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hex_visible"), "set_hex_visible", "is_hex_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "presets_visible"), "set_presets_visible", "are_presets_visible");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "intensity"), "set_intensity", "get_intensity");
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("preset_added", PropertyInfo(Variant::COLOR, "color")));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2111,7 +2111,7 @@ void ColorPicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sliders_visible"), "set_sliders_visible", "are_sliders_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hex_visible"), "set_hex_visible", "is_hex_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "presets_visible"), "set_presets_visible", "are_presets_visible");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "intensity"), "set_intensity", "get_intensity");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity"), "set_intensity", "get_intensity");
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("preset_added", PropertyInfo(Variant::COLOR, "color")));

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -504,6 +504,9 @@ public:
 	void set_focus_on_line_edit();
 	void set_focus_on_picker_shape();
 
+	void set_intensity(float intensity);
+	float get_intensity();
+
 	ColorPicker();
 	~ColorPicker();
 };


### PR DESCRIPTION
This commit adds a getter and setter for ColorPicker's intensity value. The setter works by setting the intensity through the slider, so that everything updates as expected. This closes https://github.com/Redot-Engine/redot-proposals/issues/117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ColorPicker gains an intensity property (default 0.0) to adjust displayed color intensity.
  * Intensity is adjustable via the ColorPicker UI (label, slider, value display) and available in editor/property views and scripts.
  * Input is clamped to the supported range (values outside bounds are limited).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->