### PR TITLE
Fix Segfault in OS_Unix::get_executable_path for OpenBSD

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1245,7 +1245,7 @@ String OS_Unix::get_executable_path() const {
 					}
 					goto retry;
 				}
-				if (path.empty() && !leading_dash_removed && buffer[0] == '-' && buffer.length() > 1) {
+				if (path.empty() && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
 					buffer = buffer.substr(1);
 					retried = false;
 					leading_dash_removed = true;


### PR DESCRIPTION
Due to the `goto` skipping the `!buffer.empty()` check, `buffer.length() > 1` needs to be validated before checking value of `buffer[0]`, not after.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a potential crash on OpenBSD systems that could occur during executable path detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->