### PR TITLE
OpenBSD EXE Path now works even when argv[0] is modified to something bogus

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1303,13 +1303,11 @@ String OS_Unix::get_executable_path() const {
 		buffer.clear();
 		goto path_lookup;
 	}
-	if (!path.empty()) {
-		return String::utf8(path.c_str());
+	if (path.empty()) {
+		WARN_PRINT("Couldn't get executable path from any of the methods tried");
+		return OS::get_executable_path();
 	}
-	char resolved_path[MAXPATHLEN];
-	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);
-	WARN_PRINT("Couldn't get executable path from any of the methods tried");
-	return String::utf8(resolved_path);
+	return String::utf8(path.c_str());
 }
 #elif defined(__NetBSD__)
 	int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -14,7 +14,7 @@
 /* a copy of this software and associated documentation files (the        */
 /* "Software"), to deal in the Software without restriction, including    */
 /* without limitation the rights to use, copy, modify, merge, publish,    */
-/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */f
 /* permit persons to whom the Software is furnished to do so, subject to  */
 /* the following conditions:                                              */
 /*                                                                        */
@@ -1166,7 +1166,7 @@ String OS_Unix::get_executable_path() const {
 					fallback:
 						struct stat st;
 						char buffer[PATH_MAX];
-						if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) && 
+						if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
 								S_ISREG(st.st_mode) && realpath(exe.c_str(), buffer) &&
 								st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
 							res = buffer;
@@ -1258,7 +1258,7 @@ String OS_Unix::get_executable_path() const {
 					retried = true;
 					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
 					std::string home = cpp_getenv("HOME");
-				 	if (!home.empty()) {
+					if (!home.empty()) {
 						penv = home + "/bin:" + penv;
 					}
 					goto retry;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1254,35 +1254,34 @@ String OS_Unix::get_executable_path() const {
 						}
 					}
 				}
-				if (path.empty() && !retried) {
-					retried = true;
-					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
-					std::string home = cpp_getenv("HOME");
-					if (!home.empty()) {
-						penv = home + "/bin:" + penv;
-					}
-					goto retry;
-				}
-
-				if (path.empty() && !argv0_does_not_exist && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
-					buffer = buffer.substr(1);
-					retried = false;
-					leading_dash_removed = true;
-					goto retry_without_leading_dash;
-				}
 			}
-			if (path.empty() && (argv0_does_not_exist || (slash_pos != std::string::npos && slash_pos > 0))) {
-				std::string pwd = cpp_getenv("PWD");
-				if (!pwd.empty()) {
-					argv0 = pwd + "/" + buffer;
-					path = cpp_getexe(argv0);
+			if (path.empty() && !retried) {
+				retried = true;
+				penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
+				std::string home = cpp_getenv("HOME");
+				if (!home.empty()) {
+					penv = home + "/bin:" + penv;
 				}
-				if (path.empty()) {
-					char cwd[PATH_MAX];
-					if (getcwd(cwd, PATH_MAX)) {
-						argv0 = std::string(cwd) + "/" + buffer;
-						path = cpp_getexe(argv0);
-					}
+				goto retry;
+			}
+			if (path.empty() && !argv0_does_not_exist && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
+				buffer = buffer.substr(1);
+				retried = false;
+				leading_dash_removed = true;
+				goto retry_without_leading_dash;
+			}
+		}
+		if (path.empty() && (argv0_does_not_exist || (slash_pos != std::string::npos && slash_pos > 0))) {
+			std::string pwd = cpp_getenv("PWD");
+			if (!pwd.empty()) {
+				argv0 = pwd + "/" + buffer;
+				path = cpp_getexe(argv0);
+			}
+			if (path.empty()) {
+				char cwd[PATH_MAX];
+				if (getcwd(cwd, PATH_MAX)) {
+					argv0 = std::string(cwd) + "/" + buffer;
+					path = cpp_getexe(argv0);
 				}
 			}
 		}

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -14,7 +14,7 @@
 /* a copy of this software and associated documentation files (the        */
 /* "Software"), to deal in the Software without restriction, including    */
 /* without limitation the rights to use, copy, modify, merge, publish,    */
-/* distribute, sublicense, and/or sell copies of the Software, and to     */f
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
 /* permit persons to whom the Software is furnished to do so, subject to  */
 /* the following conditions:                                              */
 /*                                                                        */

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1264,7 +1264,7 @@ String OS_Unix::get_executable_path() const {
 				}
 				goto retry;
 			}
-			if (path.empty() && !argv0_does_not_exist && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
+			if (path.empty() && !argv0_does_not_exist && !leading_dash_removed && slash_pos == std::string::npos && buffer.length() > 1 && buffer[0] == '-') {
 				buffer = buffer.substr(1);
 				retried = false;
 				leading_dash_removed = true;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1174,7 +1174,7 @@ String OS_Unix::get_executable_path() const {
 						if (res.empty() && !error1) {
 							error1 = true;
 							size_t last_slash_pos = exe.find_last_of("/");
-							if (last_slash_pos != string::npos) {
+							if (last_slash_pos != std::string::npos) {
 								exe = exe.substr(0, last_slash_pos + 1) + kif[i].p_comm;
 								goto fallback;
 							}
@@ -1182,7 +1182,7 @@ String OS_Unix::get_executable_path() const {
 						if (res.empty() && !error2) {
 							error2 = true;
 							size_t last_slash_pos = exe.find_last_of("/");
-							if (last_slash_pos != string::npos) {
+							if (last_slash_pos != std::string::npos) {
 								const char *progname = getprogname();
 								if (progname) {
 									exe = exe.substr(0, last_slash_pos + 1) + progname;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1232,7 +1232,7 @@ String OS_Unix::get_executable_path() const {
 		if (slash_pos == 0) {
 			argv0 = buffer;
 			path = cpp_getexe(argv0);
-		} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
+		} else if (slash_pos == std::string::npos || (colon_pos != std::string::npos && colon_pos > 0 && slash_pos > colon_pos)) {
 		path_lookup:
 		retry_without_leading_dash:
 			std::string penv = cpp_getenv("PATH");
@@ -1246,7 +1246,7 @@ String OS_Unix::get_executable_path() const {
 					if (!path.empty()) {
 						break;
 					}
-					if (slash_pos > colon_pos) {
+					if (!argv0_does_not_exist && colon_pos != std::string::npos && colon_pos > 0 && slash_pos > colon_pos) {
 						argv0 = tmp + "/" + buffer.substr(0, colon_pos);
 						path = cpp_getexe(argv0);
 						if (!path.empty()) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1157,7 +1157,7 @@ String OS_Unix::get_executable_path() const {
 		std::string res;
 		kvm_t *kd = nullptr;
 		kinfo_file *kif = nullptr;
-		bool error = false;
+		bool error1 = false, error2 = false;
 		kd = kvm_openfiles(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
 		if (kd) {
 			if ((kif = kvm_getfiles(kd, KERN_FILE_BYPID, getpid(), sizeof(struct kinfo_file), &cntp))) {
@@ -1166,17 +1166,28 @@ String OS_Unix::get_executable_path() const {
 					fallback:
 						struct stat st;
 						char buffer[PATH_MAX];
-						if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) &&
+						if (!stat(exe.c_str(), &st) && (st.st_mode & S_IXUSR) && 
 								S_ISREG(st.st_mode) && realpath(exe.c_str(), buffer) &&
 								st.st_dev == (dev_t)kif[i].va_fsid && st.st_ino == (ino_t)kif[i].va_fileid) {
 							res = buffer;
 						}
-						if (res.empty() && !error) {
-							error = true;
-							std::size_t last_slash_pos = exe.find_last_of("/");
-							if (last_slash_pos != std::string::npos) {
+						if (res.empty() && !error1) {
+							error1 = true;
+							size_t last_slash_pos = exe.find_last_of("/");
+							if (last_slash_pos != string::npos) {
 								exe = exe.substr(0, last_slash_pos + 1) + kif[i].p_comm;
 								goto fallback;
+							}
+						}
+						if (res.empty() && !error2) {
+							error2 = true;
+							size_t last_slash_pos = exe.find_last_of("/");
+							if (last_slash_pos != string::npos) {
+								const char *progname = getprogname();
+								if (progname) {
+									exe = exe.substr(0, last_slash_pos + 1) + progname;
+									goto fallback;
+								}
 							}
 						}
 						break;
@@ -1206,33 +1217,40 @@ String OS_Unix::get_executable_path() const {
 			}
 		}
 		kvm_close(kd);
-		std::string argv0;
-		if (!buffer.empty()) {
-		fallback:
-			std::size_t slash_pos = buffer.find('/');
-			std::size_t colon_pos = buffer.find(':');
-			if (slash_pos == 0) {
-				argv0 = buffer;
-				path = cpp_getexe(argv0);
-			} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
-			retry_without_leading_dash:
-				std::string penv = cpp_getenv("PATH");
-				if (!penv.empty()) {
-				retry:
-					std::string tmp;
-					std::stringstream sstr(penv);
-					while (std::getline(sstr, tmp, ':')) {
-						argv0 = tmp + "/" + buffer;
+	}
+	std::string argv0;
+	bool argv0_does_not_exist = false;
+	size_t slash_pos = std::string::npos;
+	size_t colon_pos = std::string::npos;
+	if (buffer.empty()) {
+		argv0_does_not_exist = true;
+		goto path_lookup;
+	} else {
+	fallback:
+		slash_pos = buffer.find('/');
+		colon_pos = buffer.find(':');
+		if (slash_pos == 0) {
+			argv0 = buffer;
+			path = cpp_getexe(argv0);
+		} else if (slash_pos == std::string::npos || slash_pos > colon_pos) {
+		path_lookup:
+		retry_without_leading_dash:
+			std::string penv = cpp_getenv("PATH");
+			if (!penv.empty()) {
+			retry:
+				std::string tmp;
+				std::stringstream sstr(penv);
+				while (std::getline(sstr, tmp, ':')) {
+					argv0 = tmp + "/" + buffer;
+					path = cpp_getexe(argv0);
+					if (!path.empty()) {
+						break;
+					}
+					if (slash_pos > colon_pos) {
+						argv0 = tmp + "/" + buffer.substr(0, colon_pos);
 						path = cpp_getexe(argv0);
 						if (!path.empty()) {
 							break;
-						}
-						if (slash_pos > colon_pos) {
-							argv0 = tmp + "/" + buffer.substr(0, colon_pos);
-							path = cpp_getexe(argv0);
-							if (!path.empty()) {
-								break;
-							}
 						}
 					}
 				}
@@ -1240,19 +1258,20 @@ String OS_Unix::get_executable_path() const {
 					retried = true;
 					penv = "/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11R6/bin:/usr/local/bin:/usr/local/sbin";
 					std::string home = cpp_getenv("HOME");
-					if (!home.empty()) {
+				 	if (!home.empty()) {
 						penv = home + "/bin:" + penv;
 					}
 					goto retry;
 				}
-				if (path.empty() && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
+
+				if (path.empty() && !argv0_does_not_exist && !leading_dash_removed && buffer.length() > 1 && buffer[0] == '-') {
 					buffer = buffer.substr(1);
 					retried = false;
 					leading_dash_removed = true;
 					goto retry_without_leading_dash;
 				}
 			}
-			if (path.empty() && slash_pos != std::string::npos && slash_pos > 0) {
+			if (path.empty() && (argv0_does_not_exist || (slash_pos != std::string::npos && slash_pos > 0))) {
 				std::string pwd = cpp_getenv("PWD");
 				if (!pwd.empty()) {
 					argv0 = pwd + "/" + buffer;
@@ -1278,6 +1297,12 @@ String OS_Unix::get_executable_path() const {
 				goto fallback;
 			}
 		}
+	}
+	if (path.empty() && !argv0_does_not_exist) {
+		argv0_does_not_exist = true;
+		retried = false;
+		buffer.clear();
+		goto path_lookup;
 	}
 	if (!path.empty()) {
 		return String::utf8(path.c_str());


### PR DESCRIPTION
I want to apologize for making a P.R. for this code segment again when I previously said I wouldn't and I was done with it. There was a major flaw with my previous code I discovered last night, which this P.R. addresses to the best of my ability. It now works even when `argv[0]` is modified to be something bogus, whether an empty string, nullptr, or non-existent file path, and it works under most such cases, unlike before.

Edit: I've now thoroughly tested this and verified all is working as intended. It is now ready for code review.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust executable-path resolution on OpenBSD: independent fallback attempts and clearer retry flows increase success locating the running program across varied environments.
  * Improved handling of missing, empty, or malformed program names; when resolution ultimately fails the system now emits a warning and returns the default executable path rather than attempting a normalization fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->