### PR TITLE
MCP: Audit and harden native MCP server implementation

### DIFF
--- a/modules/mcp/doc_classes/MCPBridge.xml
+++ b/modules/mcp/doc_classes/MCPBridge.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MCPBridge" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		TCP bridge relaying commands between the MCP server and a running game process.
 	</brief_description>
 	<description>
+		[MCPBridge] is a bidirectional TCP relay. On the server (headless) side it listens on an ephemeral loopback port and sends commands produced by MCP tools. On the game side (started with the [code]--mcp-bridge-port[/code] flag) it connects back to that port, receives commands, executes them against the live scene tree/viewport, and returns results. The bridge is single-connection and automatically replaces a stale peer when a new game process connects.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="update">
 			<return type="void" />
 			<description>
+				Pumps the bridge: on the host side it accepts pending connections; on the game side it reads incoming commands, dispatches them, and writes responses. Called each frame from the main loop (game side) or the server's bridge thread (host side).
 			</description>
 		</method>
 	</methods>

--- a/modules/mcp/doc_classes/MCPProtocol.xml
+++ b/modules/mcp/doc_classes/MCPProtocol.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MCPProtocol" inherits="JSONRPC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		MCP JSON-RPC protocol handler: capability negotiation, tool listing, and dispatch.
 	</brief_description>
 	<description>
+		Implements the Model Context Protocol request layer on top of the JSONRPC class. Handles the [code]initialize[/code] handshake with version negotiation, the [code]notifications/initialized[/code] lifecycle event, [code]ping[/code], [code]tools/list[/code], and [code]tools/call[/code]. Tool execution is delegated to the internal MCPTools class. The operation phase is gated until the [code]initialized[/code] notification is received, per spec.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_initialized" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] after the client has sent the [code]notifications/initialized[/code] handshake message, marking the start of the operation phase.
 			</description>
 		</method>
 	</methods>

--- a/modules/mcp/doc_classes/MCPServer.xml
+++ b/modules/mcp/doc_classes/MCPServer.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MCPServer" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Stdio-based MCP (Model Context Protocol) server for AI agent integration.
 	</brief_description>
 	<description>
+		The MCP server exposes the running Redot project to AI coding assistants over a JSON-RPC stdio transport. It is started with the [code]--mcp-server[/code] command-line flag, which implies headless mode. The server reads newline-delimited JSON-RPC requests on stdin and writes responses to stdout. A TCP bridge ([MCPBridge]) is used to forward tool calls (screenshots, input, tree inspection) to a separately launched game process. See [url=https://modelcontextprotocol.io/]the MCP specification[/url] for protocol details.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,16 +12,19 @@
 		<method name="is_running" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] while the server loop is processing requests.
 			</description>
 		</method>
 		<method name="start">
 			<return type="void" />
 			<description>
+				Starts the blocking server loop. Reads requests from stdin and dispatches them to the registered protocol handlers. Returns when the input stream is closed or [method stop] is requested.
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
+				Signals the server loop to stop and wakes the stdin poll.
 			</description>
 		</method>
 	</methods>

--- a/modules/mcp/mcp_bridge.cpp
+++ b/modules/mcp/mcp_bridge.cpp
@@ -133,31 +133,57 @@ Dictionary MCPBridge::send_command(const String &p_action, const Dictionary &p_a
 
 	// Wait for response (blocking with timeout)
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
-	String response_str;
+	CharString raw_buffer;
+	bool got_response = false;
 	while (OS::get_singleton()->get_ticks_msec() - start_time < 5000) {
 		conn->poll();
-		if (conn->get_available_bytes() > 0) {
-			uint8_t c;
-			int read_bytes;
-			conn->get_partial_data(&c, 1, read_bytes);
+		int avail = conn->get_available_bytes();
+		if (avail > 0) {
+			uint8_t buf[4096];
+			int to_read = avail < (int)sizeof(buf) ? avail : (int)sizeof(buf);
+			int read_bytes = 0;
+			conn->get_partial_data(buf, to_read, read_bytes);
 			if (read_bytes > 0) {
-				if (c == '\n') {
-					goto parsed;
+				// Append raw bytes to the buffer (resize + copy).
+				int old_len = raw_buffer.length();
+				raw_buffer.resize_uninitialized(old_len + read_bytes + 1);
+				char *dst = raw_buffer.ptrw();
+				memcpy(dst + old_len, buf, read_bytes);
+				dst[old_len + read_bytes] = 0;
+
+				// Only scan the newly appended bytes for the delimiter.
+				for (int i = old_len; i < old_len + read_bytes; i++) {
+					if (raw_buffer[i] == '\n') {
+						got_response = true;
+						break;
+					}
 				}
-				response_str += (char)c;
+				if (got_response) {
+					break;
+				}
 			}
 		} else {
 			OS::get_singleton()->delay_usec(1000);
 		}
 	}
 
-	{
+	if (!got_response) {
 		Dictionary err;
 		err["error"] = "Bridge timeout";
 		return err;
 	}
 
-parsed:
+	// Decode the full buffer at once so multi-byte UTF-8 sequences
+	// spanning TCP chunk boundaries are handled correctly.
+	int nl = -1;
+	for (int i = 0; i < raw_buffer.length(); i++) {
+		if (raw_buffer[i] == '\n') {
+			nl = i;
+			break;
+		}
+	}
+	int len = (nl >= 0) ? nl : raw_buffer.length();
+	String response_str = String::utf8(raw_buffer.get_data(), len);
 	if (response_str.is_empty()) {
 		Dictionary err;
 		err["error"] = "Empty response";
@@ -178,12 +204,22 @@ void MCPBridge::update() {
 	MutexLock lock(mutex);
 	if (is_host) {
 		if (server->is_connection_available()) {
+			// Only replace the connection if the current one is stale/disconnected,
+			// so we never drop a peer mid-command from the bridge thread.
+			bool current_ok = false;
 			if (connection.is_valid()) {
-				fprintf(stderr, "[MCP] Dropping existing connection for new client\n");
-				connection->disconnect_from_host();
+				connection->poll();
+				current_ok = (connection->get_status() == StreamPeerTCP::STATUS_CONNECTED);
 			}
-			connection = server->take_connection();
-			fprintf(stderr, "[MCP] Game process connected to bridge on host side\n");
+			if (!current_ok) {
+				connection = server->take_connection();
+				fprintf(stderr, "[MCP] Game process connected to bridge on host side\n");
+			} else {
+				// Drain and discard the extra pending connection.
+				Ref<StreamPeerTCP> extra = server->take_connection();
+				extra->disconnect_from_host();
+				fprintf(stderr, "[MCP] Bridge: extra pending connection discarded (active connection in use)\n");
+			}
 		}
 	} else {
 		// Client (Game) side
@@ -289,6 +325,10 @@ Dictionary MCPBridge::_process_command(const Dictionary &p_cmd) {
 				return resp;
 			}
 			Ref<Image> img = tex->get_image();
+			if (img.is_null()) {
+				resp["error"] = "Viewport returned no image (not rendered yet or headless)";
+				return resp;
+			}
 
 			float scale = args.get("scale", 1.0);
 			if (scale != 1.0) {
@@ -296,6 +336,10 @@ Dictionary MCPBridge::_process_command(const Dictionary &p_cmd) {
 			}
 
 			PackedByteArray png_buffer = img->save_png_to_buffer();
+			if (png_buffer.is_empty()) {
+				resp["error"] = "Failed to encode PNG";
+				return resp;
+			}
 			resp["image_base64"] = CryptoCore::b64_encode_str(png_buffer.ptr(), png_buffer.size());
 			resp["format"] = "png";
 			resp["width"] = img->get_width();

--- a/modules/mcp/mcp_protocol.cpp
+++ b/modules/mcp/mcp_protocol.cpp
@@ -72,8 +72,8 @@ void MCPProtocol::_bind_methods() {
 
 Dictionary MCPProtocol::_make_capabilities() const {
 	Dictionary caps;
-	// We support tools
 	Dictionary tools_cap;
+	tools_cap["listChanged"] = false;
 	caps["tools"] = tools_cap;
 	return caps;
 }
@@ -85,13 +85,27 @@ Dictionary MCPProtocol::_make_server_info() const {
 	return info;
 }
 
+String MCPProtocol::_negotiate_version(const String &p_client_version) {
+	if (p_client_version == MCP_PROTOCOL_VERSION_LATEST || p_client_version == MCP_PROTOCOL_VERSION_LEGACY) {
+		return p_client_version;
+	}
+	return MCP_PROTOCOL_VERSION_LATEST;
+}
+
 Variant MCPProtocol::_handle_initialize(const Variant &p_params) {
+	String client_version;
+	if (p_params.get_type() == Variant::DICTIONARY) {
+		Dictionary params = p_params;
+		Variant pv = params.get("protocolVersion", Variant());
+		if (pv.get_type() == Variant::STRING) {
+			client_version = pv;
+		}
+	}
+
 	Dictionary result;
-	result["protocolVersion"] = MCP_PROTOCOL_VERSION;
+	result["protocolVersion"] = _negotiate_version(client_version);
 	result["capabilities"] = _make_capabilities();
 	result["serverInfo"] = _make_server_info();
-
-	initialized = true;
 	return result;
 }
 
@@ -100,8 +114,12 @@ Array MCPProtocol::_get_tool_definitions() const {
 }
 
 Variant MCPProtocol::_handle_tools_list(const Variant &p_params) {
-	if (!is_initialized()) {
-		return make_response_error(INVALID_REQUEST, "Protocol not initialized");
+	// Defense-in-depth: process_string gates this, but guard anyway in case
+	// dispatch bypasses the override (e.g. via base pointer or a notification).
+	if (!initialized) {
+		Dictionary result;
+		result["tools"] = Array();
+		return result;
 	}
 	Dictionary result;
 	result["tools"] = _get_tool_definitions();
@@ -109,8 +127,9 @@ Variant MCPProtocol::_handle_tools_list(const Variant &p_params) {
 }
 
 Variant MCPProtocol::_handle_tools_call(const Variant &p_params) {
-	if (!is_initialized()) {
-		return make_response_error(INVALID_REQUEST, "Protocol not initialized");
+	// Defense-in-depth: never execute a tool before the init handshake.
+	if (!initialized) {
+		return _make_tool_result_error("Protocol not initialized");
 	}
 	Dictionary params;
 	if (p_params.get_type() == Variant::DICTIONARY) {
@@ -120,15 +139,15 @@ Variant MCPProtocol::_handle_tools_call(const Variant &p_params) {
 		if (!arr.is_empty() && arr[0].get_type() == Variant::DICTIONARY) {
 			params = arr[0];
 		} else {
-			return make_response_error(INVALID_PARAMS, "Tool call parameters must be an object (or array with object)");
+			return _make_tool_result_error("Tool call parameters must be an object (or array with object)");
 		}
 	} else {
-		return make_response_error(INVALID_PARAMS, "Tool call parameters must be an object");
+		return _make_tool_result_error("Tool call parameters must be an object");
 	}
 
 	String tool_name = params.get("name", "");
 	if (tool_name.is_empty()) {
-		return make_response_error(INVALID_PARAMS, "Missing tool name");
+		return _make_tool_result_error("Missing tool name");
 	}
 
 	Dictionary arguments;
@@ -154,18 +173,55 @@ Dictionary MCPProtocol::_make_tool_result(const Array &p_content, bool p_is_erro
 	return result;
 }
 
-Dictionary MCPProtocol::_make_text_content(const String &p_text) const {
+Dictionary MCPProtocol::_make_tool_result_error(const String &p_message) const {
 	Dictionary content;
 	content["type"] = "text";
-	content["text"] = p_text;
-	return content;
+	content["text"] = "Error: " + p_message;
+
+	Array content_arr;
+	content_arr.push_back(content);
+
+	Dictionary result;
+	result["content"] = content_arr;
+	result["isError"] = true;
+	return result;
 }
 
 Variant MCPProtocol::_handle_initialized_notification(const Variant &p_params) {
-	// Notification, no return value needed (but Variant() is void)
+	// Per spec, the operation phase begins after this notification.
+	initialized = true;
 	return Variant();
 }
 
 Variant MCPProtocol::_handle_ping(const Variant &p_params) {
 	return Dictionary(); // Empty object
+}
+
+String MCPProtocol::process_string(const String &p_input) {
+	// Gate tools/* requests before initialization at the protocol level,
+	// returning a proper JSON-RPC error (not a double-wrapped result).
+	// Notifications (no id) are silently dropped so the tool never executes.
+	if (!initialized && !p_input.is_empty()) {
+		JSON json;
+		if (json.parse(p_input) == OK) {
+			Variant data = json.get_data();
+			if (data.get_type() == Variant::DICTIONARY) {
+				Dictionary req = data;
+				String method = req.get("method", "");
+				if (method == "tools/list" || method == "tools/call") {
+					if (req.has("id")) {
+						Variant id = req["id"];
+						if (id.get_type() == Variant::FLOAT && id.operator float() == (float)(id.operator int())) {
+							id = id.operator int();
+						}
+						Dictionary resp = make_response_error(INVALID_REQUEST, "Protocol not initialized", id);
+						return JSON::stringify(resp);
+					}
+					// Notification before init: drop silently (no response permitted).
+					return String();
+				}
+			}
+		}
+	}
+	return JSONRPC::process_string(p_input);
 }

--- a/modules/mcp/mcp_protocol.h
+++ b/modules/mcp/mcp_protocol.h
@@ -66,11 +66,12 @@ private:
 	Dictionary _make_capabilities() const;
 	Dictionary _make_server_info() const;
 	Array _get_tool_definitions() const;
+	static String _negotiate_version(const String &p_client_version);
 	/// @}
 
 	/// Make MCP-formatted tool result
 	Dictionary _make_tool_result(const Array &p_content, bool p_is_error = false) const;
-	Dictionary _make_text_content(const String &p_text) const;
+	Dictionary _make_tool_result_error(const String &p_message) const;
 
 protected:
 	static void _bind_methods();
@@ -80,4 +81,8 @@ public:
 	~MCPProtocol();
 
 	bool is_initialized() const { return initialized; }
+
+	/// Override to gate pre-initialization requests (avoids double-wrapped errors).
+	/// Shadows JSONRPC::process_string; called via MCPProtocol* static dispatch.
+	String process_string(const String &p_input);
 };

--- a/modules/mcp/mcp_tools.cpp
+++ b/modules/mcp/mcp_tools.cpp
@@ -39,12 +39,15 @@
 #include "mcp_tools.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input_event.h"
+#include "core/input/input_map.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
+#include "core/os/keyboard.h"
 #include "core/version.h"
 #include "mcp_bridge.h"
 #include "mcp_server.h"
@@ -90,7 +93,34 @@ Error MCPTools::_ensure_callback_exists(const String &p_script_path, const Strin
 	String content = f->get_as_text();
 	f.unref();
 
-	if (content.contains("func " + p_callback_name)) {
+	// Word-boundary check: find "func <name>" as a token anywhere in the line
+	// (handles "static func", "@rpc(...) func", etc.) followed by "(" or whitespace,
+	// so substrings don't cause false positives.
+	bool exists = false;
+	{
+		String token = "func " + p_callback_name;
+		Vector<String> lines = content.split("\n");
+		for (const String &line : lines) {
+			String trimmed = line.strip_edges();
+			int idx = trimmed.find(token);
+			while (idx >= 0) {
+				// "func" must start at a token boundary (line start or after whitespace).
+				bool boundary_ok = (idx == 0) || trimmed[idx - 1] == ' ' || trimmed[idx - 1] == '\t';
+				if (boundary_ok) {
+					String rest = trimmed.substr(idx + token.length());
+					if (rest.is_empty() || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t') {
+						exists = true;
+						break;
+					}
+				}
+				idx = trimmed.find(token, idx + 1);
+			}
+			if (exists) {
+				break;
+			}
+		}
+	}
+	if (exists) {
 		return OK;
 	}
 
@@ -134,8 +164,16 @@ String MCPTools::normalize_path(const String &p_path) {
 
 bool MCPTools::validate_path(const String &p_path) {
 	String normalized = normalize_path(p_path);
-	if (normalized.contains("..") || !normalized.begins_with("res://")) {
+	if (!normalized.begins_with("res://")) {
 		return false;
+	}
+	// Reject any path segment that is exactly ".." (traversal).
+	// Filenames containing ".." as a substring (e.g. "my..file.gd") are allowed.
+	Vector<String> parts = normalized.split("/");
+	for (const String &p : parts) {
+		if (p == "..") {
+			return false;
+		}
 	}
 	return true;
 }
@@ -174,6 +212,7 @@ Array MCPTools::get_tool_definitions() {
 		tool["name"] = "scene_action";
 		tool["description"] = "Perform actions within a scene file (add nodes, set properties, wire signals). IMPORTANT: Always use this tool for .tscn files instead of direct text editing to maintain project integrity.";
 		tool["inputSchema"] = MCPSchemaBuilder::make_object_schema(props, required);
+		tool["annotations"] = MCPSchemaBuilder::make_tool_annotations(false, true, false, true);
 		tools.push_back(tool);
 	}
 
@@ -195,6 +234,7 @@ Array MCPTools::get_tool_definitions() {
 		tool["name"] = "resource_action";
 		tool["description"] = "Manage Redot resource files (.tres) and asset imports";
 		tool["inputSchema"] = MCPSchemaBuilder::make_object_schema(props, required);
+		tool["annotations"] = MCPSchemaBuilder::make_tool_annotations(false, true, false, true);
 		tools.push_back(tool);
 	}
 
@@ -212,6 +252,7 @@ Array MCPTools::get_tool_definitions() {
 		tool["name"] = "code_intel";
 		tool["description"] = "Script analysis and engine documentation lookup";
 		tool["inputSchema"] = MCPSchemaBuilder::make_object_schema(props, required);
+		tool["annotations"] = MCPSchemaBuilder::make_tool_annotations(true, false, true, false);
 		tools.push_back(tool);
 	}
 
@@ -219,9 +260,9 @@ Array MCPTools::get_tool_definitions() {
 	{
 		Dictionary props;
 		props["action"] = MCPSchemaBuilder::make_string_property("Action: 'get_info', 'set_setting', 'add_input', 'add_autoload', 'run', 'stop', 'output', 'list_files', 'read_file_res', 'create_file_res', 'open_editor'");
-		props["setting"] = MCPSchemaBuilder::make_string_property("Setting key or Autoload/Input name");
-		props["value"] = MCPSchemaBuilder::make_object_property("Value for setting");
-		props["path"] = MCPSchemaBuilder::make_string_property("File/Directory path (res://)");
+		props["setting"] = MCPSchemaBuilder::make_string_property("Used by 'set_setting' (key), 'add_input' (action name), 'add_autoload' (autoload name)");
+		props["value"] = MCPSchemaBuilder::make_object_property("Used by 'set_setting' (arbitrary value), 'add_input' ({keycode: int|str, deadzone: float}). NOT used by add_autoload.");
+		props["path"] = MCPSchemaBuilder::make_string_property("Used by 'add_autoload' (script path res://), 'list_files', 'read_file_res', 'create_file_res'");
 		props["content"] = MCPSchemaBuilder::make_string_property("Content for 'create_file_res'");
 
 		Array required;
@@ -229,8 +270,9 @@ Array MCPTools::get_tool_definitions() {
 
 		Dictionary tool;
 		tool["name"] = "project_config";
-		tool["description"] = "Global project settings and Redot-specific I/O. Note: For editing existing GDScript files, use native text editing tools for precision.";
+		tool["description"] = "Global project settings and Redot-specific I/O. add_autoload takes setting=name + path=script. add_input takes setting=name + value={keycode,deadzone}. For editing existing GDScript files, use native text editing tools for precision.";
 		tool["inputSchema"] = MCPSchemaBuilder::make_object_schema(props, required);
+		tool["annotations"] = MCPSchemaBuilder::make_tool_annotations(false, true, false, true);
 		tools.push_back(tool);
 	}
 
@@ -255,6 +297,7 @@ Array MCPTools::get_tool_definitions() {
 		tool["name"] = "game_control";
 		tool["description"] = "Interact with the running game process (screenshots, input, live tree)";
 		tool["inputSchema"] = MCPSchemaBuilder::make_object_schema(props, required);
+		tool["annotations"] = MCPSchemaBuilder::make_tool_annotations(false, true, false, true);
 		tools.push_back(tool);
 	}
 
@@ -421,22 +464,26 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 	} else if (action == "instance") {
 		String parent_path = p_args.get("node_path", ".");
 		String instance_path = p_args.get("instance_path", "");
-		Node *parent = (parent_path == "." || parent_path.is_empty()) ? root : root->get_node_or_null(parent_path);
-		Ref<PackedScene> sub = ResourceLoader::load(normalize_path(instance_path), "PackedScene");
-		if (!parent || sub.is_null()) {
-			result.set_error("Parent or instance scene not found");
+		if (!validate_path(instance_path)) {
+			result.set_error("Invalid instance_path: " + instance_path);
 		} else {
-			Node *instance = sub->instantiate();
-			if (!instance) {
-				result.set_error("Failed to instantiate scene: " + instance_path);
+			Node *parent = (parent_path == "." || parent_path.is_empty()) ? root : root->get_node_or_null(parent_path);
+			Ref<PackedScene> sub = ResourceLoader::load(normalize_path(instance_path), "PackedScene");
+			if (!parent || sub.is_null()) {
+				result.set_error("Parent or instance scene not found");
 			} else {
-				if (p_args.has("node_name")) {
-					instance->set_name(p_args["node_name"]);
+				Node *instance = sub->instantiate();
+				if (!instance) {
+					result.set_error("Failed to instantiate scene: " + instance_path);
+				} else {
+					if (p_args.has("node_name")) {
+						instance->set_name(p_args["node_name"]);
+					}
+					parent->add_child(instance);
+					instance->set_owner(root);
+					should_save = true;
+					result.add_text("Instanced '" + instance_path + "'");
 				}
-				parent->add_child(instance);
-				instance->set_owner(root);
-				should_save = true;
-				result.add_text("Instanced '" + instance_path + "'");
 			}
 		}
 	} else if (action == "set_prop") {
@@ -456,18 +503,24 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 		String sig = p_args.get("signal", "");
 		String target_path = p_args.get("target_node", ".");
 		String method = p_args.get("method", "");
-		Node *source = (node_path == "." || node_path.is_empty()) ? root : root->get_node_or_null(node_path);
-		Node *target = (target_path == "." || target_path.is_empty()) ? root : root->get_node_or_null(target_path);
-		if (!source || !target) {
-			result.set_error("Node not found");
+		if (sig.is_empty() || method.is_empty()) {
+			result.set_error("Missing signal or method");
 		} else {
-			Ref<Resource> script_res = target->get_script();
-			if (script_res.is_valid()) {
-				_ensure_callback_exists(script_res->get_path(), method);
+			Node *source = (node_path == "." || node_path.is_empty()) ? root : root->get_node_or_null(node_path);
+			Node *target = (target_path == "." || target_path.is_empty()) ? root : root->get_node_or_null(target_path);
+			if (!source || !target) {
+				result.set_error("Node not found");
+			} else if (!source->has_signal(sig)) {
+				result.set_error("Signal '" + sig + "' does not exist on " + source->get_class());
+			} else {
+				Ref<Resource> script_res = target->get_script();
+				if (script_res.is_valid()) {
+					_ensure_callback_exists(script_res->get_path(), method);
+				}
+				source->connect(sig, Callable(target, method));
+				should_save = true;
+				result.add_text("Connected signal '" + sig + "' to '" + method + "'");
 			}
-			source->connect(sig, Callable(target, method));
-			should_save = true;
-			result.add_text("Connected signal");
 		}
 	} else if (action == "reparent") {
 		String node_path = p_args.get("node_path", "");
@@ -508,6 +561,10 @@ MCPTools::ToolResult MCPTools::tool_resource_action(const Dictionary &p_args) {
 	String path = p_args.get("path", "");
 	if (action.is_empty() || path.is_empty()) {
 		result.set_error("Missing action or path");
+		return result;
+	}
+	if (!validate_path(path)) {
+		result.set_error("Invalid path: " + path);
 		return result;
 	}
 	String normalized = normalize_path(path);
@@ -578,6 +635,8 @@ MCPTools::ToolResult MCPTools::tool_resource_action(const Dictionary &p_args) {
 		String np = p_args.get("new_path", "");
 		if (np.is_empty()) {
 			result.set_error("Missing new_path");
+		} else if (!validate_path(np)) {
+			result.set_error("Invalid new_path: " + np);
 		} else {
 			Ref<Resource> copy = res->duplicate();
 			Error err = ResourceSaver::save(copy, normalize_path(np));
@@ -638,9 +697,80 @@ MCPTools::ToolResult MCPTools::tool_code_intel(const Dictionary &p_args) {
 		}
 		return result;
 	}
+	if (action == "search") {
+		String query = p_args.get("query", "");
+		if (query.is_empty()) {
+			result.set_error("Missing query");
+			return result;
+		}
+		String search_dir = p_args.get("path", "res://");
+		if (!validate_path(search_dir)) {
+			result.set_error("Invalid path: " + search_dir);
+			return result;
+		}
+		search_dir = normalize_path(search_dir);
+
+		// Recursively scan .gd files for the query string.
+		Array matches;
+		int match_count = 0;
+		const int max_matches = 100;
+		std::function<void(const String &)> scan_dir = [&](const String &p_dir) {
+			if (match_count >= max_matches) {
+				return;
+			}
+			Ref<DirAccess> d = DirAccess::open(p_dir);
+			if (d.is_null()) {
+				return;
+			}
+			d->list_dir_begin();
+			String n = d->get_next();
+			while (!n.is_empty()) {
+				if (n == "." || n == ".." || n.begins_with(".")) {
+					n = d->get_next();
+					continue;
+				}
+				String full = p_dir + (p_dir.ends_with("/") ? "" : "/") + n;
+				if (d->current_is_dir()) {
+					scan_dir(full);
+				} else if (n.ends_with(".gd")) {
+					Error ferr;
+					Ref<FileAccess> f = FileAccess::open(full, FileAccess::READ, &ferr);
+					if (f.is_valid()) {
+						int line_num = 0;
+						while (!f->eof_reached() && match_count < max_matches) {
+							String line = f->get_line();
+							line_num++;
+							if (line.find(query) != -1) {
+								Dictionary m;
+								m["file"] = full;
+								m["line"] = line_num;
+								m["text"] = line.strip_edges();
+								matches.push_back(m);
+								match_count++;
+							}
+						}
+					}
+				}
+				if (match_count >= max_matches) {
+					break;
+				}
+				n = d->get_next();
+			}
+		};
+		scan_dir(search_dir);
+		result.add_text(JSON::stringify(matches, "  "));
+		if (match_count >= max_matches) {
+			result.add_text("\n(Results truncated at " + itos(max_matches) + " matches)");
+		}
+		return result;
+	}
 	String path = p_args.get("path", "");
 	if (path.is_empty()) {
 		result.set_error("Missing path");
+		return result;
+	}
+	if (!validate_path(path)) {
+		result.set_error("Invalid path: " + path);
 		return result;
 	}
 	String normalized = normalize_path(path);
@@ -823,6 +953,66 @@ MCPTools::ToolResult MCPTools::tool_project_config(const Dictionary &p_args) {
 		} else {
 			result.set_error("Failed to list: " + p);
 		}
+	} else if (action == "add_input") {
+		String action_name = p_args.get("setting", "");
+		if (action_name.is_empty()) {
+			result.set_error("Missing setting (input action name)");
+			return result;
+		}
+		Dictionary value = p_args.get("value", Dictionary());
+		float deadzone = (float)(double)value.get("deadzone", 0.5);
+
+		Dictionary action_dict;
+		action_dict["deadzone"] = deadzone;
+		Array events;
+
+		Variant key_val = value.get("keycode", Variant());
+		if (key_val.get_type() != Variant::NIL) {
+			uint32_t code = 0;
+			if (key_val.get_type() == Variant::STRING) {
+				code = (uint32_t)find_keycode(key_val);
+			} else if (key_val.get_type() == Variant::INT || key_val.get_type() == Variant::FLOAT) {
+				code = (uint32_t)(int64_t)key_val;
+			}
+			if (code != 0) {
+				Ref<InputEventKey> key;
+				key.instantiate();
+				key->set_keycode((Key)code);
+				events.push_back(key);
+			}
+		}
+		action_dict["events"] = events;
+
+		ProjectSettings::get_singleton()->set_setting("input/" + action_name, action_dict);
+		ProjectSettings::get_singleton()->save();
+
+		// Also register at runtime for immediate availability.
+		if (!InputMap::get_singleton()->has_action(action_name)) {
+			InputMap::get_singleton()->add_action(action_name, deadzone);
+		}
+		for (int i = 0; i < events.size(); i++) {
+			Ref<InputEvent> ev = events[i];
+			if (ev.is_valid()) {
+				InputMap::get_singleton()->action_add_event(action_name, ev);
+			}
+		}
+		result.add_text("Added input action '" + action_name + "' (deadzone " + String::num(deadzone) + ", " + itos(events.size()) + " event(s))");
+	} else if (action == "add_autoload") {
+		String name = p_args.get("setting", "");
+		String p = p_args.get("path", "");
+		if (name.is_empty() || p.is_empty()) {
+			result.set_error("Missing setting (autoload name) or path");
+			return result;
+		}
+		if (!validate_path(p)) {
+			result.set_error("Invalid path: " + p);
+			return result;
+		}
+		String autoload_path = "*" + normalize_path(p);
+		ProjectSettings::get_singleton()->set_setting("autoload/" + name, autoload_path);
+		ProjectSettings::get_singleton()->set_as_internal("autoload/" + name, true);
+		ProjectSettings::get_singleton()->save();
+		result.add_text("Added autoload '" + name + "' -> " + autoload_path);
 	} else if (action == "set_setting") {
 		ProjectSettings::get_singleton()->set_setting(p_args.get("setting", ""), p_args.get("value", Variant()));
 		ProjectSettings::get_singleton()->save();

--- a/modules/mcp/mcp_tools.cpp
+++ b/modules/mcp/mcp_tools.cpp
@@ -987,13 +987,17 @@ MCPTools::ToolResult MCPTools::tool_project_config(const Dictionary &p_args) {
 		ProjectSettings::get_singleton()->save();
 
 		// Also register at runtime for immediate availability.
-		if (!InputMap::get_singleton()->has_action(action_name)) {
-			InputMap::get_singleton()->add_action(action_name, deadzone);
+		InputMap *input_map = InputMap::get_singleton();
+		if (!input_map->has_action(action_name)) {
+			input_map->add_action(action_name, deadzone);
+		} else {
+			input_map->action_set_deadzone(action_name, deadzone);
+			input_map->action_erase_events(action_name);
 		}
 		for (int i = 0; i < events.size(); i++) {
 			Ref<InputEvent> ev = events[i];
 			if (ev.is_valid()) {
-				InputMap::get_singleton()->action_add_event(action_name, ev);
+				input_map->action_add_event(action_name, ev);
 			}
 		}
 		result.add_text("Added input action '" + action_name + "' (deadzone " + String::num(deadzone) + ", " + itos(events.size()) + " event(s))");
@@ -1008,7 +1012,12 @@ MCPTools::ToolResult MCPTools::tool_project_config(const Dictionary &p_args) {
 			result.set_error("Invalid path: " + p);
 			return result;
 		}
-		String autoload_path = "*" + normalize_path(p);
+		String normalized_path = normalize_path(p);
+		if (!FileAccess::exists(normalized_path)) {
+			result.set_error("Autoload file not found: " + normalized_path);
+			return result;
+		}
+		String autoload_path = "*" + normalized_path;
 		ProjectSettings::get_singleton()->set_setting("autoload/" + name, autoload_path);
 		ProjectSettings::get_singleton()->set_as_internal("autoload/" + name, true);
 		ProjectSettings::get_singleton()->save();

--- a/modules/mcp/mcp_types.h
+++ b/modules/mcp/mcp_types.h
@@ -44,7 +44,10 @@
 #include "core/variant/variant.h"
 
 /// MCP Protocol Version
-static constexpr const char *MCP_PROTOCOL_VERSION = "2024-11-05";
+/// The latest version this server supports. Negotiated downwards if needed.
+static constexpr const char *MCP_PROTOCOL_VERSION_LATEST = "2025-06-18";
+/// Legacy version kept for backwards-compatibility negotiation.
+static constexpr const char *MCP_PROTOCOL_VERSION_LEGACY = "2024-11-05";
 static constexpr const char *MCP_SERVER_NAME = "redot-mcp";
 static constexpr const char *MCP_SERVER_VERSION = "1.0.0";
 
@@ -152,5 +155,16 @@ public:
 			prop["items"] = items;
 		}
 		return prop;
+	}
+
+	/// Build a tool annotations object (MCP 2025-06-18+).
+	/// Hints are advisory; clients MUST treat them as untrusted.
+	static Dictionary make_tool_annotations(bool p_read_only = false, bool p_destructive = false, bool p_idempotent = false, bool p_open_world = false) {
+		Dictionary annotations;
+		annotations["readOnlyHint"] = p_read_only;
+		annotations["destructiveHint"] = p_destructive;
+		annotations["idempotentHint"] = p_idempotent;
+		annotations["openWorldHint"] = p_open_world;
+		return annotations;
 	}
 };


### PR DESCRIPTION
## Summary

A comprehensive audit and hardening of the native MCP (Model Context Protocol) server module (`modules/mcp/`). The module was functional but had several bugs, spec compliance gaps, and unimplemented actions advertised in the tool schemas.

### Bugfixes
- **Capture crash**: Null-deref in `capture` action when viewport returns no image (headless/first-frame) or PNG encoding fails
- **Double-wrapped errors**: Pre-init `tools/*` requests returned a JSON-RPC error nested inside a `result` envelope instead of a top-level `error`. Fixed via a `process_string` override that gates pre-init requests and notifications

### Protocol compliance
- Updated protocol version from `2024-11-05` to `2025-06-18` with proper version negotiation (echoes client version if supported)
- Moved `initialized` flag from `initialize` response to `notifications/initialized` per spec lifecycle
- Declared `tools.listChanged` capability explicitly

### Security & robustness
- Hardened `validate_path`: segment-based `..` traversal check, applied consistently to all path-accepting actions (previously `instance_path`, resource paths, and code_intel paths were unvalidated)
- Fixed bridge concurrency: `update()` no longer drops an active connection mid-command
- Improved `send_command`: chunked reads via `CharString` accumulation with single-pass UTF-8 decode

### New functionality
- `code_intel` `search` action: recursive `.gd` file content search
- `project_config` `add_input` action: writes `InputEventKey` to `project.godot` with runtime `InputMap` registration
- `project_config` `add_autoload` action: writes autoload entry to `project.godot`

### Quality
- MCP tool annotations (`readOnlyHint`, `destructiveHint`, etc.) on all 5 tools per 2025-06-18 spec
- Clarified `project_config` schema descriptions (which params each action uses)
- Improved `_ensure_callback_exists` word-boundary detection (handles `static func`, annotation prefixes)
- Added signal-exists validation before `connect()` in `scene_action`
- Filled in class reference docs for `MCPServer`, `MCPBridge`, `MCPProtocol`
- Removed dead code (`_make_text_content`)

## Testing

All changes manually tested end-to-end with a live MCP handshake (`--mcp-server --headless`) across all 5 tools:

| Tool | Actions verified |
|------|-----------------|
| `code_intel` | `get_symbols`, `get_docs`, `validate`, `search` |
| `game_control` | `wait`, `capture`, `inspect_live`, `click`, `trigger_action`, `type` |
| `project_config` | `get_info`, `list_files`, `run`, `stop`, `output`, `read_file_res`, `create_file_res`, `set_setting`, `add_input`, `add_autoload` |
| `resource_action` | `inspect`, `inspect_asset`, `create`, `modify`, `duplicate` |
| `scene_action` | `get_node`, `create`, `add`, `set_prop`, `instance`, `reparent`, `remove`, `connect` |

Pre-init gating verified: single requests return JSON-RPC error, notifications are silently dropped.

## Notes

- AI tools were used during development, in accordance with the project [AI Policy](AI_POLICY.md). All changes have been manually tested and reviewed.
- Built and tested on Linux (`linuxbsd` platform, editor target).

## Checklist
- [x] Code compiles (`scons platform=linuxbsd target=editor`)
- [x] Manually tested all advertised tool actions
- [x] Class reference documentation updated
- [x] Pre-commit hooks passed (clang-format, codespell, copyright-headers, header-guards, file-format)
- [ ] CodeRabbit review addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added code search across GDScript files with contextual results and truncation notice.
  - Added project configuration actions for input mappings and autoloads.
  - Added richer tool metadata (annotations) and enhanced tool discovery/execution support.
- **Bug Fixes**
  - Improved protocol version negotiation and deferred initialization until the initialized notification is received.
  - Hardened tool request handling before initialization and improved invalid-request errors.
  - Improved TCP response decoding and connection handling; strengthened capture error reporting.
- **Documentation**
  - Expanded MCP bridge, protocol, and server lifecycle documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->