### PR TITLE
Change wording from "when website will be up"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ codebase of both through a more genuinely community-driven model than Godot.
 
 ### Binary downloads
 
-Official binaries for the Redot editor and the export templates will be found
-[on the Redot website](https://redotengine.org/download) once it's set up and on the [GitHub page](https://github.com/Redot-Engine/redot-engine) until then.
+Official binaries for the Redot editor and the export templates can be found
+[on the Redot website](https://redotengine.org/download) and on the [GitHub page](https://github.com/Redot-Engine/redot-engine).
 
 ### Compiling from source
 


### PR DESCRIPTION
The website very much appears to be up and is serving the binaries, the old text makes the readme feel quite out of date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Binary downloads section in README with clarified information about the availability of official editor binaries and export templates on the Redot website download page and GitHub page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1251)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->