### PR TITLE
Fix empty strings crashing lookup_code

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4302,6 +4302,12 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 ::Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) {
 	// Before parsing, try the usual stuff.
+	if (p_symbol.is_empty()) {
+		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+		r_result.class_name = "Nil";
+		return OK;
+	}
+
 	if (ClassDB::class_exists(p_symbol)) {
 		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
 		r_result.class_name = p_symbol;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4304,7 +4304,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	// Before parsing, try the usual stuff.
 	if (p_symbol.is_empty()) {
 		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
-		r_result.class_name = "Variant";//Nil
+		r_result.class_name = "Variant"; //Nil
 		return ERR_CANT_RESOLVE;
 	}
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4304,8 +4304,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	// Before parsing, try the usual stuff.
 	if (p_symbol.is_empty()) {
 		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
-		r_result.class_name = "Nil";
-		return OK;
+		r_result.class_name = "Variant";//Nil
+		return ERR_CANT_RESOLVE;
 	}
 
 	if (ClassDB::class_exists(p_symbol)) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
The fixed bug in question could be replicated as simply as holding ctrl and dragging the mouse around in the code editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor lookup to properly handle empty symbols: it now returns a clear, consistent "unresolved" result (treated as Variant/Nil) and avoids spurious class/constant resolution or analyzer confusion, improving code-intelligence accuracy and editor stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->