### PR TITLE
Fix missing cherry-pick from IK pull in

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1151,7 +1151,7 @@ void Skeleton3DEditor::create_editors() {
 	key_mod_insert_new_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	key_mod_insert_new_button->connect(SceneStringName(pressed), callable_mp(this, &Skeleton3DEditor::insert_keys).bind(true, true));
 	key_mod_insert_new_button->set_tooltip_text(TTRC("Insert new key (based on mask) for all modified bones."));
-	key_mod_insert_new_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_of_all_bones", TTRC("Insert Key (All Bones)"), KeyModifierMask::CMD_OR_CTRL + Key::INSERT));
+	key_mod_insert_new_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_of_all_modified_bones", TTRC("Insert Key (All Modified Bones)"), KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL | Key::INSERT));
 	animation_hb->add_child(key_mod_insert_new_button);
 
 	// Bone tree.

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1146,6 +1146,14 @@ void Skeleton3DEditor::create_editors() {
 	key_mod_insert_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_to_existing_tracks", TTRC("Insert Key (Existing Tracks)"), Key::INSERT));
 	animation_hb->add_child(key_mod_insert_button);
 
+	key_mod_insert_new_button = memnew(Button);
+	key_mod_insert_new_button->set_theme_type_variation(SceneStringName(FlatButton));
+	key_mod_insert_new_button->set_focus_mode(FOCUS_ACCESSIBILITY);
+	key_mod_insert_new_button->connect(SceneStringName(pressed), callable_mp(this, &Skeleton3DEditor::insert_keys).bind(true, true));
+	key_mod_insert_new_button->set_tooltip_text(TTRC("Insert new key (based on mask) for all modified bones."));
+	key_mod_insert_new_button->set_shortcut(ED_SHORTCUT("skeleton_3d_editor/insert_key_of_all_bones", TTRC("Insert Key (All Bones)"), KeyModifierMask::CMD_OR_CTRL + Key::INSERT));
+	animation_hb->add_child(key_mod_insert_new_button);
+
 	// Bone tree.
 	bones_section = memnew(EditorInspectorSection);
 	bones_section->setup("bones", "Bones", skeleton, Color(0.0f, 0.0, 0.0f), true);


### PR DESCRIPTION
Fixes gh-1269

Not sure why this change wasn't pulled in when I initially did the cherry-pick since there is other logic from this cherry-picked commit already in the engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Insert New Key" button to the Skeleton 3D editor to insert keyframes for all modified bones at once, streamlining animation workflows.
  * Added a keyboard shortcut (Shift + Cmd/Ctrl + Insert) and a flat-style button for quick, unobtrusive access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-engine/pull/1271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->