### PR TITLE
Fix mac release packaging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1197,8 +1197,8 @@ sign-mac-templates:
         if [ "$_is_mono" -eq 1 ]; then _mono_prefix="-mono"; _mono_suffix=".mono";fi
 
 
-        cp out/templates${_mono_prefix}/redot.macos.template_release.universal${_mono_suffix} tmp/macos_template.app/Contents/MacOS/redot_macos_release.universal${_mono_suffix}
-        cp out/templates${_mono_prefix}/redot.macos.template_debug.universal${_mono_suffix} tmp/macos_template.app/Contents/MacOS/redot_macos_debug.universal${_mono_suffix}
+        cp out/templates${_mono_prefix}/redot.macos.template_release.universal${_mono_suffix} tmp/macos_template.app/Contents/MacOS/redot_macos_release.universal
+        cp out/templates${_mono_prefix}/redot.macos.template_debug.universal${_mono_suffix} tmp/macos_template.app/Contents/MacOS/redot_macos_debug.universal
         chmod +x tmp/macos_template.app/Contents/MacOS/redot_macos*
 
 

--- a/misc/dist/macos_tools.app/Contents/Info.plist
+++ b/misc/dist/macos_tools.app/Contents/Info.plist
@@ -13,17 +13,17 @@
 	<key>CFBundleIconName</key>
 	<string>RedotLG</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.godotengine.redot</string>
+	<string>org.redotengine.redot</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.5.2</string>
+	<string>26.2</string>
 	<key>CFBundleSignature</key>
 	<string>GODO</string>
 	<key>CFBundleVersion</key>
-	<string>4.5.2</string>
+	<string>26.2</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Microphone access is required to capture audio.</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Fixed multiple issues with Mac signing for the editor and the mono release templates.

Fixes #1186  by bumping the version in the template app.

Fixes #1244 by removing the `_mono_suffix` environment variable from the destination file copy operation in the signing stage, so that the paths for the executables end up the same location for the mono version as the standard version.
This behavior is required for the mono version of the editor to be able to find the export template and properly export a game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified macOS template binary staging by using consistent fixed filenames for universal templates during the signing process, improving consistency across build variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->