### PR TITLE
Adds Math::sin_cos() - This computes sine and cosine of the same angle together, which reduces cycles and should improve performance slightly.

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -189,8 +189,10 @@ Basis Basis::diagonalize() {
 
 		// Compute the rotation matrix
 		Basis rot;
-		rot.rows[i][i] = rot.rows[j][j] = Math::cos(angle);
-		rot.rows[i][j] = -(rot.rows[j][i] = Math::sin(angle));
+		real_t rot_sin, rot_cos;
+		Math::sin_cos(angle, rot_sin, rot_cos);
+		rot.rows[i][i] = rot.rows[j][j] = rot_cos;
+		rot.rows[i][j] = -(rot.rows[j][i] = rot_sin);
 
 		// Update the off matrix norm
 		off_matrix_norm_2 -= rows[i][j] * rows[i][j];
@@ -621,16 +623,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 void Basis::set_euler(const Vector3 &p_euler, EulerOrder p_order) {
 	real_t c, s;
 
-	c = Math::cos(p_euler.x);
-	s = Math::sin(p_euler.x);
+	Math::sin_cos(p_euler.x, s, c);
 	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
-	c = Math::cos(p_euler.y);
-	s = Math::sin(p_euler.y);
+	Math::sin_cos(p_euler.y, s, c);
 	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
-	c = Math::cos(p_euler.z);
-	s = Math::sin(p_euler.z);
+	Math::sin_cos(p_euler.z, s, c);
 	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	switch (p_order) {
@@ -808,12 +807,12 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_angle) {
 	ERR_FAIL_COND_MSG(!p_axis.is_normalized(), "The axis Vector3 " + p_axis.operator String() + " must be normalized.");
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
-	real_t cosine = Math::cos(p_angle);
+	real_t sine, cosine;
+	Math::sin_cos(p_angle, sine, cosine);
 	rows[0][0] = axis_sq.x + cosine * (1.0f - axis_sq.x);
 	rows[1][1] = axis_sq.y + cosine * (1.0f - axis_sq.y);
 	rows[2][2] = axis_sq.z + cosine * (1.0f - axis_sq.z);
 
-	real_t sine = Math::sin(p_angle);
 	real_t t = 1 - cosine;
 
 	real_t xyzt = p_axis.x * p_axis.y * t;

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -61,6 +61,42 @@ _ALWAYS_INLINE_ float cos(float p_x) {
 	return std::cos(p_x);
 }
 
+#if !defined(__has_builtin)
+#define _MATH_FUNCS_DEFINED_HAS_BUILTIN
+#define __has_builtin(x) 0
+#endif
+
+template <typename T>
+_ALWAYS_INLINE_ void sin_cos(double p_x, T &r_sin, T &r_cos) {
+#if __has_builtin(__builtin_sincos)
+	double s, c;
+	__builtin_sincos(p_x, &s, &c);
+	r_sin = (T)s;
+	r_cos = (T)c;
+#else
+	r_sin = (T)Math::sin(p_x);
+	r_cos = (T)Math::cos(p_x);
+#endif
+}
+
+template <typename T>
+_ALWAYS_INLINE_ void sin_cos(float p_x, T &r_sin, T &r_cos) {
+#if __has_builtin(__builtin_sincosf)
+	float s, c;
+	__builtin_sincosf(p_x, &s, &c);
+	r_sin = (T)s;
+	r_cos = (T)c;
+#else
+	r_sin = (T)Math::sin(p_x);
+	r_cos = (T)Math::cos(p_x);
+#endif
+}
+
+#ifdef _MATH_FUNCS_DEFINED_HAS_BUILTIN
+#undef _MATH_FUNCS_DEFINED_HAS_BUILTIN
+#undef __has_builtin
+#endif
+
 _ALWAYS_INLINE_ double tan(double p_x) {
 	return std::tan(p_x);
 }

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -400,8 +400,8 @@ Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 		z = 0;
 		w = 0;
 	} else {
-		real_t sin_angle = Math::sin(p_angle * 0.5f);
-		real_t cos_angle = Math::cos(p_angle * 0.5f);
+		real_t sin_angle, cos_angle;
+		Math::sin_cos(p_angle * 0.5f, sin_angle, cos_angle);
 		real_t s = sin_angle / d;
 		x = p_axis.x * s;
 		y = p_axis.y * s;
@@ -419,12 +419,12 @@ Quaternion Quaternion::from_euler(const Vector3 &p_euler) {
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
 	// a3 is the angle of the first rotation, following the notation in this reference.
 
-	real_t cos_a1 = Math::cos(half_a1);
-	real_t sin_a1 = Math::sin(half_a1);
-	real_t cos_a2 = Math::cos(half_a2);
-	real_t sin_a2 = Math::sin(half_a2);
-	real_t cos_a3 = Math::cos(half_a3);
-	real_t sin_a3 = Math::sin(half_a3);
+	real_t cos_a1, sin_a1;
+	Math::sin_cos(half_a1, sin_a1, cos_a1);
+	real_t cos_a2, sin_a2;
+	Math::sin_cos(half_a2, sin_a2, cos_a2);
+	real_t cos_a3, sin_a3;
+	Math::sin_cos(half_a3, sin_a3, cos_a3);
 
 	return Quaternion(
 			sin_a1 * cos_a2 * sin_a3 + cos_a1 * sin_a2 * cos_a3,

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -91,8 +91,8 @@ real_t Transform2D::get_rotation() const {
 
 void Transform2D::set_rotation(real_t p_rot) {
 	Size2 scale = get_scale();
-	real_t cr = Math::cos(p_rot);
-	real_t sr = Math::sin(p_rot);
+	real_t cr, sr;
+	Math::sin_cos(p_rot, sr, cr);
 	columns[0][0] = cr;
 	columns[0][1] = sr;
 	columns[1][0] = -sr;
@@ -102,8 +102,8 @@ void Transform2D::set_rotation(real_t p_rot) {
 }
 
 Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
-	real_t cr = Math::cos(p_rot);
-	real_t sr = Math::sin(p_rot);
+	real_t cr, sr;
+	Math::sin_cos(p_rot, sr, cr);
 	columns[0][0] = cr;
 	columns[0][1] = sr;
 	columns[1][0] = -sr;
@@ -112,10 +112,14 @@ Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
 }
 
 Transform2D::Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos) {
-	columns[0][0] = Math::cos(p_rot) * p_scale.x;
-	columns[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
-	columns[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
-	columns[0][1] = Math::sin(p_rot) * p_scale.x;
+	real_t rot_sin, rot_cos;
+	Math::sin_cos(p_rot, rot_sin, rot_cos);
+	real_t skew_sin, skew_cos;
+	Math::sin_cos(p_rot + p_skew, skew_sin, skew_cos);
+	columns[0][0] = rot_cos * p_scale.x;
+	columns[1][1] = skew_cos * p_scale.y;
+	columns[1][0] = -skew_sin * p_scale.y;
+	columns[0][1] = rot_sin * p_scale.x;
 	columns[2] = p_pos;
 }
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -251,17 +251,23 @@ Rect2 Transform2D::xform(const Rect2 &p_rect) const {
 }
 
 void Transform2D::set_rotation_and_scale(real_t p_rot, const Size2 &p_scale) {
-	columns[0][0] = Math::cos(p_rot) * p_scale.x;
-	columns[1][1] = Math::cos(p_rot) * p_scale.y;
-	columns[1][0] = -Math::sin(p_rot) * p_scale.y;
-	columns[0][1] = Math::sin(p_rot) * p_scale.x;
+	real_t sc_sin, sc_cos;
+	Math::sin_cos(p_rot, sc_sin, sc_cos);
+	columns[0][0] = sc_cos * p_scale.x;
+	columns[1][1] = sc_cos * p_scale.y;
+	columns[1][0] = -sc_sin * p_scale.y;
+	columns[0][1] = sc_sin * p_scale.x;
 }
 
 void Transform2D::set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, real_t p_skew) {
-	columns[0][0] = Math::cos(p_rot) * p_scale.x;
-	columns[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
-	columns[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
-	columns[0][1] = Math::sin(p_rot) * p_scale.x;
+	real_t sc_rot_sin, sc_rot_cos;
+	Math::sin_cos(p_rot, sc_rot_sin, sc_rot_cos);
+	real_t sc_skew_sin, sc_skew_cos;
+	Math::sin_cos(p_rot + p_skew, sc_skew_sin, sc_skew_cos);
+	columns[0][0] = sc_rot_cos * p_scale.x;
+	columns[1][1] = sc_skew_cos * p_scale.y;
+	columns[1][0] = -sc_skew_sin * p_scale.y;
+	columns[0][1] = sc_rot_sin * p_scale.x;
 }
 
 Rect2 Transform2D::xform_inv(const Rect2 &p_rect) const {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -46,7 +46,9 @@ real_t Vector2::angle() const {
 }
 
 Vector2 Vector2::from_angle(real_t p_angle) {
-	return Vector2(Math::cos(p_angle), Math::sin(p_angle));
+	real_t sc_sin, sc_cos;
+	Math::sin_cos(p_angle, sc_sin, sc_cos);
+	return Vector2(sc_cos, sc_sin);
 }
 
 real_t Vector2::length() const {
@@ -118,8 +120,8 @@ Vector2 Vector2::round() const {
 }
 
 Vector2 Vector2::rotated(real_t p_by) const {
-	real_t sine = Math::sin(p_by);
-	real_t cosi = Math::cos(p_by);
+	real_t sine, cosi;
+	Math::sin_cos(p_by, sine, cosi);
 	return Vector2(
 			x * cosi - y * sine,
 			x * sine + y * cosi);

--- a/modules/godot_physics_3d/godot_collision_solver_3d.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d.cpp
@@ -69,8 +69,10 @@ bool GodotCollisionSolver3D::solve_static_world_boundary(const GodotShape3D *p_s
 		// Use 3 equidistant points on the circle.
 		for (int i = 0; i < 3; ++i) {
 			Vector3 vertex_pos = circle_pos;
-			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math::PI * i / 3.0);
-			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math::PI * i / 3.0);
+			double sc_sin, sc_cos;
+			Math::sin_cos(2.0 * Math::PI * i / 3.0, sc_sin, sc_cos);
+			vertex_pos += circle_axis_1 * sc_cos;
+			vertex_pos += circle_axis_2 * sc_sin;
 			supports[i] = vertex_pos;
 		}
 	}
@@ -496,8 +498,10 @@ bool GodotCollisionSolver3D::solve_distance_world_boundary(const GodotShape3D *p
 		// Use 3 equidistant points on the circle.
 		for (int i = 0; i < 3; ++i) {
 			Vector3 vertex_pos = circle_pos;
-			vertex_pos += circle_axis_1 * Math::cos(2.0 * Math::PI * i / 3.0);
-			vertex_pos += circle_axis_2 * Math::sin(2.0 * Math::PI * i / 3.0);
+			double sc_sin, sc_cos;
+			Math::sin_cos(2.0 * Math::PI * i / 3.0, sc_sin, sc_cos);
+			vertex_pos += circle_axis_1 * sc_cos;
+			vertex_pos += circle_axis_2 * sc_sin;
 			supports[i] = vertex_pos;
 		}
 	}

--- a/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
@@ -385,8 +385,10 @@ static void _generate_contacts_face_circle(const Vector3 *p_points_A, int p_poin
 
 	for (int i = 0; i < circle_segments; ++i) {
 		Vector3 point_pos = circle_B_pos;
-		point_pos += circle_B_line_1 * Math::cos(i * angle_delta);
-		point_pos += circle_B_line_2 * Math::sin(i * angle_delta);
+		real_t sc_sin, sc_cos;
+		Math::sin_cos(i * angle_delta, sc_sin, sc_cos);
+		point_pos += circle_B_line_1 * sc_cos;
+		point_pos += circle_B_line_2 * sc_sin;
 		circle_points[i] = point_pos;
 	}
 
@@ -511,8 +513,10 @@ static void _generate_contacts_circle_circle(const Vector3 *p_points_A, int p_po
 			// Circle A inside circle B.
 			for (int i = 0; i < 3; ++i) {
 				Vector3 circle_A_point = circle_A_pos;
-				circle_A_point += circle_A_line_1 * Math::cos(2.0 * Math::PI * i / 3.0);
-				circle_A_point += circle_A_line_2 * Math::sin(2.0 * Math::PI * i / 3.0);
+				double sc_sin, sc_cos;
+				Math::sin_cos(2.0 * Math::PI * i / 3.0, sc_sin, sc_cos);
+				circle_A_point += circle_A_line_1 * sc_cos;
+				circle_A_point += circle_A_line_2 * sc_sin;
 
 				contact_points[num_points] = circle_A_point;
 				++num_points;
@@ -521,8 +525,10 @@ static void _generate_contacts_circle_circle(const Vector3 *p_points_A, int p_po
 			// Circle B inside circle A.
 			for (int i = 0; i < 3; ++i) {
 				Vector3 circle_B_point = circle_B_pos;
-				circle_B_point += circle_B_line_1 * Math::cos(2.0 * Math::PI * i / 3.0);
-				circle_B_point += circle_B_line_2 * Math::sin(2.0 * Math::PI * i / 3.0);
+				double sc_sin, sc_cos;
+				Math::sin_cos(2.0 * Math::PI * i / 3.0, sc_sin, sc_cos);
+				circle_B_point += circle_B_line_1 * sc_cos;
+				circle_B_point += circle_B_line_2 * sc_sin;
 
 				Vector3 circle_A_point = circle_B_point - norm_proj;
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -879,9 +879,9 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			}
 
 			real_t angle1_rad = direction.angle() + Math::deg_to_rad((rng->randf() * 2.0 - 1.0) * spread);
-			real_t sc_sin, sc_cos;
-			Math::sin_cos(angle1_rad, sc_sin, sc_cos);
-			Vector2 rot = Vector2(sc_cos, sc_sin);
+			real_t dir_sin, dir_cos;
+			Math::sin_cos(angle1_rad, dir_sin, dir_cos);
+			Vector2 rot = Vector2(dir_cos, dir_sin);
 			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], rng->randf());
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -879,7 +879,9 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			}
 
 			real_t angle1_rad = direction.angle() + Math::deg_to_rad((rng->randf() * 2.0 - 1.0) * spread);
-			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
+			real_t sc_sin, sc_cos;
+			Math::sin_cos(angle1_rad, sc_sin, sc_cos);
+			Vector2 rot = Vector2(sc_cos, sc_sin);
 			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], rng->randf());
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
@@ -901,12 +903,16 @@ void CPUParticles2D::_particles_process(double p_delta) {
 				case EMISSION_SHAPE_SPHERE: {
 					real_t t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * rng->randf();
-					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
+					real_t sc_sin, sc_cos;
+					Math::sin_cos(t, sc_sin, sc_cos);
+					p.transform[2] = Vector2(sc_cos, sc_sin) * radius;
 				} break;
 				case EMISSION_SHAPE_SPHERE_SURFACE: {
 					real_t s = rng->randf(), t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
-					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
+					real_t sc_sin, sc_cos;
+					Math::sin_cos(t, sc_sin, sc_cos);
+					p.transform[2] = Vector2(sc_cos, sc_sin) * radius;
 				} break;
 				case EMISSION_SHAPE_RECTANGLE: {
 					p.transform[2] = Vector2(rng->randf() * 2.0 - 1.0, rng->randf() * 2.0 - 1.0) * emission_rect_extents;
@@ -1076,8 +1082,8 @@ void CPUParticles2D::_particles_process(double p_delta) {
 		}
 
 		real_t hue_rot_angle = (tex_hue_variation)*Math::TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
-		real_t hue_rot_c = Math::cos(hue_rot_angle);
-		real_t hue_rot_s = Math::sin(hue_rot_angle);
+		real_t hue_rot_c, hue_rot_s;
+		Math::sin_cos(hue_rot_angle, hue_rot_s, hue_rot_c);
 
 		Basis hue_rot_mat;
 		{
@@ -1111,8 +1117,10 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			p.transform.columns[1] = p.transform.columns[1].normalized();
 			p.transform.columns[0] = p.transform.columns[1].orthogonal();
 		} else {
-			p.transform.columns[0] = Vector2(Math::cos(p.rotation), -Math::sin(p.rotation));
-			p.transform.columns[1] = Vector2(Math::sin(p.rotation), Math::cos(p.rotation));
+			real_t sc_sin, sc_cos;
+			Math::sin_cos(p.rotation, sc_sin, sc_cos);
+			p.transform.columns[0] = Vector2(sc_cos, -sc_sin);
+			p.transform.columns[1] = Vector2(sc_sin, sc_cos);
 		}
 
 		//scale by scale

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -850,15 +850,21 @@ void CPUParticles3D::_particles_process(double p_delta) {
 
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg_to_rad((rng->randf() * 2.0 - 1.0) * spread);
-				Vector3 rot = Vector3(Math::cos(angle1_rad), Math::sin(angle1_rad), 0.0);
+				real_t sc_sin, sc_cos;
+				Math::sin_cos(angle1_rad, sc_sin, sc_cos);
+				Vector3 rot = Vector3(sc_cos, sc_sin, 0.0);
 				p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], rng->randf());
 			} else {
 				//initiate velocity spread in 3D
 				real_t angle1_rad = Math::deg_to_rad((rng->randf() * (real_t)2.0 - (real_t)1.0) * spread);
 				real_t angle2_rad = Math::deg_to_rad((rng->randf() * (real_t)2.0 - (real_t)1.0) * ((real_t)1.0 - flatness) * spread);
 
-				Vector3 direction_xz = Vector3(Math::sin(angle1_rad), 0, Math::cos(angle1_rad));
-				Vector3 direction_yz = Vector3(0, Math::sin(angle2_rad), Math::cos(angle2_rad));
+				real_t sc_sin1, sc_cos1;
+				Math::sin_cos(angle1_rad, sc_sin1, sc_cos1);
+				real_t sc_sin2, sc_cos2;
+				Math::sin_cos(angle2_rad, sc_sin2, sc_cos2);
+				Vector3 direction_xz = Vector3(sc_sin1, 0, sc_cos1);
+				Vector3 direction_yz = Vector3(0, sc_sin2, sc_cos2);
 				Vector3 spread_direction = Vector3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);
 				Vector3 direction_nrm = direction;
 				if (direction_nrm.length_squared() > 0) {
@@ -897,13 +903,17 @@ void CPUParticles3D::_particles_process(double p_delta) {
 					real_t t = Math::TAU * rng->randf();
 					real_t x = rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
-					p.transform.origin = Vector3(0, 0, 0).lerp(Vector3(radius * Math::cos(t), radius * Math::sin(t), emission_sphere_radius * s), x);
+					real_t sc_sin, sc_cos;
+					Math::sin_cos(t, sc_sin, sc_cos);
+					p.transform.origin = Vector3(0, 0, 0).lerp(Vector3(radius * sc_cos, radius * sc_sin, emission_sphere_radius * s), x);
 				} break;
 				case EMISSION_SHAPE_SPHERE_SURFACE: {
 					real_t s = 2.0 * rng->randf() - 1.0;
 					real_t t = Math::TAU * rng->randf();
 					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
-					p.transform.origin = Vector3(radius * Math::cos(t), radius * Math::sin(t), emission_sphere_radius * s);
+					real_t sc_sin, sc_cos;
+					Math::sin_cos(t, sc_sin, sc_cos);
+					p.transform.origin = Vector3(radius * sc_cos, radius * sc_sin, emission_sphere_radius * s);
 				} break;
 				case EMISSION_SHAPE_BOX: {
 					p.transform.origin = Vector3(rng->randf() * 2.0 - 1.0, rng->randf() * 2.0 - 1.0, rng->randf() * 2.0 - 1.0) * emission_box_extents;
@@ -1135,8 +1145,8 @@ void CPUParticles3D::_particles_process(double p_delta) {
 		}
 
 		real_t hue_rot_angle = (tex_hue_variation)*Math::TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
-		real_t hue_rot_c = Math::cos(hue_rot_angle);
-		real_t hue_rot_s = Math::sin(hue_rot_angle);
+		real_t hue_rot_s, hue_rot_c;
+		Math::sin_cos(hue_rot_angle, hue_rot_s, hue_rot_c);
 
 		Basis hue_rot_mat;
 		{
@@ -1173,8 +1183,10 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				p.transform.basis.set_column(2, Vector3(0, 0, 1));
 
 			} else {
-				p.transform.basis.set_column(0, Vector3(Math::cos(p.custom[0]), -Math::sin(p.custom[0]), 0.0));
-				p.transform.basis.set_column(1, Vector3(Math::sin(p.custom[0]), Math::cos(p.custom[0]), 0.0));
+				real_t sc_sin, sc_cos;
+				Math::sin_cos(p.custom[0], sc_sin, sc_cos);
+				p.transform.basis.set_column(0, Vector3(sc_cos, -sc_sin, 0.0));
+				p.transform.basis.set_column(1, Vector3(sc_sin, sc_cos, 0.0));
 				p.transform.basis.set_column(2, Vector3(0, 0, 1));
 			}
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -769,7 +769,9 @@ void CanvasItem::draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_sta
 	const real_t delta_angle = CLAMP(p_end_angle - p_start_angle, -Math::TAU, Math::TAU);
 	for (int i = 0; i < p_point_count; i++) {
 		real_t theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
-		points_ptr[i] = p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius;
+		real_t sc_sin, sc_cos;
+		Math::sin_cos(theta, sc_sin, sc_cos);
+		points_ptr[i] = p_center + Vector2(sc_cos, sc_sin) * p_radius;
 	}
 
 	draw_polyline(points, p_color, p_width, p_antialiased);
@@ -843,8 +845,10 @@ void CanvasItem::draw_circle(const Point2 &p_pos, real_t p_radius, const Color &
 
 		for (int i = 0; i < circle_segments; i++) {
 			float angle = i * circle_point_step;
-			points_ptr[i].x = Math::cos(angle) * p_radius;
-			points_ptr[i].y = Math::sin(angle) * p_radius;
+			real_t sc_sin, sc_cos;
+			Math::sin_cos(angle, sc_sin, sc_cos);
+			points_ptr[i].x = sc_cos * p_radius;
+			points_ptr[i].y = sc_sin * p_radius;
 			points_ptr[i] += p_pos;
 		}
 		points_ptr[circle_segments] = points_ptr[0];

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -376,8 +376,8 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 			}
 
 			const real_t pt_angle = (corner_idx + detail / (double)adapted_corner_detail) * quarter_arc_rad + Math::PI;
-			const real_t angle_cosine = Math::cos(pt_angle);
-			const real_t angle_sine = Math::sin(pt_angle);
+			real_t angle_sine, angle_cosine;
+			Math::sin_cos(pt_angle, angle_sine, angle_cosine);
 
 			{
 				const real_t x = inner_corner_radius[corner_idx] * angle_cosine * inner_scale[corner_idx].x + inner_points[corner_idx].x;

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -259,7 +259,7 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		ur = 1.0;
 		ui = 0.0;
 		arg = Math::PI / (le2>>1);
-		real_t sc_sin, sc_cos;
+		float sc_sin, sc_cos;
 		Math::sin_cos(arg, sc_sin, sc_cos);
 		wr = sc_cos;
 		wi = sign*sc_sin;

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -201,8 +201,10 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				phase = gSumPhase[k];
 
 				/* get real and imag part and re-interleave */
-				gFFTworksp[2*k] = magn*std::cos(phase);
-				gFFTworksp[2*k+1] = magn*std::sin(phase);
+				double sc_sin, sc_cos;
+				Math::sin_cos(phase, sc_sin, sc_cos);
+				gFFTworksp[2*k] = magn*sc_cos;
+				gFFTworksp[2*k+1] = magn*sc_sin;
 			}
 
 			/* zero negative frequencies */
@@ -257,8 +259,10 @@ void SMBPitchShift::smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		ur = 1.0;
 		ui = 0.0;
 		arg = Math::PI / (le2>>1);
-		wr = std::cos(arg);
-		wi = sign*std::sin(arg);
+		real_t sc_sin, sc_cos;
+		Math::sin_cos(arg, sc_sin, sc_cos);
+		wr = sc_cos;
+		wi = sign*sc_sin;
 		for (j = 0; j < le2; j += 2) {
 			p1r = fftBuffer+j; p1i = p1r+1;
 			p2r = p1r+le2; p2i = p2r+1;

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -81,8 +81,10 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		ur = 1.0;
 		ui = 0.0;
 		arg = Math::PI / (le2 >> 1);
-		wr = std::cos(arg);
-		wi = sign * std::sin(arg);
+		real_t sc_sin, sc_cos;
+		Math::sin_cos(arg, sc_sin, sc_cos);
+		wr = sc_cos;
+		wi = sign * sc_sin;
 		for (j = 0; j < le2; j += 2) {
 			p1r = fftBuffer + j;
 			p1i = p1r + 1;

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -81,7 +81,7 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		ur = 1.0;
 		ui = 0.0;
 		arg = Math::PI / (le2 >> 1);
-		real_t sc_sin, sc_cos;
+		float sc_sin, sc_cos;
 		Math::sin_cos(arg, sc_sin, sc_cos);
 		wr = sc_cos;
 		wi = sign * sc_sin;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1462,8 +1462,10 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 
 		for (int i = 0; i < circle_segments + 1; i++) {
 			float angle = i * circle_point_step;
-			points_ptr[i].x = Math::cos(angle) * p_radius;
-			points_ptr[i].y = Math::sin(angle) * p_radius;
+			real_t sc_sin, sc_cos;
+			Math::sin_cos(angle, sc_sin, sc_cos);
+			points_ptr[i].x = sc_cos * p_radius;
+			points_ptr[i].y = sc_sin * p_radius;
 			points_ptr[i] += p_pos;
 		}
 
@@ -1509,8 +1511,8 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 
 		for (int i = 0; i < circle_segments + 1; i++) {
 			const float angle = i * circle_point_step;
-			const float c = Math::cos(angle);
-			const float s = Math::sin(angle);
+			float s, c;
+			Math::sin_cos(angle, s, c);
 
 			points_ptr[i * 2].x = c * p_radius;
 			points_ptr[i * 2].y = s * p_radius;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -82,8 +82,10 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		const int screen_rotation_degrees = -RD::get_singleton()->screen_get_pre_rotation_degrees(p_screen);
 		float screen_rotation = Math::deg_to_rad((float)screen_rotation_degrees);
 
-		blit.push_constant.rotation_cos = Math::cos(screen_rotation);
-		blit.push_constant.rotation_sin = Math::sin(screen_rotation);
+		real_t sc_sin, sc_cos;
+		Math::sin_cos(screen_rotation, sc_sin, sc_cos);
+		blit.push_constant.rotation_cos = sc_cos;
+		blit.push_constant.rotation_sin = sc_sin;
 		// Swap width and height when the orientation is not the native one.
 		if (screen_rotation_degrees % 180 != 0) {
 			SWAP(screen_size.width, screen_size.height);
@@ -243,8 +245,10 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 
 	const int screen_rotation_degrees = -RD::get_singleton()->screen_get_pre_rotation_degrees(DisplayServer::MAIN_WINDOW_ID);
 	float screen_rotation = Math::deg_to_rad((float)screen_rotation_degrees);
-	blit.push_constant.rotation_cos = Math::cos(screen_rotation);
-	blit.push_constant.rotation_sin = Math::sin(screen_rotation);
+	real_t sc_sin, sc_cos;
+	Math::sin_cos(screen_rotation, sc_sin, sc_cos);
+	blit.push_constant.rotation_cos = sc_cos;
+	blit.push_constant.rotation_sin = sc_sin;
 	blit.push_constant.src_rect[0] = 0.0;
 	blit.push_constant.src_rect[1] = 0.0;
 	blit.push_constant.src_rect[2] = 1.0;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3392,8 +3392,10 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 						float radius = ls->light_get_param(ins->base, RS::LIGHT_PARAM_RANGE);
 						float angle = ls->light_get_param(ins->base, RS::LIGHT_PARAM_SPOT_ANGLE);
 
-						float w = radius * Math::sin(Math::deg_to_rad(angle));
-						float d = radius * Math::cos(Math::deg_to_rad(angle));
+						real_t sc_sin, sc_cos;
+						Math::sin_cos(Math::deg_to_rad(angle), sc_sin, sc_cos);
+						float w = radius * sc_sin;
+						float d = radius * sc_cos;
 
 						Vector3 base = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * d;
 


### PR DESCRIPTION
I also replaced certain individual calls of sin and cos with sin_cos. I did not do every single instance of sine and cosine because it is mostly not necessary in every case and I did not want to add more code to review. Plus I wanted to not touch tons of files. We can, if someone wanted to, but the pay off is a one-off and I don't think it will be impactful outside of hot paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized trigonometric usage by introducing `Math::sin_cos` (leveraging compiler builtins when available).
  * Updated rotation, Euler/axis-angle conversions, circle sampling, particle initialization/orientation, and various rendering/audio/physics computations to use paired sine/cosine calculations.
  * Improves efficiency in drawing arcs/circles, generating particle motion, computing collision contact points, and running audio effects, with no expected visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->