### PR TITLE
CDO Fixes For OpenBSD EXE Path

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1152,131 +1152,126 @@ String OS_Unix::get_executable_path() const {
 	return b;
 #elif defined(__OpenBSD__)
 	std::string path;
-	auto is_exe = [](std::string exe) {
+	auto cpp_getexe = [](std::string exe) {
 		int cntp = 0;
 		std::string res;
 		kvm_t *kd = nullptr;
 		kinfo_file *kif = nullptr;
 		bool error = false;
 		kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
-		if (!kd) {
-			return res;
-		}
-		if ((kif = kvm_getfiles(kd, KERN_FILE_BYPID, getpid(), sizeof(struct kinfo_file), &cntp))) {
-			for (int i = 0; i < cntp && kif[i].fd_fd < 0; i++) {
-				if (kif[i].fd_fd == KERN_FILE_TEXT) {
-					struct stat st;
-				fallback:
-					char buffer[PATH_MAX];
-					if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
-							S_ISREG(st.st_mode) && realpath(exe.c_str(), buffer) &&
-							st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
-						res = buffer;
-					}
-					if (res.empty() && !error) {
-						error = true;
-						std::size_t last_slash_pos = exe.find_last_of("/");
-						if (last_slash_pos != std::string::npos) {
-							exe = exe.substr(0, last_slash_pos + 1) + kif[i].p_comm;
-							goto fallback;
+		if (kd) {
+			if ((kif = kvm_getfiles(kd, KERN_FILE_BYPID, getpid(), sizeof(struct kinfo_file), &cntp))) {
+				for (int i = 0; i < cntp && kif[i].fd_fd < 0; i++) {
+					if (kif[i].fd_fd == KERN_FILE_TEXT) {
+					fallback:
+						struct stat st;
+						char buffer[PATH_MAX];
+						if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
+								S_ISREG(st.st_mode) && realpath(exe.c_str(), buffer) &&
+								st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
+							res = buffer;
 						}
+						if (res.empty() && !error) {
+							error = true;
+							std::size_t last_slash_pos = exe.find_last_of("/");
+							if (last_slash_pos != std::string::npos) {
+								exe = exe.substr(0, last_slash_pos + 1) + kif[i].p_comm;
+								goto fallback;
+							}
+						}
+						break;
 					}
-					break;
 				}
 			}
+			kvm_close(kd);
 		}
-		kvm_close(kd);
 		return res;
 	};
-	auto cppstr_getenv = [](std::string name) {
+	auto cpp_getenv = [](std::string name) {
 		const char *cresult = getenv(name.c_str());
 		std::string result = cresult ? cresult : "";
 		return result;
 	};
 	int cntp = 0;
+	std::string buffer;
 	kvm_t *kd = nullptr;
 	kinfo_proc *proc_info = nullptr;
-	std::vector<std::string> buffer;
 	bool error = false, retried = false;
 	kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
 	if (kd) {
 		if ((proc_info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), sizeof(struct kinfo_proc), &cntp))) {
 			char **cmd = kvm_getargv(kd, proc_info, 0);
-			if (cmd) {
-				for (int i = 0; cmd[i]; i++) {
-					buffer.push_back(cmd[i]);
-				}
+			if (cmd && cmd[0]) {
+				buffer = cmd[0];
 			}
 		}
 		kvm_close(kd);
+		std::string argv0;
 		if (!buffer.empty()) {
-			std::string argv0;
-			if (!buffer[0].empty()) {
-			fallback:
-				std::size_t slash_pos = buffer[0].find('/');
-				std::size_t colon_pos = buffer[0].find(':');
-				if (slash_pos == 0) {
-					argv0 = buffer[0];
-					path = is_exe(argv0);
-				} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
-					std::string penv = cppstr_getenv("PATH");
-					if (!penv.empty()) {
-					retry:
-						std::string tmp;
-						std::stringstream sstr(penv);
-						while (std::getline(sstr, tmp, ':')) {
-							argv0 = tmp + "/" + buffer[0];
-							path = is_exe(argv0);
+		fallback:
+			std::size_t slash_pos = buffer.find('/');
+			std::size_t colon_pos = buffer.find(':');
+			if (slash_pos == 0) {
+				argv0 = buffer;
+				path = cpp_getexe(argv0);
+			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
+				std::string penv = cpp_getenv("PATH");
+				if (!penv.empty()) {
+				retry:
+					std::string tmp;
+					std::stringstream sstr(penv);
+					while (std::getline(sstr, tmp, ':')) {
+						argv0 = tmp + "/" + buffer;
+						path = cpp_getexe(argv0);
+						if (!path.empty()) {
+							break;
+						}
+						if (slash_pos > colon_pos) {
+							argv0 = tmp + "/" + buffer.substr(0, colon_pos);
+							path = cpp_getexe(argv0);
 							if (!path.empty()) {
 								break;
 							}
-							if (slash_pos > colon_pos) {
-								argv0 = tmp + "/" + buffer[0].substr(0, colon_pos);
-								path = is_exe(argv0);
-								if (!path.empty()) {
-									break;
-								}
-							}
 						}
-					}
-					if (path.empty() && !retried) {
-						retried = true;
-						penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
-						std::string home = cppstr_getenv("HOME");
-						if (!home.empty()) {
-							penv = home + "/bin:" + penv;
-						}
-						goto retry;
 					}
 				}
-				if (path.empty() && slash_pos > 0) {
-					std::string pwd = cppstr_getenv("PWD");
-					if (!pwd.empty()) {
-						argv0 = pwd + "/" + buffer[0];
-						path = is_exe(argv0);
+				if (path.empty() && !retried) {
+					retried = true;
+					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
+					std::string home = cpp_getenv("HOME");
+					if (!home.empty()) {
+						penv = home + "/bin:" + penv;
 					}
-					if (path.empty()) {
-						char cwd[PATH_MAX];
-						if (getcwd(cwd, PATH_MAX)) {
-							argv0 = std::string(cwd) + "/" + buffer[0];
-							path = is_exe(argv0);
-						}
+					goto retry;
+				}
+			}
+			if (path.empty() && slash_pos > 0) {
+				std::string pwd = cpp_getenv("PWD");
+				if (!pwd.empty()) {
+					argv0 = pwd + "/" + buffer;
+					path = cpp_getexe(argv0);
+				}
+				if (path.empty()) {
+					char cwd[PATH_MAX];
+					if (getcwd(cwd, PATH_MAX)) {
+						argv0 = std::string(cwd) + "/" + buffer;
+						path = cpp_getexe(argv0);
 					}
 				}
 			}
-			if (path.empty() && !error) {
-				error = true;
-				buffer.clear();
-				std::string underscore = cppstr_getenv("_");
-				if (!underscore.empty()) {
-					buffer.push_back(underscore);
-					goto fallback;
-				}
+		}
+		if (path.empty() && !error) {
+			error = true;
+			buffer.clear();
+			std::string underscore = cpp_getenv("_");
+			if (!underscore.empty()) {
+				buffer = underscore;
+				goto fallback;
 			}
 		}
-		if (!path.empty()) {
-			return String::utf8(path.c_str());
-		}
+	}
+	if (!path.empty()) {
+		return String::utf8(path.c_str());
 	}
 	char resolved_path[MAXPATHLEN];
 	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);


### PR DESCRIPTION
TL;DR I'm CDO. It's like OCD, but in alphabetical order, just as it should be.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path resolution for OpenBSD systems to ensure more reliable identification and execution of the application across different environment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1253)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->