### PR TITLE
Update wayland class name to Redot branding

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -73,11 +73,11 @@ String DisplayServerWayland::_get_app_id_from_context(Context p_context) {
 
 	switch (p_context) {
 		case CONTEXT_EDITOR: {
-			app_id = "org.godotengine.Editor";
+			app_id = "org.redotengine.Editor";
 		} break;
 
 		case CONTEXT_PROJECTMAN: {
-			app_id = "org.godotengine.ProjectManager";
+			app_id = "org.redotengine.ProjectManager";
 		} break;
 
 		case CONTEXT_ENGINE:
@@ -86,7 +86,7 @@ String DisplayServerWayland::_get_app_id_from_context(Context p_context) {
 			if (config_name.length() != 0) {
 				app_id = config_name;
 			} else {
-				app_id = "org.godotengine.Redot";
+				app_id = "org.redotengine.Redot";
 			}
 		}
 	}


### PR DESCRIPTION
Updates the branding in wayland to be redot. This way mistakenly reverted in 21ec28e49b1590beb0b7c6866d5de29c2e37297b 

This is not related to android as android does not use wayland so it should not effect it.

This field is used to set the class name in wayland for identification purposes so that outside programs know about it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s Wayland application IDs to use Redot-specific identifiers, improving desktop integration on Linux/Wayland.
  * The editor, engine/default, and project manager now present consistent Redot app IDs instead of the previous ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->