### PR TITLE
Update Linux CI workflow to use GODOT_CPP_BRANCH 4.5

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -8,7 +8,7 @@ env:
     dev_mode=yes
     module_text_server_fb_enabled=yes
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
-  GODOT_CPP_BRANCH: 4.4
+  GODOT_CPP_BRANCH: 4.5
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt
@@ -167,7 +167,7 @@ jobs:
         with:
           bin: ${{ matrix.bin }}
           scons-flags: target=template_debug dev_build=yes verbose=yes
-          redot-cpp-branch: ${{ env.GODOT_CPP_BRANCH }}
+          redot-cpp-branch: "master"
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save


### PR DESCRIPTION
Update the workflows to test against GDExtension 4.5 instead of 4.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Linux build configuration to use godot-cpp version 4.5.
  * Set redot-cpp compilation to use the master branch instead of following the global godot-cpp setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->