### PR TITLE
Fix mis-named .dll in OpenVisualStudio csproj file.

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/RedotTools.OpenVisualStudio.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/RedotTools.OpenVisualStudio.csproj
@@ -9,7 +9,7 @@
     <RollForward>LatestMajor</RollForward>
     <RootNamespace>GodotTools.OpenVisualStudio</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition="Exists('$(SolutionDir)/../../../../bin/GodotSharp/Api/Debug/GodotSharp.dll') And ('$(GodotPlatform)' == 'windows' Or ('$(GodotPlatform)' == '' And '$(OS)' == 'Windows_NT'))">
+   <PropertyGroup Condition="Exists('$(SolutionDir)/../../../../bin/GodotSharp/Api/Debug/RedotSharp.dll') And ('$(GodotPlatform)' == 'windows' Or ('$(GodotPlatform)' == '' And '$(OS)' == 'Windows_NT'))">
     <OutputPath>$(SolutionDir)/../../../../bin/GodotSharp/Tools</OutputPath>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>False</AppendRuntimeIdentifierToOutputPath>


### PR DESCRIPTION
Fixes #1155 

Tested by building on Linux (mingw, etc...):
```
./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
```

This command created the RedotTools.OpenVisualStudio.dll & similar files in the resulting GodotSharp/Tools folder after fixing the .dll name.  This should fix the missing functionality for Windows users if integrated into the CI pipeline.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build configuration to correctly detect the updated debug DLL, helping the editor integrate with the right runtime files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->