### PR TITLE
GH-1226 Have Wayland chosen as default if user is using it

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3196,6 +3196,13 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 		int display_driver_idx = -1;
 
+		if (display_driver == "default") {
+			String display = OS::get_singleton()->get_environment("WAYLAND_DISPLAY");
+			if (!display.is_empty()) {
+				display_driver = "wayland";
+			}
+		}
+
 		if (display_driver.is_empty() || display_driver == "default") {
 			display_driver_idx = 0;
 		} else {


### PR DESCRIPTION
Fixes #1226 Current Design of Godot has it so that you have to explicitly set Wayland as the chosen display driver in project settings or via the command line. This change will automatically have Wayland chosen if detected and the display driver is set to the default driver. Essentially making the default chosen option the display server that the user is using instead of X11.

This may have some consequences since there are mentions of wayland features not being entirely complete, but that is something we can work towards. https://github.com/godotengine/godot/issues/88346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display driver configuration now automatically selects Wayland when set to default and Wayland is available on the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->