### PR TITLE
Add More Reliable OpenBSD Executable Path Solution

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1199,91 +1199,90 @@ String OS_Unix::get_executable_path() const {
 	std::vector<std::string> buffer;
 	bool error = false, retried = false;
 	kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
-	if (!kd) {
-		path.clear();
-		return path;
-	}
-	if ((proc_info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), sizeof(struct kinfo_proc), &cntp))) {
-		char **cmd = kvm_getargv(kd, proc_info, 0);
-		if (cmd) {
-			for (int i = 0; cmd[i]; i++) {
-				buffer.push_back(cmd[i]);
+	if (kd) {
+		if ((proc_info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), sizeof(struct kinfo_proc), &cntp))) {
+			char **cmd = kvm_getargv(kd, proc_info, 0);
+			if (cmd) {
+				for (int i = 0; cmd[i]; i++) {
+					buffer.push_back(cmd[i]);
+				}
 			}
 		}
-	}
-	kvm_close(kd);
-	if (!buffer.empty()) {
-		std::string argv0;
-		if (!buffer[0].empty()) {
-		fallback:
-			std::size_t slash_pos = buffer[0].find('/');
-			std::size_t colon_pos = buffer[0].find(':');
-			if (slash_pos == 0) {
-				argv0 = buffer[0];
-				path = is_exe(argv0);
-			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
-				std::string penv = cppstr_getenv("PATH");
-				if (!penv.empty()) {
-				retry:
-					std::string tmp;
-					std::stringstream sstr(penv);
-					while (std::getline(sstr, tmp, ':')) {
-						argv0 = tmp + "/" + buffer[0];
-						path = is_exe(argv0);
-						if (!path.empty()) {
-							break;
-						}
-						if (slash_pos > colon_pos) {
-							argv0 = tmp + "/" + buffer[0].substr(0, colon_pos);
+		kvm_close(kd);
+		if (!buffer.empty()) {
+			std::string argv0;
+			if (!buffer[0].empty()) {
+			fallback:
+				std::size_t slash_pos = buffer[0].find('/');
+				std::size_t colon_pos = buffer[0].find(':');
+				if (slash_pos == 0) {
+					argv0 = buffer[0];
+					path = is_exe(argv0);
+				} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
+					std::string penv = cppstr_getenv("PATH");
+					if (!penv.empty()) {
+					retry:
+						std::string tmp;
+						std::stringstream sstr(penv);
+						while (std::getline(sstr, tmp, ':')) {
+							argv0 = tmp + "/" + buffer[0];
 							path = is_exe(argv0);
 							if (!path.empty()) {
 								break;
 							}
+							if (slash_pos > colon_pos) {
+								argv0 = tmp + "/" + buffer[0].substr(0, colon_pos);
+								path = is_exe(argv0);
+								if (!path.empty()) {
+									break;
+								}
+							}
+						}
+					}
+					if (path.empty() && !retried) {
+						retried = true;
+						penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
+						std::string home = cppstr_getenv("HOME");
+						if (!home.empty()) {
+							penv = home + "/bin:" + penv;
+						}
+						goto retry;
+					}
+				}
+				if (path.empty() && slash_pos > 0) {
+					std::string pwd = cppstr_getenv("PWD");
+					if (!pwd.empty()) {
+						argv0 = pwd + "/" + buffer[0];
+						path = is_exe(argv0);
+					}
+					if (path.empty()) {
+						char cwd[PATH_MAX];
+						if (getcwd(cwd, PATH_MAX)) {
+							argv0 = std::string(cwd) + "/" + buffer[0];
+							path = is_exe(argv0);
 						}
 					}
 				}
-				if (path.empty() && !retried) {
-					retried = true;
-					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
-					std::string home = cppstr_getenv("HOME");
-					if (!home.empty()) {
-						penv = home + "/bin:" + penv;
-					}
-					goto retry;
-				}
 			}
-			if (path.empty() && slash_pos > 0) {
-				std::string pwd = cppstr_getenv("PWD");
-				if (!pwd.empty()) {
-					argv0 = pwd + "/" + buffer[0];
-					path = is_exe(argv0);
-				}
-				if (path.empty()) {
-					char cwd[PATH_MAX];
-					if (getcwd(cwd, PATH_MAX)) {
-						argv0 = std::string(cwd) + "/" + buffer[0];
-						path = is_exe(argv0);
-					}
+			if (path.empty() && !error) {
+				error = true;
+				buffer.clear();
+				std::string underscore = cppstr_getenv("_");
+				if (!underscore.empty()) {
+					buffer.push_back(underscore);
+					goto fallback;
 				}
 			}
 		}
-		if (path.empty() && !error) {
-			error = true;
-			buffer.clear();
-			std::string underscore = cppstr_getenv("_");
-			if (!underscore.empty()) {
-				buffer.push_back(underscore);
-				goto fallback;
-			}
+		if (!path.empty()) {
+			return String::utf8(path.c_str());
 		}
 	}
-	if (path.empty()) {
-		char resolved_path[MAXPATHLEN];
-		realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-		WARN_PRINT("Couldn't get executable path from any of the methods tried");
-		return String(resolved_path);
-	}
-	return String::utf8(path.c_str());
+	char resolved_path[MAXPATHLEN];
+	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
+	WARN_PRINT("Couldn't get executable path from any of the methods tried");
+	return String(resolved_path);
+}
 #elif defined(__NetBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
 	char buf[MAXPATHLEN];

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1159,16 +1159,18 @@ String OS_Unix::get_executable_path() const {
 		kinfo_file *kif = nullptr;
 		bool error = false;
 		kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
-		if (!kd) return res;
+		if (!kd) {
+			return res;
+		}
 		if ((kif = kvm_getfiles(kd, KERN_FILE_BYPID, getpid(), sizeof(struct kinfo_file), &cntp))) {
 			for (int i = 0; i < cntp && kif[i].fd_fd < 0; i++) {
 				if (kif[i].fd_fd == KERN_FILE_TEXT) {
 					struct stat st;
-					fallback:
+				fallback:
 					char buffer[PATH_MAX];
 					if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
-						(st.st_mode & S_IFREG) && realpath(exe.c_str(), buffer) &&
-						st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
+							(st.st_mode & S_IFREG) && realpath(exe.c_str(), buffer) &&
+							st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
 						res = buffer;
 					}
 					if (res.empty() && !error) {
@@ -1213,26 +1215,30 @@ String OS_Unix::get_executable_path() const {
 	if (!buffer.empty()) {
 		std::string argv0;
 		if (!buffer[0].empty()) {
-			fallback:
+		fallback:
 			std::size_t slash_pos = buffer[0].find('/');
 			std::size_t colon_pos = buffer[0].find(':');
 			if (slash_pos == 0) {
 				argv0 = buffer[0];
 				path = is_exe(argv0);
-			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) { 
+			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
 				std::string penv = cppstr_getenv("PATH");
 				if (!penv.empty()) {
-					retry:
+				retry:
 					std::string tmp;
 					std::stringstream sstr(penv);
 					while (std::getline(sstr, tmp, ':')) {
 						argv0 = tmp + "/" + buffer[0];
 						path = is_exe(argv0);
-						if (!path.empty()) break;
+						if (!path.empty()) {
+							break;
+						}
 						if (slash_pos > colon_pos) {
 							argv0 = tmp + "/" + buffer[0].substr(0, colon_pos);
 							path = is_exe(argv0);
-							if (!path.empty()) break;
+							if (!path.empty()) {
+								break;
+							}
 						}
 					}
 				}

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -63,13 +63,18 @@
 #include <sys/sysctl.h>
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <kvm.h>
 #endif
 
 #if defined(__OpenBSD__)
 #include <sys/swap.h>
+#include <sys/types.h>
 #include <uvm/uvmexp.h>
+#include <climits>
+#include <sstream>
+#include <string>
+#include <vector>
 #endif
 
 #if defined(__NetBSD__)
@@ -1146,11 +1151,130 @@ String OS_Unix::get_executable_path() const {
 	}
 	return b;
 #elif defined(__OpenBSD__)
-	char resolved_path[MAXPATHLEN];
-
-	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-
-	return String(resolved_path);
+	std::string path;
+	auto is_exe = [](std::string exe) {
+		int cntp = 0;
+		std::string res;
+		kvm_t *kd = nullptr;
+		kinfo_file *kif = nullptr;
+		bool error = false;
+		kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
+		if (!kd) return res;
+		if ((kif = kvm_getfiles(kd, KERN_FILE_BYPID, getpid(), sizeof(struct kinfo_file), &cntp))) {
+			for (int i = 0; i < cntp && kif[i].fd_fd < 0; i++) {
+				if (kif[i].fd_fd == KERN_FILE_TEXT) {
+					struct stat st;
+					fallback:
+					char buffer[PATH_MAX];
+					if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
+						(st.st_mode & S_IFREG) && realpath(exe.c_str(), buffer) &&
+						st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
+						res = buffer;
+					}
+					if (res.empty() && !error) {
+						error = true;
+						std::size_t last_slash_pos = exe.find_last_of("/");
+						if (last_slash_pos != std::string::npos) {
+							exe = exe.substr(0, last_slash_pos + 1) + kif[i].p_comm;
+							goto fallback;
+						}
+					}
+					break;
+				}
+			}
+		}
+		kvm_close(kd);
+		return res;
+	};
+	auto cppstr_getenv = [](std::string name) {
+		const char *cresult = getenv(name.c_str());
+		std::string result = cresult ? cresult : "";
+		return result;
+	};
+	int cntp = 0;
+	kvm_t *kd = nullptr;
+	kinfo_proc *proc_info = nullptr;
+	std::vector<std::string> buffer;
+	bool error = false, retried = false;
+	kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
+	if (!kd) {
+		path.clear();
+		return path;
+	}
+	if ((proc_info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), sizeof(struct kinfo_proc), &cntp))) {
+		char **cmd = kvm_getargv(kd, proc_info, 0);
+		if (cmd) {
+			for (int i = 0; cmd[i]; i++) {
+				buffer.push_back(cmd[i]);
+			}
+		}
+	}
+	kvm_close(kd);
+	if (!buffer.empty()) {
+		std::string argv0;
+		if (!buffer[0].empty()) {
+			fallback:
+			std::size_t slash_pos = buffer[0].find('/');
+			std::size_t colon_pos = buffer[0].find(':');
+			if (slash_pos == 0) {
+				argv0 = buffer[0];
+				path = is_exe(argv0);
+			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) { 
+				std::string penv = cppstr_getenv("PATH");
+				if (!penv.empty()) {
+					retry:
+					std::string tmp;
+					std::stringstream sstr(penv);
+					while (std::getline(sstr, tmp, ':')) {
+						argv0 = tmp + "/" + buffer[0];
+						path = is_exe(argv0);
+						if (!path.empty()) break;
+						if (slash_pos > colon_pos) {
+							argv0 = tmp + "/" + buffer[0].substr(0, colon_pos);
+							path = is_exe(argv0);
+							if (!path.empty()) break;
+						}
+					}
+				}
+				if (path.empty() && !retried) {
+					retried = true;
+					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
+					std::string home = cppstr_getenv("HOME");
+					if (!home.empty()) {
+						penv = home + "/bin:" + penv;
+					}
+					goto retry;
+				}
+			}
+			if (path.empty() && slash_pos > 0) {
+				std::string pwd = cppstr_getenv("PWD");
+				if (!pwd.empty()) {
+					argv0 = pwd + "/" + buffer[0];
+					path = is_exe(argv0);
+				}
+				if (path.empty()) {
+					char cwd[PATH_MAX];
+					if (getcwd(cwd, PATH_MAX)) {
+						argv0 = std::string(cwd) + "/" + buffer[0];
+						path = is_exe(argv0);
+					}
+				}
+			}
+		}
+		if (path.empty() && !error) {
+			error = true;
+			buffer.clear();
+			std::string underscore = cppstr_getenv("_");
+			if (!underscore.empty()) {
+				buffer.push_back(underscore);
+				goto fallback;
+			}
+		}
+	}
+	if (!path.empty()) {
+		errno = 0;
+	}
+	return String(path.c_str());
 #elif defined(__NetBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
 	char buf[MAXPATHLEN];

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1280,8 +1280,8 @@ String OS_Unix::get_executable_path() const {
 	}
 	char resolved_path[MAXPATHLEN];
 	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-	WARN_PRINT("Couldn't get executable path from any of the methods tried");
-	return String(resolved_path);
+	WARN_PRINT("Couldn't get executable path from any of the methods tried");	
+	return String::utf8(resolved_path);
 }
 #elif defined(__NetBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
@@ -1297,7 +1297,7 @@ String OS_Unix::get_executable_path() const {
 
 	realpath(buf, resolved_path);
 
-	return String(resolved_path);
+	return String::utf8(resolved_path);
 #elif defined(__FreeBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
 	char buf[MAXPATHLEN];

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1277,13 +1277,9 @@ String OS_Unix::get_executable_path() const {
 			}
 		}
 	}
-	if (!path.empty()) {
-		errno = 0;
-	} else {
-		char resolved_path[MAXPATHLEN];
-		realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-		WARN_PRINT("Couldn't get executable path and there is no remaining fallback method");
-		return String(resolved_path);
+	if (path.empty()) {
+		WARN_PRINT("Couldn't get executable path from any of the methods tried");
+		return OS::get_executable_path();
 	}
 	return String::utf8(path.c_str());
 #elif defined(__NetBSD__)

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1280,7 +1280,7 @@ String OS_Unix::get_executable_path() const {
 	}
 	char resolved_path[MAXPATHLEN];
 	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-	WARN_PRINT("Couldn't get executable path from any of the methods tried");	
+	WARN_PRINT("Couldn't get executable path from any of the methods tried");
 	return String::utf8(resolved_path);
 }
 #elif defined(__NetBSD__)

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1278,8 +1278,10 @@ String OS_Unix::get_executable_path() const {
 		}
 	}
 	if (path.empty()) {
+		char resolved_path[MAXPATHLEN];
+		realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
 		WARN_PRINT("Couldn't get executable path from any of the methods tried");
-		return OS::get_executable_path();
+		return String(resolved_path);
 	}
 	return String::utf8(path.c_str());
 #elif defined(__NetBSD__)

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1169,7 +1169,7 @@ String OS_Unix::get_executable_path() const {
 				fallback:
 					char buffer[PATH_MAX];
 					if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
-							(st.st_mode & S_IFREG) && realpath(exe.c_str(), buffer) &&
+							S_ISREG(st.st_mode) && realpath(exe.c_str(), buffer) &&
 							st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
 						res = buffer;
 					}
@@ -1279,8 +1279,12 @@ String OS_Unix::get_executable_path() const {
 	}
 	if (!path.empty()) {
 		errno = 0;
+	} else {
+		char resolved_path[MAXPATHLEN];
+		realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
+		return String(resolved_path);
 	}
-	return String(path.c_str());
+	return String::utf8(path.c_str());
 #elif defined(__NetBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
 	char buf[MAXPATHLEN];

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1282,6 +1282,7 @@ String OS_Unix::get_executable_path() const {
 	} else {
 		char resolved_path[MAXPATHLEN];
 		realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
+		WARN_PRINT("Couldn't get executable path and there is no remaining fallback method");
 		return String(resolved_path);
 	}
 	return String::utf8(path.c_str());

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -533,6 +533,9 @@ def configure(env: "SConsEnvironment"):
     if platform.system() == "FreeBSD":
         env.Append(LINKFLAGS=["-lkvm"])
 
+    if platform.system() == "OpenBSD":
+        env.Append(LINKFLAGS=["-lkvm"])
+
     # Link those statically for portability
     if env["use_static_cpp"]:
         env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable executable-path resolution on OpenBSD: inspects the running process to derive and validate candidate paths from argv[0], PATH entries, current directory and PWD, with an environment-variable fallback; logs a warning and falls back to the previous method if unresolved.
* **Chores**
  * Improved OpenBSD build support by updating included system headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->