### PR TITLE
Fix incorrect version macro usage in MCP module

### DIFF
--- a/modules/mcp/mcp_tools.cpp
+++ b/modules/mcp/mcp_tools.cpp
@@ -702,8 +702,8 @@ MCPTools::ToolResult MCPTools::tool_project_config(const Dictionary &p_args) {
 		info["name"] = ProjectSettings::get_singleton()->get_setting("application/config/name", "Unnamed");
 		info["main_scene"] = ProjectSettings::get_singleton()->get_setting("application/run/main_scene", "");
 		Dictionary v;
-		v["major"] = VERSION_MAJOR;
-		v["minor"] = VERSION_MINOR;
+		v["major"] = REDOT_VERSION_MAJOR;
+		v["minor"] = REDOT_VERSION_MINOR;
 		info["version"] = v;
 		result.add_text(JSON::stringify(info, "  "));
 	} else if (action == "run") {


### PR DESCRIPTION
The module was using deprecated versions of the version macros, this caused compilation failure when built with the `deprecated=no` build option in Scons. Updated to use the proper version macros for Redot.

Fixes #1254 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version information retrieval to ensure accurate major and minor version numbers are reported in project configuration responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->