### PR TITLE
Bump version

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,10 +1,10 @@
 short_name = "redot"
 name = "Redot Engine LTS"
 major = 26
-minor = 2
+minor = 3
 patch = 0
-status = "stable"
-status_version = 0
+status = "alpha"
+status_version = 1
 module_config = ""
 website = "https://redotengine.org"
 docs = "latest"


### PR DESCRIPTION
Set version to 26.3-alpha.1 to begin the 26.3 dev cycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the engine’s version metadata to the next minor release.
  * Changed the release status from stable to alpha, with the alpha status version incremented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->