### PR TITLE
solves string->int casts issue in #1294

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3812,7 +3812,7 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 			} else if (op_type.kind == GDScriptParser::DataType::ENUM && cast_type.builtin_type == Variant::INT) {
 				valid = true;
 			} else if (op_type.kind == GDScriptParser::DataType::BUILTIN && cast_type.kind == GDScriptParser::DataType::BUILTIN) {
-				valid = Variant::can_convert(op_type.builtin_type, cast_type.builtin_type);
+				valid = Variant::can_convert_strict(op_type.builtin_type, cast_type.builtin_type);
 			} else if (op_type.kind != GDScriptParser::DataType::BUILTIN && cast_type.kind != GDScriptParser::DataType::BUILTIN) {
 				valid = is_type_compatible(cast_type, op_type) || is_type_compatible(op_type, cast_type);
 			}


### PR DESCRIPTION
I do not know why they didn't use strict here, if it was intentional or not. I did a couple of tests in gdscript for it:

```
# These work
var a := 5 as float
var b := 3.9 as int
var c := 1 as bool 
var d := 3.9 as float

var e := "hello" as StringName
var f := &"hello" as String
var g := "path/to/node" as NodePath
var h := ^"path/to/node" as String

var i := "red" as Color

# untyped variant.
func take(v):
    var j := v as int

var l := [1, 2] as Array
```
and
```
# These do not work (as they shouldn't.)
func return_str() -> String:
    return "5"

func return_int() -> int:
    return 5

func test() -> void:
    var a := return_str() as int
    var b := return_str() as float
    var c := return_str() as bool
    var d := return_int() as String
    var e := Vector2(1, 2) as String
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened type-checking for built-in value conversions in GDScript, so some casts that were previously accepted will now be correctly rejected when they are not strictly valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->