### PR TITLE
Added a helper bash script to make building RedotSharp easier

### DIFF
--- a/mono_build_scripts_linux.sh
+++ b/mono_build_scripts_linux.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+SOURCE_NAME="MyLocalNugetSource"
+SOURCE_PATH="$HOME/MyLocalNugetSource"
+
+if ! command -v dotnet &> /dev/null; then
+    echo "Error: dotnet command not found. Please install .NET SDK."
+    exit 1
+fi
+
+if ! dotnet nuget list source | grep -q "$SOURCE_NAME"; then
+    echo "Local nuget store not found, making one in $HOME..."
+    mkdir -p "$SOURCE_PATH"
+    dotnet nuget add source "$SOURCE_PATH" --name "$SOURCE_NAME"
+fi
+
+# Build editor binary
+scons compiledb=yes dev_build=yes platform=linuxbsd target=editor module_mono_enabled=yes || {
+    echo "Error: scons build failed"
+    exit 1
+}
+
+# Generate glue sources
+./bin/redot.linuxbsd.editor.dev.*.mono --headless --generate-mono-glue modules/mono/glue
+
+#Generate binaries
+./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd --push-nupkgs-local "$HOME/MyLocalNugetSource/"


### PR DESCRIPTION
A lot of contributors are having issues building and debugging mono builds.
I am adding a bash script to help with this.

Note, this only supports Linux, but Windows and Mac users should be able to look at the script and infer what commands need to be ran for their platform.

If anyone wants to make dedicated windows or mac versions, I will be more than happy to approve and merge those too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Linux build automation script to simplify local building and packaging: verifies required tooling, sets up a local package feed if needed, builds the editor with Mono support, generates necessary Mono sources and assemblies, and publishes NuGet packages to the local feed for easier local testing and distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->