### PR TITLE
If 'argv[0]' was modified with a leading dash, take that into account.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1196,7 +1196,7 @@ String OS_Unix::get_executable_path() const {
 	std::string buffer;
 	kvm_t *kd = nullptr;
 	kinfo_proc *proc_info = nullptr;
-	bool error = false, retried = false;
+	bool error = false, retried = false, leading_dash_removed = false;
 	kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
 	if (kd) {
 		if ((proc_info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), sizeof(struct kinfo_proc), &cntp))) {
@@ -1215,6 +1215,7 @@ String OS_Unix::get_executable_path() const {
 				argv0 = buffer;
 				path = cpp_getexe(argv0);
 			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
+			retry_without_leading_dash:
 				std::string penv = cpp_getenv("PATH");
 				if (!penv.empty()) {
 				retry:
@@ -1244,8 +1245,14 @@ String OS_Unix::get_executable_path() const {
 					}
 					goto retry;
 				}
+				if (path.empty() && !leading_dash_removed && buffer[0] == '-' && buffer.length() > 1) {
+					buffer = buffer.substr(1);
+					retried = false;
+					leading_dash_removed = true;
+					goto retry_without_leading_dash;
+				}
 			}
-			if (path.empty() && slash_pos > 0) {
+			if (path.empty() && slash_pos != std::string::npos && slash_pos > 0) {
 				std::string pwd = cpp_getenv("PWD");
 				if (!pwd.empty()) {
 					argv0 = pwd + "/" + buffer;
@@ -1266,6 +1273,8 @@ String OS_Unix::get_executable_path() const {
 			std::string underscore = cpp_getenv("_");
 			if (!underscore.empty()) {
 				buffer = underscore;
+				leading_dash_removed = false;
+				retried = false;
 				goto fallback;
 			}
 		}


### PR DESCRIPTION
In some very rare and obscure cases, a parent shell process, or calling process, may modify the current process's `argv[0]`, to be the executable file's base name, while removing the all directory and path separator components, while also prepending a singular leading dash ('-') character.

One of the more common and easy examples of this which may be observed on an OpenBSD system, Korn Shell does this, just check the `argv[0]`, and very often you will notice it will be modified to read as `-ksh` despite not having a leading dash ('-') with its actual executable file's base name.

This pull request takes that into account, and allows the executable path to still succeed, to be correctly retrieved, under cases where `kinfo_file.p_comm[MAXCOMLEN]` is truncated due to the `MAXCOMLEN` byte limit, which is a rather small amount of characters. IIRC it is only 16 bytes.

The OpenBSD executable path code, I admit, is extremely hacky, and takes a lot of guesswork, but after this P.R. get merged, I think our solution will finally cover all the most likely possible ways to get it. Adding any more checks, here on out, isn't necessary. There comes a point where it's too much.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path resolution on OpenBSD systems, with better handling of unconventional path patterns to enhance reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->