### PR TITLE
Mark `apply_intensity` method as `const` in Color documentation

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -98,7 +98,7 @@
 		</constructor>
 	</constructors>
 	<methods>
-		<method name="apply_intensity">
+		<method name="apply_intensity" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="intensity" type="float" />
 			<description>


### PR DESCRIPTION
Fix error in the offline documentation for `Color`.

Not sure how auto-merge allowed this to happen if one of the builds was failing...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Color class documentation to clarify that the `apply_intensity` method operates without modifying the object, enhancing API clarity for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->