### PR TITLE
Improve Nix flake app build flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ nix run .
 
 This will automatically install all build dependencies and compile Redot if the binary doesn't exist.
 
-Detailed Nix usage, including passing SCons build flags through `nix run`, forwarding runtime arguments, and manual `nix develop` workflows, is documented in `docs/nix.md`.
+Detailed Nix usage, including passing SCons build flags through `nix run`, forwarding runtime arguments, and manual `nix develop` workflows, is documented in the `Nix usage guide` at `doc/nix.md`.
 
 
 ## Community and contributing

--- a/doc/nix.md
+++ b/doc/nix.md
@@ -37,6 +37,8 @@ nix run . -- --help
 
 This supports the same SCons flags documented by the build system, such as `production=yes`, `target=template_release`, `module_mono_enabled=yes`, `precision=double`, `ccflags=...`, and more.
 
+The wrapper only uses a subset of those flags when deciding which existing binary can be reused: `target`, `arch`, `dev_build`, `precision`, `threads`, and `extra_suffix`. Other SCons flags such as `production=yes`, `module_mono_enabled=yes`, or custom `ccflags` are still forwarded to `scons`, but they do not change the wrapper's reuse check.
+
 ## Manual builds with `nix develop`
 
 For full manual control over the build process:
@@ -51,14 +53,18 @@ scons platform=linuxbsd  # or: scons platform=macos
 # Example with extra build flags.
 scons platform=linuxbsd target=template_release production=yes
 
-# Run the editor - binary name reflects your platform and architecture.
-# Examples: redot.linuxbsd.editor.x86_64, redot.macos.editor.arm64
-./bin/redot.<platform>.editor.<arch>
+# Run the editor - binary names can include optional suffixes.
+# Examples:
+#   redot.linuxbsd.editor.x86_64
+#   redot.linuxbsd.editor.dev.x86_64
+#   redot.linuxbsd.editor.double.x86_64
+#   redot.linuxbsd.editor.x86_64.nothreads
+./bin/redot.<platform>.<target>[.dev][.double].<arch>[.nothreads][.<extra_suffix>]
 ```
 
 ## Notes
 
-- `nix run .` only auto-builds when a matching binary does not exist yet.
+- `nix run .` only auto-builds when the expected binary for the wrapper-managed naming fields does not exist yet.
 - If you want to rebuild with different flags after a binary was already produced, remove the existing binary first or use `nix develop` and run `scons` manually.
-- The flake app automatically detects your platform and architecture.
+- The flake app automatically detects your platform and architecture, and `arch=auto` resolves to the host architecture.
 - Nix works on Linux and macOS, and is available at [nixos.org/download.html](https://nixos.org/download.html).

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
         show_help=0
         target=editor
         target_arch=${arch}
+        scons_platform=${platform}
         dev_build=no
         precision=single
         threads=yes
@@ -103,16 +104,25 @@
           fi
 
           if [ "$parsing_runtime_args" -eq 0 ]; then
-            scons_args+=("$arg")
-
             case "$arg" in
               target=*) target=''${arg#target=} ;;
-              arch=*) target_arch=''${arg#arch=} ;;
+              arch=*)
+                target_arch=''${arg#arch=}
+                if [ "$target_arch" = "auto" ]; then
+                  target_arch=${arch}
+                fi
+                ;;
+              platform=*)
+                scons_platform=''${arg#platform=}
+                continue
+                ;;
               dev_build=*) dev_build=''${arg#dev_build=} ;;
               precision=*) precision=''${arg#precision=} ;;
               threads=*) threads=''${arg#threads=} ;;
               extra_suffix=*) extra_suffix=''${arg#extra_suffix=} ;;
             esac
+
+            scons_args+=("$arg")
           else
             runtime_args+=("$arg")
           fi
@@ -145,7 +155,7 @@ EOF
           exit 0
         fi
 
-        binary_pattern="redot.${platform}.''${target}"
+        binary_pattern="redot.$scons_platform.''${target}"
 
         if [ "$dev_build" = "yes" ]; then
           binary_pattern="$binary_pattern.dev"
@@ -165,26 +175,17 @@ EOF
           binary_pattern="$binary_pattern.$extra_suffix"
         fi
 
-        shopt -s nullglob
-        matches=(./bin/"$binary_pattern"*)
+        binary_path="./bin/$binary_pattern"
 
-        if [ "''${#matches[@]}" -eq 0 ]; then
+        if [ ! -f "$binary_path" ]; then
           echo "Building Redot..."
-          scons platform=${platform} "''${scons_args[@]}"
-          matches=(./bin/"$binary_pattern"*)
+          scons "''${scons_args[@]}" platform=$scons_platform
         fi
 
-        if [ "''${#matches[@]}" -eq 0 ]; then
-          echo "Could not find a built Redot binary matching $binary_pattern" >&2
+        if [ ! -f "$binary_path" ]; then
+          echo "Could not find a built Redot binary at $binary_path" >&2
           exit 1
         fi
-
-        binary_path="''${matches[0]}"
-        for candidate in "''${matches[@]}"; do
-          if [ "$candidate" -nt "$binary_path" ]; then
-            binary_path="$candidate"
-          fi
-        done
 
         exec "$binary_path" "''${runtime_args[@]}"
       '';


### PR DESCRIPTION
## Problem
The current Nix entrypoint is convenient for `nix run .`, but it only builds with the default `scons platform=...` invocation.

That means users cannot pass normal SCons build flags through the flake app, so workflows like `dev_build=yes`, `production=yes`, `target=template_release`, or module toggles require dropping down to `nix develop` and running `scons` manually.

There were also two follow-on issues in the wrapper:
- it assumed a fixed editor binary name, so builds like `dev_build=yes` produced a valid binary that the wrapper then failed to launch
- production/LTO builds needed `gcc-ar`, which was not available in the wrapper environment

## What This PR Changes
- allow `nix run . -- ...` to pass SCons build flags into the flake wrapper
- split wrapper arguments so build flags go to `scons` and arguments after an internal `--` still reach the built Redot binary
- resolve the output binary more robustly for common SCons naming variations like `target`, `dev_build`, `precision`, `threads`, and `extra_suffix`
- add wrapper `--help` output so the Nix syntax is discoverable from the CLI
- document the Nix workflow more clearly in `README.md`, including build-flag examples, runtime-arg forwarding, and rebuild caveats
- include the toolchain pieces needed for production/LTO builds in the wrapper environment

## Result
Nix users can keep using the simple flake entrypoint while still accessing the build customization that Redot already exposes through SCons.

Examples supported by this change:
- `nix run . -- target=editor dev_build=yes num_jobs=12`
- `nix run . -- target=template_release production=yes`
- `nix run . -- target=editor dev_build=yes -- --path /tmp/project`

## Testing
- `nix flake show .`
- `nix run . -- --help`
- `nix run . -- target=editor dev_build=yes num_jobs=12 -- --help`
- `nix run . -- target=editor num_jobs=12 -- --help`
- `nix run . -- target=template_release production=yes num_jobs=12 -- --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined README with reference to dedicated Nix usage guide.
  * Added comprehensive documentation covering Nix workflow, build flags, argument separation, and manual development processes.

* **New Features**
  * Enhanced Nix execution with dynamic binary detection, automatic building, and improved argument parsing for build and runtime parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->