### PR TITLE
GH-1183 Fix engine freeze when Skeleton3DEditor is Deleted

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -918,6 +918,9 @@ void Skeleton3DEditor::_joint_tree_button_clicked(Object *p_item, int p_column, 
 }
 
 void Skeleton3DEditor::_update_properties() {
+	if (is_deleting) {
+		return;
+	}
 	if (pose_editor) {
 		pose_editor->_update_properties();
 	}
@@ -1166,6 +1169,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			update_joint_tree();
 		} break;
 		case NOTIFICATION_PREDELETE: {
+			is_deleting = true;
 			if (editor_plugin) {
 				editor_plugin->skeleton_editor = nullptr;
 			}

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -146,6 +146,7 @@ class Skeleton3DEditor : public VBoxContainer {
 	Button *edit_mode_button = nullptr;
 
 	bool edit_mode = false;
+	bool is_deleting = false;
 
 	HBoxContainer *animation_hb = nullptr;
 	Button *key_loc_button = nullptr;


### PR DESCRIPTION
fixes #1183 

Before the Skeleton3DEditor is freed it will cause the editor to iterate through every bone and call `_update_properties` this operation is expensive and takes ~1500 microseconds per call. On skeletons with many bones this will cause a noticeable freeze of the engine. This change will prevent `_update_properties` from being called on deletion. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the 3D skeleton editor to handle skeleton deletion operations more reliably, preventing visual glitches and editor instability that previously occurred during the deletion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->