### PR TITLE
Update release build scripts to enable DX12 support on Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,8 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa"
+    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
+    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
   variables:
     PLATFORM: "windows"
 
@@ -137,7 +138,8 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa"
+    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
+    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
   variables:
     PLATFORM: "windows"
 
@@ -148,7 +150,8 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa"
+    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
+    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
   script:
     - !reference [ .build-release-template, script ]
   after_script:
@@ -176,7 +179,8 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa"
+    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
+    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
   script:
     - !reference [ .build-release-template-mono, script ]
   after_script:


### PR DESCRIPTION
Adjusted release build scripts to install dx12 dependencies, and added the build flags to enable DX12 support for Windows builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration to enable D3D12 graphics API support, including automatic installation of the required D3D12 SDK as part of the build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->