### PR TITLE
Enable Physics Interpolation by Default

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2058,7 +2058,7 @@ SceneTree::SceneTree() {
 	root->set_as_audio_listener_3d(true);
 #endif // _3D_DISABLED
 
-	set_physics_interpolation_enabled(GLOBAL_DEF("physics/common/physics_interpolation", false));
+	set_physics_interpolation_enabled(GLOBAL_DEF("physics/common/physics_interpolation", true));
 
 	// Always disable jitter fix if physics interpolation is enabled -
 	// Jitter fix will interfere with interpolation, and is not necessary


### PR DESCRIPTION
When creating a new project, physics interpolation is currently disabled by default. This means that for developers who use 60 hz monitors (or otherwise make the physics tick rate match the refresh rate), everything will seem to work fine. 

However, for those who use a monitor with a different refresh rate, the project may end up stuttery. This is most noticable if both _physics_process() and _process() are mixed within code.

By enabling physics interpolation by default, projects should behave far more predictably across hardware. This is important, since a developer shouldn't be expected to change a default setting when their project otherwise works perfectly on their hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Physics interpolation is now enabled by default, providing smoother physics simulations and improved visual quality for physics-based animations without requiring manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->