### PR TITLE
Add support for adjusting color intensity with `Color::apply_intensity` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ gmon.out
 # Jetbrains IDEs
 .idea/
 .fleet/
+.junie/
 
 # Kate
 *.kate-swp

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -336,6 +336,15 @@ Color Color::inverted() const {
 	return c;
 }
 
+Color Color::apply_intensity(float p_intensity) const {
+	if (Math::is_zero_approx(p_intensity)) {
+		return Color(r, g, b, a);
+	}
+
+	float multiplier = Math::pow(2, p_intensity);
+	return Color(CLAMP(r * multiplier, 0.0f, 1.0f), CLAMP(g * multiplier, 0.0f, 1.0f), CLAMP(b * multiplier, 0.0f, 1.0f), a);
+}
+
 Color Color::html(const String &p_rgba) {
 	if (p_rgba.is_empty()) {
 		return Color();

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -109,6 +109,16 @@ struct [[nodiscard]] Color {
 	Color clamp(const Color &p_min = Color(0, 0, 0, 0), const Color &p_max = Color(1, 1, 1, 1)) const;
 	void invert();
 	Color inverted() const;
+	/**
+	 * Applies an intensity adjustment to the color by modifying the RGB components.
+	 * The alpha component remains unchanged. The intensity is applied as a
+	 * power-of-two multiplier to the RGB values, clamped between 0.0 and 1.0.
+	 *
+	 * @param p_intensity The intensity level to apply. A value of 0 will keep the color unchanged.
+	 *                    Positive values increase brightness, and negative values decrease brightness.
+	 * @return A new Color instance with the adjusted RGB components and the original alpha value.
+	 */
+	Color apply_intensity(float p_intensity) const;
 
 	_FORCE_INLINE_ float get_luminance() const {
 		return 0.2126f * r + 0.7152f * g + 0.0722f * b;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2263,6 +2263,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Color, get_luminance, sarray(), varray());
 	bind_method(Color, srgb_to_linear, sarray(), varray());
 	bind_method(Color, linear_to_srgb, sarray(), varray());
+	bind_method(Color, apply_intensity, sarray("intensity"), varray());
 
 	bind_method(Color, is_equal_approx, sarray("to"), varray());
 

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -98,6 +98,15 @@
 		</constructor>
 	</constructors>
 	<methods>
+		<method name="apply_intensity">
+			<return type="Color" />
+			<param index="0" name="intensity" type="float" />
+			<description>
+				Adjusts the color's intensity by multiplying the RGB components with a factor derived from the given intensity.
+				The factor is calculated as 2 raised to the power of the provided intensity value.
+				The adjusted RGB values are clamped to the range [code]0.0[/code] and [code]1.0[/code].
+			</description>
+		</method>
 		<method name="blend" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="over" type="Color" />

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
+using Vec3 = System.Numerics.Vector3;
 #nullable enable
 
 namespace Godot
@@ -345,6 +347,32 @@ namespace Godot
                 (float)Mathf.Clamp(B, minimum.B, maximum.B),
                 (float)Mathf.Clamp(A, minimum.A, maximum.A)
             );
+        }
+
+        /// <summary>
+        /// Modifies the color by applying an intensity level to its RGB components.
+        /// The intensity is applied as a power-of-two multiplier to the RGB values,
+        /// clamping the resulting values within the range of 0.0 to 1.0.
+        /// </summary>
+        /// <param name="intensity">
+        /// The intensity level to apply. A value of zero makes no changes,
+        /// while positive values increase brightness and negative values decrease it.
+        /// </param>
+        /// <returns>
+        /// A new color with the modified RGB intensity.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe Color ApplyIntensity(float intensity)
+        {
+            Color result = this;
+            if (Mathf.IsZeroApprox(intensity))
+                return result;
+
+            float multiplier = MathF.Pow(2f, intensity);
+            // Use SIMD to apply the multiplier to the raw memory containing the RGB components and clamp the result.
+            Vec3* rgb = (Vec3*)Unsafe.AsPointer(ref result);
+            *rgb = Vec3.Clamp(*rgb * multiplier, Vec3.Zero, Vec3.One);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Added `Color::apply_intensity()` method to allow applying an intensity value directly to a `Color` like can be done with the Color Picker.

Closes https://github.com/Redot-Engine/redot-proposals/issues/117

I added bindings for both GDScript and C#, note that the C# variant is SIMD optimized.

Someone else is welcome to add SSE and NEON intrinsics for the C++ version later on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a color intensity adjustment to Color (scales RGB by a power-of-two factor; RGB clamped to [0.0,1.0]; alpha preserved).
  * Exposed equivalent intensity-adjustment method in the C# Color API.

* **Documentation**
  * Updated Color class docs to include the new intensity-adjustment method.

* **Chores**
  * Added a rule to ignore the /.junie/ directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->