### PR TITLE
constexpr math functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ st[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]
 # Python development
 .venv
 venv
+uv.lock
 
 # Python generated
 __pycache__/

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -125,7 +125,7 @@ bool Basis::is_diagonal() const {
 }
 
 bool Basis::is_rotation() const {
-	return is_conformal() && Math::is_equal_approx(determinant(), 1);
+	return is_conformal() && Math::is_equal_approx(determinant(), static_cast<real_t>(1.), static_cast<real_t>(UNIT_EPSILON));
 }
 
 #ifdef MATH_CHECKS

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -125,7 +125,7 @@ bool Basis::is_diagonal() const {
 }
 
 bool Basis::is_rotation() const {
-	return is_conformal() && Math::is_equal_approx(determinant(), 1, (real_t)UNIT_EPSILON);
+	return is_conformal() && Math::is_equal_approx(determinant(), 1);
 }
 
 #ifdef MATH_CHECKS

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -30,6 +30,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+/**
+ * @file color.cpp
+ *
+ * [Add any documentation that applies to the entire file here!]
+ */
+
 #include "color.h"
 
 #include "color_names.inc"

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -30,12 +30,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-/**
- * @file color.cpp
- *
- * [Add any documentation that applies to the entire file here!]
- */
-
 #include "color.h"
 
 #include "color_names.inc"
@@ -44,78 +38,6 @@
 #include "core/templates/hash_map.h"
 
 #include "thirdparty/misc/ok_color.h"
-
-uint32_t Color::to_argb32() const {
-	uint32_t c = (uint8_t)Math::round(a * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(r * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255.0f);
-
-	return c;
-}
-
-uint32_t Color::to_abgr32() const {
-	uint32_t c = (uint8_t)Math::round(a * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(r * 255.0f);
-
-	return c;
-}
-
-uint32_t Color::to_rgba32() const {
-	uint32_t c = (uint8_t)Math::round(r * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255.0f);
-	c <<= 8;
-	c |= (uint8_t)Math::round(a * 255.0f);
-
-	return c;
-}
-
-uint64_t Color::to_abgr64() const {
-	uint64_t c = (uint16_t)Math::round(a * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(r * 65535.0f);
-
-	return c;
-}
-
-uint64_t Color::to_argb64() const {
-	uint64_t c = (uint16_t)Math::round(a * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(r * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535.0f);
-
-	return c;
-}
-
-uint64_t Color::to_rgba64() const {
-	uint64_t c = (uint16_t)Math::round(r * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535.0f);
-	c <<= 16;
-	c |= (uint16_t)Math::round(a * 65535.0f);
-
-	return c;
-}
 
 void _append_hex(float p_val, char32_t *string) {
 	int v = Math::round(p_val * 255.0f);
@@ -141,53 +63,7 @@ String Color::to_html(bool p_alpha) const {
 	return txt;
 }
 
-float Color::get_h() const {
-	float min = MIN(r, g);
-	min = MIN(min, b);
-	float max = MAX(r, g);
-	max = MAX(max, b);
-
-	float delta = max - min;
-
-	if (delta == 0.0f) {
-		return 0.0f;
-	}
-
-	float h;
-	if (r == max) {
-		h = (g - b) / delta; // between yellow & magenta
-	} else if (g == max) {
-		h = 2 + (b - r) / delta; // between cyan & yellow
-	} else {
-		h = 4 + (r - g) / delta; // between magenta & cyan
-	}
-
-	h /= 6.0f;
-	if (h < 0.0f) {
-		h += 1.0f;
-	}
-
-	return h;
-}
-
-float Color::get_s() const {
-	float min = MIN(r, g);
-	min = MIN(min, b);
-	float max = MAX(r, g);
-	max = MAX(max, b);
-
-	float delta = max - min;
-
-	return (max != 0.0f) ? (delta / max) : 0.0f;
-}
-
-float Color::get_v() const {
-	float max = MAX(r, g);
-	max = MAX(max, b);
-	return max;
-}
-
-void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
+void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) noexcept {
 	int i;
 	float f, p, q, t;
 	a = p_alpha;
@@ -267,52 +143,6 @@ void Color::set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	a = c.a;
 }
 
-bool Color::is_equal_approx(const Color &p_color) const {
-	return Math::is_equal_approx(r, p_color.r) && Math::is_equal_approx(g, p_color.g) && Math::is_equal_approx(b, p_color.b) && Math::is_equal_approx(a, p_color.a);
-}
-
-bool Color::is_same(const Color &p_color) const {
-	return Math::is_same(r, p_color.r) && Math::is_same(g, p_color.g) && Math::is_same(b, p_color.b) && Math::is_same(a, p_color.a);
-}
-
-Color Color::clamp(const Color &p_min, const Color &p_max) const {
-	return Color(
-			CLAMP(r, p_min.r, p_max.r),
-			CLAMP(g, p_min.g, p_max.g),
-			CLAMP(b, p_min.b, p_max.b),
-			CLAMP(a, p_min.a, p_max.a));
-}
-
-void Color::invert() {
-	r = 1.0f - r;
-	g = 1.0f - g;
-	b = 1.0f - b;
-}
-
-Color Color::hex(uint32_t p_hex) {
-	float a = (p_hex & 0xFF) / 255.0f;
-	p_hex >>= 8;
-	float b = (p_hex & 0xFF) / 255.0f;
-	p_hex >>= 8;
-	float g = (p_hex & 0xFF) / 255.0f;
-	p_hex >>= 8;
-	float r = (p_hex & 0xFF) / 255.0f;
-
-	return Color(r, g, b, a);
-}
-
-Color Color::hex64(uint64_t p_hex) {
-	float a = (p_hex & 0xFFFF) / 65535.0f;
-	p_hex >>= 16;
-	float b = (p_hex & 0xFFFF) / 65535.0f;
-	p_hex >>= 16;
-	float g = (p_hex & 0xFFFF) / 65535.0f;
-	p_hex >>= 16;
-	float r = (p_hex & 0xFFFF) / 65535.0f;
-
-	return Color(r, g, b, a);
-}
-
 static int _parse_col4(const String &p_str, int p_ofs) {
 	char character = p_str[p_ofs];
 
@@ -328,21 +158,6 @@ static int _parse_col4(const String &p_str, int p_ofs) {
 
 static int _parse_col8(const String &p_str, int p_ofs) {
 	return _parse_col4(p_str, p_ofs) * 16 + _parse_col4(p_str, p_ofs + 1);
-}
-
-Color Color::inverted() const {
-	Color c = *this;
-	c.invert();
-	return c;
-}
-
-Color Color::apply_intensity(float p_intensity) const {
-	if (Math::is_zero_approx(p_intensity)) {
-		return Color(r, g, b, a);
-	}
-
-	float multiplier = Math::pow(2, p_intensity);
-	return Color(CLAMP(r * multiplier, 0.0f, 1.0f), CLAMP(g * multiplier, 0.0f, 1.0f), CLAMP(b * multiplier, 0.0f, 1.0f), a);
 }
 
 Color Color::html(const String &p_rgba) {
@@ -408,6 +223,15 @@ bool Color::html_is_valid(const String &p_color) {
 	}
 
 	return true;
+}
+
+Color Color::apply_intensity(float p_intensity) const {
+	if (Math::is_zero_approx(p_intensity)) {
+		return Color(r, g, b, a);
+	}
+
+	float multiplier = std::pow(2.f, p_intensity);
+	return Color(CLAMP(r * multiplier, 0.0f, 1.0f), CLAMP(g * multiplier, 0.0f, 1.0f), CLAMP(b * multiplier, 0.0f, 1.0f), a);
 }
 
 Color Color::named(const String &p_name) {
@@ -478,7 +302,7 @@ Color Color::from_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	return c;
 }
 
-Color Color::from_rgbe9995(uint32_t p_rgbe) {
+Color Color::from_rgbe9995(uint32_t p_rgbe) noexcept {
 	float r = p_rgbe & 0x1ff;
 	float g = (p_rgbe >> 9) & 0x1ff;
 	float b = (p_rgbe >> 18) & 0x1ff;
@@ -489,7 +313,7 @@ Color Color::from_rgbe9995(uint32_t p_rgbe) {
 	float gd = g * m;
 	float bd = b * m;
 
-	return Color(rd, gd, bd, 1.0f);
+	return Color{ rd, gd, bd, 1.0f };
 }
 
 Color Color::from_rgba8(int64_t p_r8, int64_t p_g8, int64_t p_b8, int64_t p_a8) {

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -32,6 +32,12 @@
 
 #pragma once
 
+/**
+ * @file color.h
+ *
+ * [Add any documentation that applies to the entire file here!]
+ */
+
 #include "core/math/math_funcs.h"
 #include <bit>
 

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -32,15 +32,37 @@
 
 #pragma once
 
-/**
- * @file color.h
- *
- * [Add any documentation that applies to the entire file here!]
- */
-
 #include "core/math/math_funcs.h"
+#include <bit>
 
 class String;
+
+namespace color_pack {
+
+constexpr uint32_t floats_to_uint32(const float f1, const float f2, const float f3, const float f4) noexcept {
+	constexpr auto scale = static_cast<float>(std::numeric_limits<uint8_t>::max());
+	uint32_t c = static_cast<uint8_t>(Math::round(f1 * scale));
+	c <<= 8;
+	c |= static_cast<uint8_t>(Math::round(f2 * scale));
+	c <<= 8;
+	c |= static_cast<uint8_t>(Math::round(f3 * scale));
+	c <<= 8;
+	c |= static_cast<uint8_t>(Math::round(f4 * scale));
+	return c;
+}
+
+constexpr uint64_t floats_to_uint64(const float f1, const float f2, const float f3, const float f4) noexcept {
+	constexpr auto scale = static_cast<float>(std::numeric_limits<uint16_t>::max());
+	uint64_t c = static_cast<uint16_t>(Math::round(f1 * scale));
+	c <<= 16;
+	c |= static_cast<uint16_t>(Math::round(f2 * scale));
+	c <<= 16;
+	c |= static_cast<uint16_t>(Math::round(f3 * scale));
+	c <<= 16;
+	c |= static_cast<uint16_t>(Math::round(f4 * scale));
+	return c;
+}
+} //namespace color_pack
 
 struct [[nodiscard]] Color {
 	union {
@@ -55,60 +77,170 @@ struct [[nodiscard]] Color {
 		// NOLINTEND(modernize-use-default-member-init)
 	};
 
-	uint32_t to_rgba32() const;
-	uint32_t to_argb32() const;
-	uint32_t to_abgr32() const;
-	uint64_t to_rgba64() const;
-	uint64_t to_argb64() const;
-	uint64_t to_abgr64() const;
+	constexpr Color() noexcept :
+			r(0), g(0), b(0), a(1) {}
+
+	/**
+	 * RGBA construct parameters.
+	 * Alpha is not optional as otherwise we can't bind the RGB version for scripting.
+	 */
+	constexpr Color(float p_r, float p_g, float p_b, float p_a) noexcept :
+			r(p_r), g(p_g), b(p_b), a(p_a) {}
+
+	/**
+	 * RGB construct parameters.
+	 */
+	constexpr Color(float p_r, float p_g, float p_b) noexcept :
+			r(p_r), g(p_g), b(p_b), a(1) {}
+
+	/**
+	 * Construct a Color from another Color, but with the specified alpha value.
+	 */
+	constexpr Color(const Color &p_c, float p_a) noexcept :
+			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
+
+	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+	Color(const String &p_code) {
+		if (html_is_valid(p_code)) {
+			*this = html(p_code);
+		} else {
+			*this = named(p_code);
+		}
+	}
+
+	Color(const String &p_code, float p_a) :
+			Color(p_code) { a = p_a; }
+	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
+
+	constexpr uint32_t to_rgba32() const noexcept {
+		return color_pack::floats_to_uint32(r, g, b, a);
+	}
+
+	constexpr uint32_t to_argb32() const noexcept {
+		return color_pack::floats_to_uint32(a, r, g, b);
+	}
+
+	constexpr uint32_t to_abgr32() const noexcept {
+		return color_pack::floats_to_uint32(a, b, g, r);
+	}
+
+	constexpr uint64_t to_rgba64() const noexcept {
+		return color_pack::floats_to_uint64(r, g, b, a);
+	}
+
+	constexpr uint64_t to_argb64() const noexcept {
+		return color_pack::floats_to_uint64(a, r, g, b);
+	}
+
+	constexpr uint64_t to_abgr64() const noexcept {
+		return color_pack::floats_to_uint64(a, b, g, r);
+	}
+
 	String to_html(bool p_alpha = true) const;
-	float get_h() const;
-	float get_s() const;
-	float get_v() const;
-	void set_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
+	constexpr float get_h() const noexcept {
+		const float min = MIN(r, MIN(g, b));
+		const float max = MAX(r, MAX(g, b));
+		const float delta = max - min;
+
+		if (delta == 0.0f) {
+			return 0.0f;
+		}
+
+		float h;
+		if (r == max) {
+			h = (g - b) / delta; // between yellow & magenta
+		} else if (g == max) {
+			h = 2 + (b - r) / delta; // between cyan & yellow
+		} else {
+			h = 4 + (r - g) / delta; // between magenta & cyan
+		}
+
+		h /= 6.0f;
+		if (h < 0.0f) {
+			h += 1.0f;
+		}
+
+		return h;
+	}
+
+	constexpr float get_s() const noexcept {
+		const float min = MIN(r, MIN(g, b));
+		const float max = MAX(r, MAX(g, b));
+		const float delta = max - min;
+		return (max != 0.0f) ? (delta / max) : 0.0f;
+	}
+
+	constexpr float get_v() const noexcept {
+		return MAX(r, MAX(g, b));
+	}
+
+	void set_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f) noexcept;
 	float get_ok_hsl_h() const;
 	float get_ok_hsl_s() const;
 	float get_ok_hsl_l() const;
 	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	void set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 
-	_FORCE_INLINE_ float &operator[](int p_idx) {
+	constexpr float &operator[](const int p_idx) noexcept {
 		return components[p_idx];
 	}
-	_FORCE_INLINE_ const float &operator[](int p_idx) const {
+	constexpr const float &operator[](const int p_idx) const noexcept {
 		return components[p_idx];
 	}
 
-	constexpr bool operator==(const Color &p_color) const {
-		return (r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a);
-	}
-	constexpr bool operator!=(const Color &p_color) const {
-		return (r != p_color.r || g != p_color.g || b != p_color.b || a != p_color.a);
+	constexpr bool operator==(const Color &p_color) const noexcept {
+		return r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a;
 	}
 
-	constexpr Color operator+(const Color &p_color) const;
-	constexpr void operator+=(const Color &p_color);
+	constexpr Color operator+(const Color &p_color) const noexcept;
+	constexpr Color &operator+=(const Color &p_color) noexcept;
 
-	constexpr Color operator-() const;
-	constexpr Color operator-(const Color &p_color) const;
-	constexpr void operator-=(const Color &p_color);
+	constexpr Color operator-() const noexcept;
+	constexpr Color operator-(const Color &p_color) const noexcept;
+	constexpr Color &operator-=(const Color &p_color) noexcept;
 
-	constexpr Color operator*(const Color &p_color) const;
-	constexpr Color operator*(float p_scalar) const;
-	constexpr void operator*=(const Color &p_color);
-	constexpr void operator*=(float p_scalar);
+	constexpr Color operator*(const Color &p_color) const noexcept;
+	constexpr Color operator*(float p_scalar) const noexcept;
+	constexpr Color &operator*=(const Color &p_color) noexcept;
+	constexpr Color &operator*=(float p_scalar) noexcept;
 
-	constexpr Color operator/(const Color &p_color) const;
-	constexpr Color operator/(float p_scalar) const;
-	constexpr void operator/=(const Color &p_color);
-	constexpr void operator/=(float p_scalar);
+	constexpr Color operator/(const Color &p_color) const noexcept;
+	constexpr Color operator/(float p_scalar) const noexcept;
+	constexpr Color &operator/=(const Color &p_color) noexcept;
+	constexpr Color &operator/=(float p_scalar) noexcept;
 
-	bool is_equal_approx(const Color &p_color) const;
-	bool is_same(const Color &p_color) const;
+	constexpr bool is_equal_approx(const Color &p_color) const noexcept {
+		return Math::is_equal_approx(r, p_color.r) && Math::is_equal_approx(g, p_color.g) && Math::is_equal_approx(b, p_color.b) && Math::is_equal_approx(a, p_color.a);
+	}
 
-	Color clamp(const Color &p_min = Color(0, 0, 0, 0), const Color &p_max = Color(1, 1, 1, 1)) const;
-	void invert();
-	Color inverted() const;
+	constexpr bool is_same(const Color &p_color) const noexcept {
+		return Math::is_same(r, p_color.r) && Math::is_same(g, p_color.g) && Math::is_same(b, p_color.b) && Math::is_same(a, p_color.a);
+	}
+
+	constexpr Color clamp(const Color &p_min = { 0, 0, 0, 0 }, const Color &p_max = { 1, 1, 1, 1 }) const noexcept {
+		return Color{
+			CLAMP(r, p_min.r, p_max.r),
+			CLAMP(g, p_min.g, p_max.g),
+			CLAMP(b, p_min.b, p_max.b),
+			CLAMP(a, p_min.a, p_max.a)
+		};
+	}
+
+	constexpr void invert() noexcept {
+		r = 1.0f - r;
+		g = 1.0f - g;
+		b = 1.0f - b;
+	}
+	constexpr Color inverted() const noexcept {
+		Color c = *this;
+		c.invert();
+		return c;
+	}
+
+	constexpr float get_luminance() const noexcept {
+		return 0.2126f * r + 0.7152f * g + 0.0722f * b;
+	}
+
 	/**
 	 * Applies an intensity adjustment to the color by modifying the RGB components.
 	 * The alpha component remains unchanged. The intensity is applied as a
@@ -120,11 +252,7 @@ struct [[nodiscard]] Color {
 	 */
 	Color apply_intensity(float p_intensity) const;
 
-	_FORCE_INLINE_ float get_luminance() const {
-		return 0.2126f * r + 0.7152f * g + 0.0722f * b;
-	}
-
-	_FORCE_INLINE_ Color lerp(const Color &p_to, float p_weight) const {
+	constexpr Color lerp(const Color &p_to, const float p_weight) const noexcept {
 		Color res = *this;
 		res.r = Math::lerp(res.r, p_to.r, p_weight);
 		res.g = Math::lerp(res.g, p_to.g, p_weight);
@@ -133,26 +261,26 @@ struct [[nodiscard]] Color {
 		return res;
 	}
 
-	_FORCE_INLINE_ Color darkened(float p_amount) const {
+	constexpr Color darkened(const float p_amount) const noexcept {
 		Color res = *this;
-		res.r = res.r * (1.0f - p_amount);
-		res.g = res.g * (1.0f - p_amount);
-		res.b = res.b * (1.0f - p_amount);
+		res.r *= 1.0f - p_amount;
+		res.g *= 1.0f - p_amount;
+		res.b *= 1.0f - p_amount;
 		return res;
 	}
 
-	_FORCE_INLINE_ Color lightened(float p_amount) const {
+	constexpr Color lightened(const float p_amount) const noexcept {
 		Color res = *this;
-		res.r = res.r + (1.0f - res.r) * p_amount;
-		res.g = res.g + (1.0f - res.g) * p_amount;
-		res.b = res.b + (1.0f - res.b) * p_amount;
+		res.r += (1.0f - res.r) * p_amount;
+		res.g += (1.0f - res.g) * p_amount;
+		res.b += (1.0f - res.b) * p_amount;
 		return res;
 	}
 
-	_FORCE_INLINE_ uint32_t to_rgbe9995() const {
+	constexpr uint32_t to_rgbe9995() const noexcept {
 		// https://github.com/microsoft/DirectX-Graphics-Samples/blob/v10.0.19041.0/MiniEngine/Core/Color.cpp
-		static const float kMaxVal = float(0x1FF << 7);
-		static const float kMinVal = float(1.f / (1 << 16));
+		constexpr float kMaxVal{ 0x1FF << 7 };
+		constexpr float kMinVal{ 1.f / (1 << 16) };
 
 		// Clamp RGB to [0, 1.FF*2^16]
 		const float _r = CLAMP(r, 0.0f, kMaxVal);
@@ -166,35 +294,33 @@ struct [[nodiscard]] Color {
 		// add 15 to it.  When added to the channels, it causes the implicit '1.0'
 		// bit and the first 8 mantissa bits to be shifted down to the low 9 bits
 		// of the mantissa, rounding the truncated bits.
-		union {
-			float f;
-			uint32_t i;
-		} R, G, B, E;
 
-		E.f = MaxChannel;
-		E.i += 0x07804000; // Add 15 to the exponent and 0x4000 to the mantissa
-		E.i &= 0x7F800000; // Zero the mantissa
+		float E = MaxChannel;
+		auto Ei = std::bit_cast<uint32_t>(E);
+		Ei += 0x07804000; // Add 15 to the exponent and 0x4000 to the mantissa
+		Ei &= 0x7F800000; // Zero the mantissa
+		E = std::bit_cast<float>(Ei);
 
 		// This shifts the 9-bit values we need into the lowest bits, rounding as
 		// needed. Note that if the channel has a smaller exponent than the max
 		// channel, it will shift even more.  This is intentional.
-		R.f = _r + E.f;
-		G.f = _g + E.f;
-		B.f = _b + E.f;
+		const float R = _r + E;
+		const float G = _g + E;
+		const float B = _b + E;
 
 		// Convert the Bias to the correct exponent in the upper 5 bits.
-		E.i <<= 4;
-		E.i += 0x10000000;
+		Ei <<= 4;
+		Ei += 0x10000000;
 
 		// Combine the fields. RGB floats have unwanted data in the upper 9
 		// bits. Only red needs to mask them off because green and blue shift
 		// it out to the left.
-		return E.i | (B.i << 18U) | (G.i << 9U) | (R.i & 511U);
+		return Ei | std::bit_cast<uint32_t>(B) << 18U | std::bit_cast<uint32_t>(G) << 9U | (std::bit_cast<uint32_t>(R) & 511U);
 	}
 
-	_FORCE_INLINE_ Color blend(const Color &p_over) const {
+	constexpr Color blend(const Color &p_over) const noexcept {
 		Color res;
-		float sa = 1.0f - p_over.a;
+		const float sa = 1.0f - p_over.a;
 		res.a = a * sa + p_over.a;
 		if (res.a == 0) {
 			return Color(0, 0, 0, 0);
@@ -206,22 +332,41 @@ struct [[nodiscard]] Color {
 		return res;
 	}
 
-	_FORCE_INLINE_ Color srgb_to_linear() const {
+	constexpr Color srgb_to_linear() const noexcept {
 		return Color(
 				r < 0.04045f ? r * (1.0f / 12.92f) : Math::pow(float((r + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
 				g < 0.04045f ? g * (1.0f / 12.92f) : Math::pow(float((g + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
 				b < 0.04045f ? b * (1.0f / 12.92f) : Math::pow(float((b + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
 				a);
 	}
-	_FORCE_INLINE_ Color linear_to_srgb() const {
+
+	constexpr Color linear_to_srgb() const noexcept {
 		return Color(
 				r < 0.0031308f ? 12.92f * r : (1.0 + 0.055) * Math::pow(r, 1.0f / 2.4f) - 0.055,
 				g < 0.0031308f ? 12.92f * g : (1.0 + 0.055) * Math::pow(g, 1.0f / 2.4f) - 0.055,
 				b < 0.0031308f ? 12.92f * b : (1.0 + 0.055) * Math::pow(b, 1.0f / 2.4f) - 0.055, a);
 	}
 
-	static Color hex(uint32_t p_hex);
-	static Color hex64(uint64_t p_hex);
+	static constexpr Color hex(uint32_t p_hex) noexcept {
+		const float a = (p_hex & 0xFF) / 255.0f;
+		p_hex >>= 8;
+		const float b = (p_hex & 0xFF) / 255.0f;
+		p_hex >>= 8;
+		const float g = (p_hex & 0xFF) / 255.0f;
+		p_hex >>= 8;
+		const float r = (p_hex & 0xFF) / 255.0f;
+		return Color{ r, g, b, a };
+	}
+	static constexpr Color hex64(uint64_t p_hex) noexcept {
+		const float a = (p_hex & 0xFFFF) / 65535.0f;
+		p_hex >>= 16;
+		const float b = (p_hex & 0xFFFF) / 65535.0f;
+		p_hex >>= 16;
+		const float g = (p_hex & 0xFFFF) / 65535.0f;
+		p_hex >>= 16;
+		const float r = (p_hex & 0xFFFF) / 65535.0f;
+		return Color{ r, g, b, a };
+	}
 	static Color html(const String &p_rgba);
 	static bool html_is_valid(const String &p_color);
 	static Color named(const String &p_name);
@@ -234,166 +379,107 @@ struct [[nodiscard]] Color {
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_ok_hsv(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
-	static Color from_rgbe9995(uint32_t p_rgbe);
+	static Color from_rgbe9995(uint32_t p_rgbe) noexcept;
 	static Color from_rgba8(int64_t p_r8, int64_t p_g8, int64_t p_b8, int64_t p_a8 = 255);
 
-	constexpr bool operator<(const Color &p_color) const; // Used in set keys.
+	constexpr bool operator<(const Color &p_color) const noexcept; // Used in set keys.
 	explicit operator String() const;
 
 	// For the binder.
-	_FORCE_INLINE_ void set_r8(int32_t r8) { r = (CLAMP(r8, 0, 255) / 255.0f); }
-	_FORCE_INLINE_ int32_t get_r8() const { return int32_t(CLAMP(Math::round(r * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_g8(int32_t g8) { g = (CLAMP(g8, 0, 255) / 255.0f); }
-	_FORCE_INLINE_ int32_t get_g8() const { return int32_t(CLAMP(Math::round(g * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_b8(int32_t b8) { b = (CLAMP(b8, 0, 255) / 255.0f); }
-	_FORCE_INLINE_ int32_t get_b8() const { return int32_t(CLAMP(Math::round(b * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_a8(int32_t a8) { a = (CLAMP(a8, 0, 255) / 255.0f); }
-	_FORCE_INLINE_ int32_t get_a8() const { return int32_t(CLAMP(Math::round(a * 255.0f), 0.0f, 255.0f)); }
+	constexpr void set_r8(int32_t r8) noexcept { r = (CLAMP(r8, 0, 255) / 255.0f); }
+	constexpr int32_t get_r8() const noexcept { return int32_t(CLAMP(Math::round(r * 255.0f), 0.0f, 255.0f)); }
+	constexpr void set_g8(int32_t g8) noexcept { g = (CLAMP(g8, 0, 255) / 255.0f); }
+	constexpr int32_t get_g8() const noexcept { return int32_t(CLAMP(Math::round(g * 255.0f), 0.0f, 255.0f)); }
+	constexpr void set_b8(int32_t b8) noexcept { b = (CLAMP(b8, 0, 255) / 255.0f); }
+	constexpr int32_t get_b8() const noexcept { return int32_t(CLAMP(Math::round(b * 255.0f), 0.0f, 255.0f)); }
+	constexpr void set_a8(int32_t a8) noexcept { a = (CLAMP(a8, 0, 255) / 255.0f); }
+	constexpr int32_t get_a8() const noexcept { return int32_t(CLAMP(Math::round(a * 255.0f), 0.0f, 255.0f)); }
 
-	_FORCE_INLINE_ void set_h(float p_h) { set_hsv(p_h, get_s(), get_v(), a); }
-	_FORCE_INLINE_ void set_s(float p_s) { set_hsv(get_h(), p_s, get_v(), a); }
-	_FORCE_INLINE_ void set_v(float p_v) { set_hsv(get_h(), get_s(), p_v, a); }
-	_FORCE_INLINE_ void set_ok_hsl_h(float p_h) { set_ok_hsl(p_h, get_ok_hsl_s(), get_ok_hsl_l(), a); }
-	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
-	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
-
-	constexpr Color() :
-			r(0), g(0), b(0), a(1) {}
-
-	/**
-	 * RGBA construct parameters.
-	 * Alpha is not optional as otherwise we can't bind the RGB version for scripting.
-	 */
-	constexpr Color(float p_r, float p_g, float p_b, float p_a) :
-			r(p_r), g(p_g), b(p_b), a(p_a) {}
-
-	/**
-	 * RGB construct parameters.
-	 */
-	constexpr Color(float p_r, float p_g, float p_b) :
-			r(p_r), g(p_g), b(p_b), a(1) {}
-
-	/**
-	 * Construct a Color from another Color, but with the specified alpha value.
-	 */
-	constexpr Color(const Color &p_c, float p_a) :
-			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
-
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-	Color(const String &p_code) {
-		if (html_is_valid(p_code)) {
-			*this = html(p_code);
-		} else {
-			*this = named(p_code);
-		}
-	}
-
-	Color(const String &p_code, float p_a) {
-		*this = Color(p_code);
-		a = p_a;
-	}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
+	void set_h(float p_h) { set_hsv(p_h, get_s(), get_v(), a); }
+	void set_s(float p_s) { set_hsv(get_h(), p_s, get_v(), a); }
+	void set_v(float p_v) { set_hsv(get_h(), get_s(), p_v, a); }
+	void set_ok_hsl_h(float p_h) { set_ok_hsl(p_h, get_ok_hsl_s(), get_ok_hsl_l(), a); }
+	void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
+	void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
 };
 
-constexpr Color Color::operator+(const Color &p_color) const {
-	return Color(
-			r + p_color.r,
-			g + p_color.g,
-			b + p_color.b,
-			a + p_color.a);
+constexpr Color Color::operator+(const Color &p_color) const noexcept {
+	return Color{ r + p_color.r, g + p_color.g, b + p_color.b, a + p_color.a };
 }
 
-constexpr void Color::operator+=(const Color &p_color) {
-	r = r + p_color.r;
-	g = g + p_color.g;
-	b = b + p_color.b;
-	a = a + p_color.a;
+constexpr Color &Color::operator+=(const Color &p_color) noexcept {
+	r += p_color.r;
+	g += p_color.g;
+	b += p_color.b;
+	a += p_color.a;
+	return *this;
 }
 
-constexpr Color Color::operator-(const Color &p_color) const {
-	return Color(
-			r - p_color.r,
-			g - p_color.g,
-			b - p_color.b,
-			a - p_color.a);
+constexpr Color Color::operator-(const Color &p_color) const noexcept {
+	return Color{ r - p_color.r, g - p_color.g, b - p_color.b, a - p_color.a };
 }
 
-constexpr void Color::operator-=(const Color &p_color) {
-	r = r - p_color.r;
-	g = g - p_color.g;
-	b = b - p_color.b;
-	a = a - p_color.a;
+constexpr Color &Color::operator-=(const Color &p_color) noexcept {
+	r -= p_color.r;
+	g -= p_color.g;
+	b -= p_color.b;
+	a -= p_color.a;
+	return *this;
 }
 
-constexpr Color Color::operator*(const Color &p_color) const {
-	return Color(
-			r * p_color.r,
-			g * p_color.g,
-			b * p_color.b,
-			a * p_color.a);
+constexpr Color Color::operator*(const Color &p_color) const noexcept {
+	return Color{ r * p_color.r, g * p_color.g, b * p_color.b, a * p_color.a };
 }
 
-constexpr Color Color::operator*(float p_scalar) const {
-	return Color(
-			r * p_scalar,
-			g * p_scalar,
-			b * p_scalar,
-			a * p_scalar);
+constexpr Color Color::operator*(float p_scalar) const noexcept {
+	return Color{ r * p_scalar, g * p_scalar, b * p_scalar, a * p_scalar };
 }
 
-constexpr void Color::operator*=(const Color &p_color) {
-	r = r * p_color.r;
-	g = g * p_color.g;
-	b = b * p_color.b;
-	a = a * p_color.a;
+constexpr Color &Color::operator*=(const Color &p_color) noexcept {
+	r *= p_color.r;
+	g *= p_color.g;
+	b *= p_color.b;
+	a *= p_color.a;
+	return *this;
 }
 
-constexpr void Color::operator*=(float p_scalar) {
-	r = r * p_scalar;
-	g = g * p_scalar;
-	b = b * p_scalar;
-	a = a * p_scalar;
+constexpr Color &Color::operator*=(float p_scalar) noexcept {
+	r *= p_scalar;
+	g *= p_scalar;
+	b *= p_scalar;
+	a *= p_scalar;
+	return *this;
 }
 
-constexpr Color Color::operator/(const Color &p_color) const {
-	return Color(
-			r / p_color.r,
-			g / p_color.g,
-			b / p_color.b,
-			a / p_color.a);
+constexpr Color Color::operator/(const Color &p_color) const noexcept {
+	return Color{ r / p_color.r, g / p_color.g, b / p_color.b, a / p_color.a };
 }
 
-constexpr Color Color::operator/(float p_scalar) const {
-	return Color(
-			r / p_scalar,
-			g / p_scalar,
-			b / p_scalar,
-			a / p_scalar);
+constexpr Color Color::operator/(const float p_scalar) const noexcept {
+	return Color{ r / p_scalar, g / p_scalar, b / p_scalar, a / p_scalar };
 }
 
-constexpr void Color::operator/=(const Color &p_color) {
-	r = r / p_color.r;
-	g = g / p_color.g;
-	b = b / p_color.b;
-	a = a / p_color.a;
+constexpr Color &Color::operator/=(const Color &p_color) noexcept {
+	r /= p_color.r;
+	g /= p_color.g;
+	b /= p_color.b;
+	a /= p_color.a;
+	return *this;
 }
 
-constexpr void Color::operator/=(float p_scalar) {
-	r = r / p_scalar;
-	g = g / p_scalar;
-	b = b / p_scalar;
-	a = a / p_scalar;
+constexpr Color &Color::operator/=(float p_scalar) noexcept {
+	r /= p_scalar;
+	g /= p_scalar;
+	b /= p_scalar;
+	a /= p_scalar;
+	return *this;
 }
 
-constexpr Color Color::operator-() const {
-	return Color(
-			1.0f - r,
-			1.0f - g,
-			1.0f - b,
-			1.0f - a);
+constexpr Color Color::operator-() const noexcept {
+	return Color{ 1.0f - r, 1.0f - g, 1.0f - b, 1.0f - a };
 }
 
-constexpr bool Color::operator<(const Color &p_color) const {
+constexpr bool Color::operator<(const Color &p_color) const noexcept {
 	if (r == p_color.r) {
 		if (g == p_color.g) {
 			if (b == p_color.b) {
@@ -412,3 +498,153 @@ constexpr bool Color::operator<(const Color &p_color) const {
 constexpr Color operator*(float p_scalar, const Color &p_color) {
 	return p_color * p_scalar;
 }
+
+// Named colors:
+struct Colors {
+	static constexpr auto AliceBlue = Color::hex(0xF0F8FFFF);
+	static constexpr auto AntiqueWhite = Color::hex(0xFAEBD7FF);
+	static constexpr auto Aqua = Color::hex(0x00FFFFFF);
+	static constexpr auto Aquamarine = Color::hex(0x7FFFD4FF);
+	static constexpr auto Azure = Color::hex(0xF0FFFFFF);
+	static constexpr auto Beige = Color::hex(0xF5F5DCFF);
+	static constexpr auto Bisque = Color::hex(0xFFE4C4FF);
+	static constexpr auto Black = Color::hex(0x000000FF);
+	static constexpr auto BlanchedAlmond = Color::hex(0xFFEBCDFF);
+	static constexpr auto Blue = Color::hex(0x0000FFFF);
+	static constexpr auto BlueViolet = Color::hex(0x8A2BE2FF);
+	static constexpr auto Brown = Color::hex(0xA52A2AFF);
+	static constexpr auto BurlyWood = Color::hex(0xDEB887FF);
+	static constexpr auto CadetBlue = Color::hex(0x5F9EA0FF);
+	static constexpr auto Chartreuse = Color::hex(0x7FFF00FF);
+	static constexpr auto Chocolate = Color::hex(0xD2691EFF);
+	static constexpr auto Coral = Color::hex(0xFF7F50FF);
+	static constexpr auto CornflowerBlue = Color::hex(0x6495EDFF);
+	static constexpr auto Cornsilk = Color::hex(0xFFF8DCFF);
+	static constexpr auto Crimson = Color::hex(0xDC143CFF);
+	static constexpr auto Cyan = Aqua;
+	static constexpr auto DarkBlue = Color::hex(0x00008BFF);
+	static constexpr auto DarkCyan = Color::hex(0x008B8BFF);
+	static constexpr auto DarkGoldenrod = Color::hex(0xB8860BFF);
+	static constexpr auto DarkGray = Color::hex(0xA9A9A9FF);
+	static constexpr auto DarkGreen = Color::hex(0x006400FF);
+	static constexpr auto DarkKhaki = Color::hex(0xBDB76BFF);
+	static constexpr auto DarkMagenta = Color::hex(0x8B008BFF);
+	static constexpr auto DarkOliveGreen = Color::hex(0x556B2FFF);
+	static constexpr auto DarkOrange = Color::hex(0xFF8C00FF);
+	static constexpr auto DarkOrchid = Color::hex(0x9932CCFF);
+	static constexpr auto DarkRed = Color::hex(0x8B0000FF);
+	static constexpr auto DarkSalmon = Color::hex(0xE9967AFF);
+	static constexpr auto DarkSeaGreen = Color::hex(0x8FBC8FFF);
+	static constexpr auto DarkSlateBlue = Color::hex(0x483D8BFF);
+	static constexpr auto DarkSlateGray = Color::hex(0x2F4F4FFF);
+	static constexpr auto DarkTurquoise = Color::hex(0x00CED1FF);
+	static constexpr auto DarkViolet = Color::hex(0x9400D3FF);
+	static constexpr auto DeepPink = Color::hex(0xFF1493FF);
+	static constexpr auto DeepSkyBlue = Color::hex(0x00BFFFFF);
+	static constexpr auto DimGray = Color::hex(0x696969FF);
+	static constexpr auto DodgerBlue = Color::hex(0x1E90FFFF);
+	static constexpr auto Firebrick = Color::hex(0xB22222FF);
+	static constexpr auto FloralWhite = Color::hex(0xFFFAF0FF);
+	static constexpr auto ForestGreen = Color::hex(0x228B22FF);
+	static constexpr auto Fuchsia = Color::hex(0xFF00FFFF);
+	static constexpr auto Gainsboro = Color::hex(0xDCDCDCFF);
+	static constexpr auto GhostWhite = Color::hex(0xF8F8FFFF);
+	static constexpr auto Gold = Color::hex(0xFFD700FF);
+	static constexpr auto Goldenrod = Color::hex(0xDAA520FF);
+	static constexpr auto Gray = Color::hex(0xBEBEBEFF);
+	static constexpr auto Green = Color::hex(0x00FF00FF);
+	static constexpr auto GreenYellow = Color::hex(0xADFF2FFF);
+	static constexpr auto Honeydew = Color::hex(0xF0FFF0FF);
+	static constexpr auto HotPink = Color::hex(0xFF69B4FF);
+	static constexpr auto IndianRed = Color::hex(0xCD5C5CFF);
+	static constexpr auto Indigo = Color::hex(0x4B0082FF);
+	static constexpr auto Ivory = Color::hex(0xFFFFF0FF);
+	static constexpr auto Khaki = Color::hex(0xF0E68CFF);
+	static constexpr auto Lavender = Color::hex(0xE6E6FAFF);
+	static constexpr auto LavenderBlush = Color::hex(0xFFF0F5FF);
+	static constexpr auto LawnGreen = Color::hex(0x7CFC00FF);
+	static constexpr auto LemonChiffon = Color::hex(0xFFFACDFF);
+	static constexpr auto LightBlue = Color::hex(0xADD8E6FF);
+	static constexpr auto LightCoral = Color::hex(0xF08080FF);
+	static constexpr auto LightCyan = Color::hex(0xE0FFFFFF);
+	static constexpr auto LightGoldenrod = Color::hex(0xFAFAD2FF);
+	static constexpr auto LightGray = Color::hex(0xD3D3D3FF);
+	static constexpr auto LightGreen = Color::hex(0x90EE90FF);
+	static constexpr auto LightPink = Color::hex(0xFFB6C1FF);
+	static constexpr auto LightSalmon = Color::hex(0xFFA07AFF);
+	static constexpr auto LightSeaGreen = Color::hex(0x20B2AAFF);
+	static constexpr auto LightSkyBlue = Color::hex(0x87CEFAFF);
+	static constexpr auto LightSlateGray = Color::hex(0x778899FF);
+	static constexpr auto LightSteelBlue = Color::hex(0xB0C4DEFF);
+	static constexpr auto LightYellow = Color::hex(0xFFFFE0FF);
+	static constexpr auto Lime = Green;
+	static constexpr auto LimeGreen = Color::hex(0x32CD32FF);
+	static constexpr auto Linen = Color::hex(0xFAF0E6FF);
+	static constexpr auto Magenta = Fuchsia;
+	static constexpr auto Maroon = Color::hex(0xB03060FF);
+	static constexpr auto MediumAquamarine = Color::hex(0x66CDAAFF);
+	static constexpr auto MediumBlue = Color::hex(0x0000CDFF);
+	static constexpr auto MediumOrchid = Color::hex(0xBA55D3FF);
+	static constexpr auto MediumPurple = Color::hex(0x9370DBFF);
+	static constexpr auto MediumSeaGreen = Color::hex(0x3CB371FF);
+	static constexpr auto MediumSlateBlue = Color::hex(0x7B68EEFF);
+	static constexpr auto MediumSpringGreen = Color::hex(0x00FA9AFF);
+	static constexpr auto MediumTurquoise = Color::hex(0x48D1CCFF);
+	static constexpr auto MediumVioletRed = Color::hex(0xC71585FF);
+	static constexpr auto MidnightBlue = Color::hex(0x191970FF);
+	static constexpr auto MintCream = Color::hex(0xF5FFFAFF);
+	static constexpr auto MistyRose = Color::hex(0xFFE4E1FF);
+	static constexpr auto Moccasin = Color::hex(0xFFE4B5FF);
+	static constexpr auto NavajoWhite = Color::hex(0xFFDEADFF);
+	static constexpr auto NavyBlue = Color::hex(0x000080FF);
+	static constexpr auto OldLace = Color::hex(0xFDF5E6FF);
+	static constexpr auto Olive = Color::hex(0x808000FF);
+	static constexpr auto OliveDrab = Color::hex(0x6B8E23FF);
+	static constexpr auto Orange = Color::hex(0xFFA500FF);
+	static constexpr auto OrangeRed = Color::hex(0xFF4500FF);
+	static constexpr auto Orchid = Color::hex(0xDA70D6FF);
+	static constexpr auto PaleGoldenrod = Color::hex(0xEEE8AAFF);
+	static constexpr auto PaleGreen = Color::hex(0x98FB98FF);
+	static constexpr auto PaleTorquoise = Color::hex(0xAFEEEEFF);
+	static constexpr auto PaleVioletRed = Color::hex(0xDB7093FF);
+	static constexpr auto PapayaWhip = Color::hex(0xFFEFD5FF);
+	static constexpr auto PeachPuff = Color::hex(0xFFDAB9FF);
+	static constexpr auto Peru = Color::hex(0xCD853FFF);
+	static constexpr auto Pink = Color::hex(0xFFC0CBFF);
+	static constexpr auto Plum = Color::hex(0xDDA0DDFF);
+	static constexpr auto PowderBlue = Color::hex(0xB0E0E6FF);
+	static constexpr auto Purple = Color::hex(0xA020F0FF);
+	static constexpr auto RebeccaPurple = Color::hex(0x663399FF);
+	static constexpr auto Red = Color::hex(0xFF0000FF);
+	static constexpr auto RosyBrown = Color::hex(0xBC8F8FFF);
+	static constexpr auto RoyalBlue = Color::hex(0x4169E1FF);
+	static constexpr auto SaddleBrown = Color::hex(0x8B4513FF);
+	static constexpr auto Salmon = Color::hex(0xFA8072FF);
+	static constexpr auto SandyBrown = Color::hex(0xF4A460FF);
+	static constexpr auto SeaGreen = Color::hex(0x2E8B57FF);
+	static constexpr auto Seashell = Color::hex(0xFFF5EEFF);
+	static constexpr auto Sienna = Color::hex(0xA0522DFF);
+	static constexpr auto Silver = Color::hex(0xC0C0C0FF);
+	static constexpr auto SkyBlue = Color::hex(0x87CEEBFF);
+	static constexpr auto SlateBlue = Color::hex(0x6A5ACDFF);
+	static constexpr auto SlateGray = Color::hex(0x708090FF);
+	static constexpr auto Snow = Color::hex(0xFFFAFAFF);
+	static constexpr auto SpringGreen = Color::hex(0x00FF7FFF);
+	static constexpr auto SteelBlue = Color::hex(0x4682B4FF);
+	static constexpr auto Tan = Color::hex(0xD2B48CFF);
+	static constexpr auto Teal = Color::hex(0x008080FF);
+	static constexpr auto Thistle = Color::hex(0xD8BFD8FF);
+	static constexpr auto Tomato = Color::hex(0xFF6347FF);
+	static constexpr auto Transparent = Color::hex(0xFFFFFF00);
+	static constexpr auto Turquoise = Color::hex(0x40E0D0FF);
+	static constexpr auto Violet = Color::hex(0xEE82EEFF);
+	static constexpr auto WebGray = Color::hex(0x808080FF);
+	static constexpr auto WebGreen = Color::hex(0x008000FF);
+	static constexpr auto WebMaroon = Color::hex(0x800000FF);
+	static constexpr auto WebPurple = Color::hex(0x800080FF);
+	static constexpr auto Wheat = Color::hex(0xF5DEB3FF);
+	static constexpr auto White = Color::hex(0xFFFFFFFF);
+	static constexpr auto WhiteSmoke = Color::hex(0xF5F5F5FF);
+	static constexpr auto Yellow = Color::hex(0xFFFF00FF);
+	static constexpr auto YellowGreen = Color::hex(0x9ACD32FF);
+};

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -605,7 +605,7 @@ struct Colors {
 	static constexpr auto Orchid = Color::hex(0xDA70D6FF);
 	static constexpr auto PaleGoldenrod = Color::hex(0xEEE8AAFF);
 	static constexpr auto PaleGreen = Color::hex(0x98FB98FF);
-	static constexpr auto PaleTorquoise = Color::hex(0xAFEEEEFF);
+	static constexpr auto PaleTurquoise = Color::hex(0xAFEEEEFF);
 	static constexpr auto PaleVioletRed = Color::hex(0xDB7093FF);
 	static constexpr auto PapayaWhip = Color::hex(0xFFEFD5FF);
 	static constexpr auto PeachPuff = Color::hex(0xFFDAB9FF);

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -46,7 +46,7 @@ GODOT_GCC_WARNING_POP
 #include "thirdparty/misc/stb_rect_pack.h"
 
 const int clipper_precision = 5; ///< Based on CMP_EPSILON.
-const double clipper_scale = Math::pow(10.0, clipper_precision);
+const double clipper_scale = std::pow(10.0, clipper_precision);
 
 void Geometry2D::merge_many_polygons(const Vector<Vector<Vector2>> &p_polygons, Vector<Vector<Vector2>> &r_out_polygons, Vector<Vector<Vector2>> &r_out_holes) {
 	using namespace Clipper2Lib;

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -43,16 +43,20 @@
 #include <limits>
 
 namespace Math {
-inline constexpr double SQRT2 = 1.4142135623730950488016887242;
-inline constexpr double SQRT3 = 1.7320508075688772935274463415059;
-inline constexpr double SQRT12 = 0.7071067811865475244008443621048490;
-inline constexpr double SQRT13 = 0.57735026918962576450914878050196;
-inline constexpr double LN2 = 0.6931471805599453094172321215;
-inline constexpr double TAU = 6.2831853071795864769252867666;
-inline constexpr double PI = 3.1415926535897932384626433833;
-inline constexpr double E = 2.7182818284590452353602874714;
-inline constexpr double INF = std::numeric_limits<double>::infinity();
-inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+constexpr double SQRT2 = 1.4142135623730950488016887242;
+constexpr double SQRT3 = 1.7320508075688772935274463415059;
+constexpr double SQRT12 = 0.7071067811865475244008443621048490;
+constexpr double SQRT13 = 0.57735026918962576450914878050196;
+constexpr double LN2 = 0.6931471805599453094172321215;
+constexpr double TAU = 6.2831853071795864769252867666;
+constexpr double PI = 3.1415926535897932384626433833;
+constexpr double E = 2.7182818284590452353602874714;
+constexpr double INF = std::numeric_limits<double>::infinity();
+constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+constexpr double DB_CONVERSION_GAIN = 8.6858896380650365530225783783321;
+constexpr double GAIN_CONVERSION_DB = 0.11512925464970228420089957273422;
+constexpr double UINT32_MAX_D = 1.0 / static_cast<double>(UINT32_MAX);
+constexpr float UINT32_MAX_F = 1.0f / static_cast<float>(UINT32_MAX);
 } // namespace Math
 
 #define CMP_EPSILON 0.00001

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -30,6 +30,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+/**
+ * @file math_funcs.cpp
+ *
+ * [Add any documentation that applies to the entire file here!]
+ */
+
 #include "math_funcs.h"
 
 #include "core/error/error_macros.h"

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -30,12 +30,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-/**
- * @file math_funcs.cpp
- *
- * [Add any documentation that applies to the entire file here!]
- */
-
 #include "math_funcs.h"
 
 #include "core/error/error_macros.h"
@@ -43,32 +37,33 @@
 
 static RandomPCG default_rand;
 
-uint32_t Math::rand_from_seed(uint64_t *p_seed) {
+uint32_t Math::rand_from_seed(uint64_t *p_seed) noexcept {
+	// TODO: mcdubh - Rework core/math/random_pcg.h
 	RandomPCG rng = RandomPCG(*p_seed);
 	uint32_t r = rng.rand();
 	*p_seed = rng.get_seed();
 	return r;
 }
 
-void Math::seed(uint64_t p_value) {
+void Math::seed(uint64_t p_value) noexcept {
 	default_rand.seed(p_value);
 }
 
-void Math::randomize() {
+void Math::randomize() noexcept {
 	default_rand.randomize();
 }
 
-uint32_t Math::rand() {
+uint32_t Math::rand() noexcept {
 	return default_rand.rand();
 }
 
-double Math::randfn(double p_mean, double p_deviation) {
+double Math::randfn(double p_mean, double p_deviation) noexcept {
 	return default_rand.randfn(p_mean, p_deviation);
 }
 
-int Math::step_decimals(double p_step) {
-	static const int maxn = 10;
-	static const double sd[maxn] = {
+int Math::step_decimals(double p_step) noexcept {
+	constexpr int maxn = 10;
+	constexpr double sd[maxn] = {
 		0.9999, // somehow compensate for floating point error
 		0.09999,
 		0.009999,
@@ -81,8 +76,9 @@ int Math::step_decimals(double p_step) {
 		0.0000000009999
 	};
 
-	double abs = Math::abs(p_step);
-	double decs = abs - (int)abs; // Strip away integer part
+	double int_part;
+	double decs = Math::modf_with_ptr(Math::abs(p_step), &int_part); // strip int part.
+
 	for (int i = 0; i < maxn; i++) {
 		if (decs >= sd[i]) {
 			return i;
@@ -92,46 +88,52 @@ int Math::step_decimals(double p_step) {
 	return 0;
 }
 
-int Math::range_step_decimals(double p_step) {
-	if (p_step < 0.0000000000001) {
+// Only meant for editor usage in float ranges, where a step of 0
+// means that decimal digits should not be limited in String::num.
+int Math::range_step_decimals(double p_step) noexcept {
+	if (p_step < 1e-13) {
 		return 16; // Max value hardcoded in String::num
 	}
 	return step_decimals(p_step);
 }
 
-double Math::ease(double p_x, double p_c) {
+double Math::ease(double p_x, double p_c) noexcept {
+	// clamp p_x to [0,1]
 	if (p_x < 0) {
 		p_x = 0;
 	} else if (p_x > 1.0) {
 		p_x = 1.0;
 	}
-	if (p_c > 0) {
+
+	// No ease (raw)
+	if (p_c == 0.0) {
+		return 0;
+	}
+
+	// Ease-out / ease-in
+	if (p_c > 0.0) {
 		if (p_c < 1.0) {
 			return 1.0 - Math::pow(1.0 - p_x, 1.0 / p_c);
-		} else {
-			return Math::pow(p_x, p_c);
 		}
-	} else if (p_c < 0) {
-		//inout ease
-
-		if (p_x < 0.5) {
-			return Math::pow(p_x * 2.0, -p_c) * 0.5;
-		} else {
-			return (1.0 - Math::pow(1.0 - (p_x - 0.5) * 2.0, -p_c)) * 0.5 + 0.5;
-		}
-	} else {
-		return 0; // no ease (raw)
+		return Math::pow(p_x, p_c);
 	}
+
+	// In-out ease
+	if (p_x < 0.5) {
+		return Math::pow(p_x * 2.0, -p_c) * 0.5;
+	}
+
+	return (1.0 - Math::pow(1.0 - (p_x - 0.5) * 2.0, -p_c)) * 0.5 + 0.5;
 }
 
-double Math::snapped(double p_value, double p_step) {
-	if (p_step != 0) {
+double Math::snapped(double p_value, double p_step) noexcept {
+	if (p_step != 0.0) {
 		p_value = Math::floor(p_value / p_step + 0.5) * p_step;
 	}
 	return p_value;
 }
 
-uint32_t Math::larger_prime(uint32_t p_val) {
+uint32_t Math::larger_prime(uint32_t p_val) noexcept {
 	static const uint32_t primes[] = {
 		5,
 		13,
@@ -165,24 +167,28 @@ uint32_t Math::larger_prime(uint32_t p_val) {
 		0,
 	};
 
-	int idx = 0;
-	while (true) {
-		ERR_FAIL_COND_V(primes[idx] == 0, 0);
-		if (primes[idx] > p_val) {
-			return primes[idx];
+	for (auto prime : primes) {
+		if (prime == 0) {
+			// sentinel value at the end there..
+			break;
 		}
-		idx++;
+		if (prime > p_val) {
+			return prime;
+		}
 	}
+
+	// No larger prime in the table
+	return 0;
 }
 
-double Math::random(double p_from, double p_to) {
+double Math::random(double p_from, double p_to) noexcept {
 	return default_rand.random(p_from, p_to);
 }
 
-float Math::random(float p_from, float p_to) {
+float Math::random(float p_from, float p_to) noexcept {
 	return default_rand.random(p_from, p_to);
 }
 
-int Math::random(int p_from, int p_to) {
+int Math::random(int p_from, int p_to) noexcept {
 	return default_rand.random(p_from, p_to);
 }

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -68,8 +68,8 @@ double Math::randfn(double p_mean, double p_deviation) noexcept {
 }
 
 int Math::step_decimals(double p_step) noexcept {
-	constexpr int maxn = 10;
-	constexpr double sd[maxn] = {
+	static constexpr int maxn = 10;
+	static constexpr double sd[maxn] = {
 		0.9999, // somehow compensate for floating point error
 		0.09999,
 		0.009999,

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -36,6 +36,7 @@
 #include "core/math/math_defs.h"
 #include "core/typedefs.h"
 
+#include <algorithm>
 #include <bit>
 #include <cfloat>
 #include <cmath>

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -32,32 +32,24 @@
 
 #pragma once
 
-/**
- * @file math_funcs.h
- *
- * [Add any documentation that applies to the entire file here!]
- */
-
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
 #include "core/typedefs.h"
 
+#include <bit>
 #include <cfloat>
 #include <cmath>
+#include <concepts> // std::floating_point
 
 namespace Math {
 
-_ALWAYS_INLINE_ double sin(double p_x) {
-	return std::sin(p_x);
-}
-_ALWAYS_INLINE_ float sin(float p_x) {
+template <typename T>
+_ALWAYS_INLINE_ T sin(T p_x) {
 	return std::sin(p_x);
 }
 
-_ALWAYS_INLINE_ double cos(double p_x) {
-	return std::cos(p_x);
-}
-_ALWAYS_INLINE_ float cos(float p_x) {
+template <std::floating_point T>
+_ALWAYS_INLINE_ T cos(T p_x) {
 	return std::cos(p_x);
 }
 
@@ -66,29 +58,16 @@ _ALWAYS_INLINE_ float cos(float p_x) {
 #define __has_builtin(x) 0
 #endif
 
-template <typename T>
-_ALWAYS_INLINE_ void sin_cos(double p_x, T &r_sin, T &r_cos) {
+template <std::floating_point T, std::floating_point X>
+_ALWAYS_INLINE_ void sin_cos(X p_x, T &r_sin, T &r_cos) {
 #if __has_builtin(__builtin_sincos)
 	double s, c;
 	__builtin_sincos(p_x, &s, &c);
-	r_sin = (T)s;
-	r_cos = (T)c;
+	r_sin = static_cast<T>(s);
+	r_cos = static_cast<T>(c);
 #else
-	r_sin = (T)Math::sin(p_x);
-	r_cos = (T)Math::cos(p_x);
-#endif
-}
-
-template <typename T>
-_ALWAYS_INLINE_ void sin_cos(float p_x, T &r_sin, T &r_cos) {
-#if __has_builtin(__builtin_sincosf)
-	float s, c;
-	__builtin_sincosf(p_x, &s, &c);
-	r_sin = (T)s;
-	r_cos = (T)c;
-#else
-	r_sin = (T)Math::sin(p_x);
-	r_cos = (T)Math::cos(p_x);
+	r_sin = static_cast<T>(Math::sin(p_x));
+	r_cos = static_cast<T>(Math::cos(p_x));
 #endif
 }
 
@@ -97,786 +76,794 @@ _ALWAYS_INLINE_ void sin_cos(float p_x, T &r_sin, T &r_cos) {
 #undef __has_builtin
 #endif
 
-_ALWAYS_INLINE_ double tan(double p_x) {
-	return std::tan(p_x);
-}
-_ALWAYS_INLINE_ float tan(float p_x) {
+template <std::floating_point T>
+_ALWAYS_INLINE_ T tan(T p_x) {
 	return std::tan(p_x);
 }
 
-_ALWAYS_INLINE_ double sinh(double p_x) {
-	return std::sinh(p_x);
-}
-_ALWAYS_INLINE_ float sinh(float p_x) {
+template <std::floating_point T>
+_ALWAYS_INLINE_ T sinh(T p_x) {
 	return std::sinh(p_x);
 }
 
-_ALWAYS_INLINE_ double sinc(double p_x) {
-	return p_x == 0 ? 1 : sin(p_x) / p_x;
-}
-_ALWAYS_INLINE_ float sinc(float p_x) {
+template <std::floating_point T>
+_ALWAYS_INLINE_ T sinc(T p_x) {
 	return p_x == 0 ? 1 : sin(p_x) / p_x;
 }
 
-_ALWAYS_INLINE_ double sincn(double p_x) {
+template <std::floating_point T>
+_ALWAYS_INLINE_ T sincn(T p_x) {
 	return sinc(PI * p_x);
 }
-_ALWAYS_INLINE_ float sincn(float p_x) {
-	return sinc((float)PI * p_x);
+
+/*
+ * Less overhead vs std::clamp due to just comparing values,
+ * lowers <algorithm> dependency in this file, too.
+ */
+template <typename T, typename U, typename V>
+constexpr auto clamp(T x, U minv, V maxv) noexcept {
+	using R = std::common_type_t<T, U, V>;
+	return std::min(std::max(static_cast<R>(x), static_cast<R>(minv)), static_cast<R>(maxv));
 }
 
-_ALWAYS_INLINE_ double cosh(double p_x) {
-	return std::cosh(p_x);
-}
-_ALWAYS_INLINE_ float cosh(float p_x) {
-	return std::cosh(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T cosh(T x) noexcept {
+	return std::cosh(x);
 }
 
-_ALWAYS_INLINE_ double tanh(double p_x) {
-	return std::tanh(p_x);
-}
-_ALWAYS_INLINE_ float tanh(float p_x) {
-	return std::tanh(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T tanh(T x) noexcept {
+	return std::tanh(x);
 }
 
-/// Always does clamping so always safe to use.
-_ALWAYS_INLINE_ double asin(double p_x) {
-	return p_x < -1 ? (-PI / 2) : (p_x > 1 ? (PI / 2) : std::asin(p_x));
-}
-_ALWAYS_INLINE_ float asin(float p_x) {
-	return p_x < -1 ? (-(float)PI / 2) : (p_x > 1 ? ((float)PI / 2) : std::asin(p_x));
+template <std::floating_point T>
+_ALWAYS_INLINE_ T asin(T x) noexcept {
+	x = clamp(x, T(-1), T(1));
+	return std::asin(x);
 }
 
-/// Always does clamping so always safe to use.
-_ALWAYS_INLINE_ double acos(double p_x) {
-	return p_x < -1 ? PI : (p_x > 1 ? 0 : std::acos(p_x));
-}
-_ALWAYS_INLINE_ float acos(float p_x) {
-	return p_x < -1 ? (float)PI : (p_x > 1 ? 0 : std::acos(p_x));
+template <std::floating_point T>
+_ALWAYS_INLINE_ T acos(T x) noexcept {
+	x = clamp(x, T(-1), T(1));
+	return std::acos(x);
 }
 
-_ALWAYS_INLINE_ double atan(double p_x) {
-	return std::atan(p_x);
-}
-_ALWAYS_INLINE_ float atan(float p_x) {
-	return std::atan(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T atan(T x) noexcept {
+	return std::atan(x);
 }
 
-_ALWAYS_INLINE_ double atan2(double p_y, double p_x) {
-	return std::atan2(p_y, p_x);
-}
-_ALWAYS_INLINE_ float atan2(float p_y, float p_x) {
-	return std::atan2(p_y, p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T atan2(T y, T x) noexcept {
+	return std::atan2(y, x);
 }
 
-_ALWAYS_INLINE_ double asinh(double p_x) {
-	return std::asinh(p_x);
-}
-_ALWAYS_INLINE_ float asinh(float p_x) {
-	return std::asinh(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T asinh(T x) noexcept {
+	return std::asinh(x);
 }
 
-/// Always does clamping so always safe to use.
-_ALWAYS_INLINE_ double acosh(double p_x) {
-	return p_x < 1 ? 0 : std::acosh(p_x);
-}
-_ALWAYS_INLINE_ float acosh(float p_x) {
-	return p_x < 1 ? 0 : std::acosh(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T acosh(T x) noexcept {
+	x = clamp(x, T(1), std::numeric_limits<T>::infinity());
+	return std::acosh(x);
 }
 
-/// Always does clamping so always safe to use.
-_ALWAYS_INLINE_ double atanh(double p_x) {
-	return p_x <= -1 ? -INF : (p_x >= 1 ? INF : std::atanh(p_x));
-}
-_ALWAYS_INLINE_ float atanh(float p_x) {
-	return p_x <= -1 ? (float)-INF : (p_x >= 1 ? (float)INF : std::atanh(p_x));
+template <std::floating_point T>
+_ALWAYS_INLINE_ T atanh(T x) noexcept {
+	x = clamp(x, T(-1) + CMP_EPSILON, T(1) - CMP_EPSILON);
+	return std::atanh(x);
 }
 
-_ALWAYS_INLINE_ double sqrt(double p_x) {
-	return std::sqrt(p_x);
-}
-_ALWAYS_INLINE_ float sqrt(float p_x) {
-	return std::sqrt(p_x);
+template <std::floating_point T>
+_FORCE_INLINE_ T sqrt(T x) noexcept {
+	return std::sqrt(x);
 }
 
-_ALWAYS_INLINE_ double fmod(double p_x, double p_y) {
-	return std::fmod(p_x, p_y);
-}
-_ALWAYS_INLINE_ float fmod(float p_x, float p_y) {
-	return std::fmod(p_x, p_y);
+template <std::integral T>
+_FORCE_INLINE_ double sqrt(T x) noexcept {
+	return std::sqrt(static_cast<double>(x));
 }
 
-_ALWAYS_INLINE_ double modf(double p_x, double *r_y) {
-	return std::modf(p_x, r_y);
-}
-_ALWAYS_INLINE_ float modf(float p_x, float *r_y) {
-	return std::modf(p_x, r_y);
+template <std::floating_point T, std::convertible_to<T> U>
+_FORCE_INLINE_ T fmod(T x, U y) noexcept {
+	return std::fmod(x, y);
 }
 
-_ALWAYS_INLINE_ double floor(double p_x) {
-	return std::floor(p_x);
-}
-_ALWAYS_INLINE_ float floor(float p_x) {
-	return std::floor(p_x);
+template <std::floating_point T>
+_FORCE_INLINE_ T modf(T x, T y) noexcept {
+	return std::modf(x, y);
 }
 
-_ALWAYS_INLINE_ double ceil(double p_x) {
-	return std::ceil(p_x);
-}
-_ALWAYS_INLINE_ float ceil(float p_x) {
-	return std::ceil(p_x);
+template <std::floating_point T>
+_FORCE_INLINE_ T modf_with_ptr(T x, T *y) noexcept {
+	return std::modf(x, y);
 }
 
-_ALWAYS_INLINE_ double pow(double p_x, double p_y) {
-	return std::pow(p_x, p_y);
-}
-_ALWAYS_INLINE_ float pow(float p_x, float p_y) {
-	return std::pow(p_x, p_y);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T floor(T x) noexcept {
+	return std::floor(x);
 }
 
-_ALWAYS_INLINE_ double log(double p_x) {
-	return std::log(p_x);
-}
-_ALWAYS_INLINE_ float log(float p_x) {
-	return std::log(p_x);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T ceil(T x) noexcept {
+	return std::ceil(x);
 }
 
-_ALWAYS_INLINE_ double log1p(double p_x) {
-	return std::log1p(p_x);
-}
-_ALWAYS_INLINE_ float log1p(float p_x) {
-	return std::log1p(p_x);
-}
+/*
+ * For non negative integer exponents.
+ */
+template <std::floating_point T>
+constexpr T ipow(T base, long long exp) noexcept {
+	// TODO: Should we handle negatives?
+	T res = T(1);
+	T b = base;
+	unsigned long long e = static_cast<unsigned long long>(exp);
 
-_ALWAYS_INLINE_ double log2(double p_x) {
-	return std::log2(p_x);
-}
-_ALWAYS_INLINE_ float log2(float p_x) {
-	return std::log2(p_x);
-}
-
-_ALWAYS_INLINE_ double exp(double p_x) {
-	return std::exp(p_x);
-}
-_ALWAYS_INLINE_ float exp(float p_x) {
-	return std::exp(p_x);
-}
-
-_ALWAYS_INLINE_ bool is_nan(double p_val) {
-	return std::isnan(p_val);
-}
-
-_ALWAYS_INLINE_ bool is_nan(float p_val) {
-	return std::isnan(p_val);
-}
-
-_ALWAYS_INLINE_ bool is_inf(double p_val) {
-	return std::isinf(p_val);
-}
-
-_ALWAYS_INLINE_ bool is_inf(float p_val) {
-	return std::isinf(p_val);
-}
-
-/// @name These methods assume (p_num + p_den) doesn't overflow.
-/// @{
-_ALWAYS_INLINE_ int32_t division_round_up(int32_t p_num, int32_t p_den) {
-	int32_t offset = (p_num < 0 && p_den < 0) ? 1 : -1;
-	return (p_num + p_den + offset) / p_den;
-}
-_ALWAYS_INLINE_ uint32_t division_round_up(uint32_t p_num, uint32_t p_den) {
-	return (p_num + p_den - 1) / p_den;
-}
-_ALWAYS_INLINE_ int64_t division_round_up(int64_t p_num, int64_t p_den) {
-	int32_t offset = (p_num < 0 && p_den < 0) ? 1 : -1;
-	return (p_num + p_den + offset) / p_den;
-}
-_ALWAYS_INLINE_ uint64_t division_round_up(uint64_t p_num, uint64_t p_den) {
-	return (p_num + p_den - 1) / p_den;
-}
-/// @}
-
-_ALWAYS_INLINE_ bool is_finite(double p_val) {
-	return std::isfinite(p_val);
-}
-_ALWAYS_INLINE_ bool is_finite(float p_val) {
-	return std::isfinite(p_val);
-}
-
-_ALWAYS_INLINE_ double abs(double p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ float abs(float p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ int8_t abs(int8_t p_value) {
-	return p_value > 0 ? p_value : -p_value;
-}
-_ALWAYS_INLINE_ int16_t abs(int16_t p_value) {
-	return p_value > 0 ? p_value : -p_value;
-}
-_ALWAYS_INLINE_ int32_t abs(int32_t p_value) {
-	return std::abs(p_value);
-}
-_ALWAYS_INLINE_ int64_t abs(int64_t p_value) {
-	return std::abs(p_value);
-}
-
-_ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
-	double value = fmod(p_x, p_y);
-	if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
-		value += p_y;
+	if (exp == 0) {
+		return res;
 	}
-	value += 0.0;
-	return value;
-}
-_ALWAYS_INLINE_ float fposmod(float p_x, float p_y) {
-	float value = fmod(p_x, p_y);
-	if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
-		value += p_y;
+	if (exp == 1) {
+		return b;
 	}
-	value += 0.0f;
-	return value;
-}
-
-_ALWAYS_INLINE_ double fposmodp(double p_x, double p_y) {
-	double value = fmod(p_x, p_y);
-	if (value < 0) {
-		value += p_y;
+	if (exp == 2) {
+		return b * b;
 	}
-	value += 0.0;
-	return value;
-}
-_ALWAYS_INLINE_ float fposmodp(float p_x, float p_y) {
-	float value = fmod(p_x, p_y);
-	if (value < 0) {
-		value += p_y;
+	if (exp == 3) {
+		return b * b * b;
 	}
-	value += 0.0f;
-	return value;
-}
 
-_ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
-	ERR_FAIL_COND_V_MSG(p_y == 0, 0, "Division by zero in posmod is undefined. Returning 0 as fallback.");
-	int64_t value = p_x % p_y;
-	if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
-		value += p_y;
+	// exponentiation by squaring.
+	while (e != 0) {
+		if (e & 1ULL) {
+			res *= b;
+		}
+		b *= b;
+		e >>= 1ULL;
 	}
-	return value;
+
+	return res;
 }
 
-_ALWAYS_INLINE_ double deg_to_rad(double p_y) {
-	return p_y * (PI / 180.0);
-}
-_ALWAYS_INLINE_ float deg_to_rad(float p_y) {
-	return p_y * ((float)PI / 180.0f);
-}
-
-_ALWAYS_INLINE_ double rad_to_deg(double p_y) {
-	return p_y * (180.0 / PI);
-}
-_ALWAYS_INLINE_ float rad_to_deg(float p_y) {
-	return p_y * (180.0f / (float)PI);
-}
-
-_ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) {
-	return p_from + (p_to - p_from) * p_weight;
-}
-_ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) {
-	return p_from + (p_to - p_from) * p_weight;
-}
-
-_ALWAYS_INLINE_ double cubic_interpolate(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
-	return 0.5 *
-			((p_from * 2.0) +
-					(-p_pre + p_to) * p_weight +
-					(2.0 * p_pre - 5.0 * p_from + 4.0 * p_to - p_post) * (p_weight * p_weight) +
-					(-p_pre + 3.0 * p_from - 3.0 * p_to + p_post) * (p_weight * p_weight * p_weight));
-}
-_ALWAYS_INLINE_ float cubic_interpolate(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
-	return 0.5f *
-			((p_from * 2.0f) +
-					(-p_pre + p_to) * p_weight +
-					(2.0f * p_pre - 5.0f * p_from + 4.0f * p_to - p_post) * (p_weight * p_weight) +
-					(-p_pre + 3.0f * p_from - 3.0f * p_to + p_post) * (p_weight * p_weight * p_weight));
-}
-
-_ALWAYS_INLINE_ double cubic_interpolate_angle(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
-	double from_rot = fmod(p_from, TAU);
-
-	double pre_diff = fmod(p_pre - from_rot, TAU);
-	double pre_rot = from_rot + fmod(2.0 * pre_diff, TAU) - pre_diff;
-
-	double to_diff = fmod(p_to - from_rot, TAU);
-	double to_rot = from_rot + fmod(2.0 * to_diff, TAU) - to_diff;
-
-	double post_diff = fmod(p_post - to_rot, TAU);
-	double post_rot = to_rot + fmod(2.0 * post_diff, TAU) - post_diff;
-
-	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
-}
-
-_ALWAYS_INLINE_ float cubic_interpolate_angle(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
-	float from_rot = fmod(p_from, (float)TAU);
-
-	float pre_diff = fmod(p_pre - from_rot, (float)TAU);
-	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)TAU) - pre_diff;
-
-	float to_diff = fmod(p_to - from_rot, (float)TAU);
-	float to_rot = from_rot + fmod(2.0f * to_diff, (float)TAU) - to_diff;
-
-	float post_diff = fmod(p_post - to_rot, (float)TAU);
-	float post_rot = to_rot + fmod(2.0f * post_diff, (float)TAU) - post_diff;
-
-	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
-}
-
-_ALWAYS_INLINE_ double cubic_interpolate_in_time(double p_from, double p_to, double p_pre, double p_post, double p_weight,
-		double p_to_t, double p_pre_t, double p_post_t) {
-	/* Barry-Goldman method */
-	double t = lerp(0.0, p_to_t, p_weight);
-	double a1 = lerp(p_pre, p_from, p_pre_t == 0 ? 0.0 : (t - p_pre_t) / -p_pre_t);
-	double a2 = lerp(p_from, p_to, p_to_t == 0 ? 0.5 : t / p_to_t);
-	double a3 = lerp(p_to, p_post, p_post_t - p_to_t == 0 ? 1.0 : (t - p_to_t) / (p_post_t - p_to_t));
-	double b1 = lerp(a1, a2, p_to_t - p_pre_t == 0 ? 0.0 : (t - p_pre_t) / (p_to_t - p_pre_t));
-	double b2 = lerp(a2, a3, p_post_t == 0 ? 1.0 : t / p_post_t);
-	return lerp(b1, b2, p_to_t == 0 ? 0.5 : t / p_to_t);
-}
-_ALWAYS_INLINE_ float cubic_interpolate_in_time(float p_from, float p_to, float p_pre, float p_post, float p_weight,
-		float p_to_t, float p_pre_t, float p_post_t) {
-	/* Barry-Goldman method */
-	float t = lerp(0.0f, p_to_t, p_weight);
-	float a1 = lerp(p_pre, p_from, p_pre_t == 0 ? 0.0f : (t - p_pre_t) / -p_pre_t);
-	float a2 = lerp(p_from, p_to, p_to_t == 0 ? 0.5f : t / p_to_t);
-	float a3 = lerp(p_to, p_post, p_post_t - p_to_t == 0 ? 1.0f : (t - p_to_t) / (p_post_t - p_to_t));
-	float b1 = lerp(a1, a2, p_to_t - p_pre_t == 0 ? 0.0f : (t - p_pre_t) / (p_to_t - p_pre_t));
-	float b2 = lerp(a2, a3, p_post_t == 0 ? 1.0f : t / p_post_t);
-	return lerp(b1, b2, p_to_t == 0 ? 0.5f : t / p_to_t);
-}
-
-_ALWAYS_INLINE_ double cubic_interpolate_angle_in_time(double p_from, double p_to, double p_pre, double p_post, double p_weight,
-		double p_to_t, double p_pre_t, double p_post_t) {
-	double from_rot = fmod(p_from, TAU);
-
-	double pre_diff = fmod(p_pre - from_rot, TAU);
-	double pre_rot = from_rot + fmod(2.0 * pre_diff, TAU) - pre_diff;
-
-	double to_diff = fmod(p_to - from_rot, TAU);
-	double to_rot = from_rot + fmod(2.0 * to_diff, TAU) - to_diff;
-
-	double post_diff = fmod(p_post - to_rot, TAU);
-	double post_rot = to_rot + fmod(2.0 * post_diff, TAU) - post_diff;
-
-	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
-}
-_ALWAYS_INLINE_ float cubic_interpolate_angle_in_time(float p_from, float p_to, float p_pre, float p_post, float p_weight,
-		float p_to_t, float p_pre_t, float p_post_t) {
-	float from_rot = fmod(p_from, (float)TAU);
-
-	float pre_diff = fmod(p_pre - from_rot, (float)TAU);
-	float pre_rot = from_rot + fmod(2.0f * pre_diff, (float)TAU) - pre_diff;
-
-	float to_diff = fmod(p_to - from_rot, (float)TAU);
-	float to_rot = from_rot + fmod(2.0f * to_diff, (float)TAU) - to_diff;
-
-	float post_diff = fmod(p_post - to_rot, (float)TAU);
-	float post_rot = to_rot + fmod(2.0f * post_diff, (float)TAU) - post_diff;
-
-	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
-}
-
-/** Formula from Wikipedia article on Bezier curves. */
-_ALWAYS_INLINE_ double bezier_interpolate(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
-	double omt = (1.0 - p_t);
-	double omt2 = omt * omt;
-	double omt3 = omt2 * omt;
-	double t2 = p_t * p_t;
-	double t3 = t2 * p_t;
-
-	return p_start * omt3 + p_control_1 * omt2 * p_t * 3.0 + p_control_2 * omt * t2 * 3.0 + p_end * t3;
-}
-
-/** Formula from Wikipedia article on Bezier curves. */
-_ALWAYS_INLINE_ float bezier_interpolate(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
-	float omt = (1.0f - p_t);
-	float omt2 = omt * omt;
-	float omt3 = omt2 * omt;
-	float t2 = p_t * p_t;
-	float t3 = t2 * p_t;
-
-	return p_start * omt3 + p_control_1 * omt2 * p_t * 3.0f + p_control_2 * omt * t2 * 3.0f + p_end * t3;
-}
-
-/** Formula from Wikipedia article on Bezier curves. */
-_ALWAYS_INLINE_ double bezier_derivative(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
-	double omt = (1.0 - p_t);
-	double omt2 = omt * omt;
-	double t2 = p_t * p_t;
-
-	double d = (p_control_1 - p_start) * 3.0 * omt2 + (p_control_2 - p_control_1) * 6.0 * omt * p_t + (p_end - p_control_2) * 3.0 * t2;
-	return d;
-}
-
-/** Formula from Wikipedia article on Bezier curves. */
-_ALWAYS_INLINE_ float bezier_derivative(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
-	float omt = (1.0f - p_t);
-	float omt2 = omt * omt;
-	float t2 = p_t * p_t;
-
-	float d = (p_control_1 - p_start) * 3.0f * omt2 + (p_control_2 - p_control_1) * 6.0f * omt * p_t + (p_end - p_control_2) * 3.0f * t2;
-	return d;
-}
-
-_ALWAYS_INLINE_ double angle_difference(double p_from, double p_to) {
-	double difference = fmod(p_to - p_from, TAU);
-	return fmod(2.0 * difference, TAU) - difference;
-}
-_ALWAYS_INLINE_ float angle_difference(float p_from, float p_to) {
-	float difference = fmod(p_to - p_from, (float)TAU);
-	return fmod(2.0f * difference, (float)TAU) - difference;
-}
-
-_ALWAYS_INLINE_ double lerp_angle(double p_from, double p_to, double p_weight) {
-	return p_from + angle_difference(p_from, p_to) * p_weight;
-}
-_ALWAYS_INLINE_ float lerp_angle(float p_from, float p_to, float p_weight) {
-	return p_from + angle_difference(p_from, p_to) * p_weight;
-}
-
-_ALWAYS_INLINE_ double inverse_lerp(double p_from, double p_to, double p_value) {
-	return (p_value - p_from) / (p_to - p_from);
-}
-_ALWAYS_INLINE_ float inverse_lerp(float p_from, float p_to, float p_value) {
-	return (p_value - p_from) / (p_to - p_from);
-}
-
-_ALWAYS_INLINE_ double remap(double p_value, double p_istart, double p_istop, double p_ostart, double p_ostop) {
-	return lerp(p_ostart, p_ostop, inverse_lerp(p_istart, p_istop, p_value));
-}
-_ALWAYS_INLINE_ float remap(float p_value, float p_istart, float p_istop, float p_ostart, float p_ostop) {
-	return lerp(p_ostart, p_ostop, inverse_lerp(p_istart, p_istop, p_value));
-}
-
-_ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right, double p_tolerance) {
-	// Check for exact equality first, required to handle "infinity" values.
-	if (p_left == p_right) {
-		return true;
-	}
-	// Then check for approximate equality.
-	return abs(p_left - p_right) < p_tolerance;
-}
-_ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right, float p_tolerance) {
-	// Check for exact equality first, required to handle "infinity" values.
-	if (p_left == p_right) {
-		return true;
-	}
-	// Then check for approximate equality.
-	return abs(p_left - p_right) < p_tolerance;
-}
-
-_ALWAYS_INLINE_ bool is_equal_approx(double p_left, double p_right) {
-	// Check for exact equality first, required to handle "infinity" values.
-	if (p_left == p_right) {
-		return true;
-	}
-	// Then check for approximate equality.
-	double tolerance = CMP_EPSILON * abs(p_left);
-	if (tolerance < CMP_EPSILON) {
-		tolerance = CMP_EPSILON;
-	}
-	return abs(p_left - p_right) < tolerance;
-}
-_ALWAYS_INLINE_ bool is_equal_approx(float p_left, float p_right) {
-	// Check for exact equality first, required to handle "infinity" values.
-	if (p_left == p_right) {
-		return true;
-	}
-	// Then check for approximate equality.
-	float tolerance = (float)CMP_EPSILON * abs(p_left);
-	if (tolerance < (float)CMP_EPSILON) {
-		tolerance = (float)CMP_EPSILON;
-	}
-	return abs(p_left - p_right) < tolerance;
-}
-
-_ALWAYS_INLINE_ bool is_zero_approx(double p_value) {
-	return abs(p_value) < CMP_EPSILON;
-}
-_ALWAYS_INLINE_ bool is_zero_approx(float p_value) {
-	return abs(p_value) < (float)CMP_EPSILON;
-}
-
-_ALWAYS_INLINE_ bool is_same(double p_left, double p_right) {
-	return (p_left == p_right) || (is_nan(p_left) && is_nan(p_right));
-}
-_ALWAYS_INLINE_ bool is_same(float p_left, float p_right) {
-	return (p_left == p_right) || (is_nan(p_left) && is_nan(p_right));
-}
-
-_ALWAYS_INLINE_ double smoothstep(double p_from, double p_to, double p_s) {
-	if (is_equal_approx(p_from, p_to)) {
-		if (likely(p_from <= p_to)) {
-			return p_s <= p_from ? 0.0 : 1.0;
-		} else {
-			return p_s <= p_to ? 1.0 : 0.0;
+template <std::floating_point T>
+constexpr T pow(T x, T y) noexcept {
+	// Requires both params to be the same floating-type.
+	// Cast types manually when needed.
+	if (std::is_constant_evaluated()) {
+		// std::pow() isn't constexpr until C++23, so this is our workaround.
+		if (static_cast<T>(static_cast<long long>(y)) == y) {
+			// We need to be sure this is not a fraction.
+			return ipow(x, static_cast<long long>(y));
 		}
 	}
-	double s = CLAMP((p_s - p_from) / (p_to - p_from), 0.0, 1.0);
-	return s * s * (3.0 - 2.0 * s);
-}
-_ALWAYS_INLINE_ float smoothstep(float p_from, float p_to, float p_s) {
-	if (is_equal_approx(p_from, p_to)) {
-		if (likely(p_from <= p_to)) {
-			return p_s <= p_from ? 0.0f : 1.0f;
-		} else {
-			return p_s <= p_to ? 1.0f : 0.0f;
-		}
-	}
-	float s = CLAMP((p_s - p_from) / (p_to - p_from), 0.0f, 1.0f);
-	return s * s * (3.0f - 2.0f * s);
+	// Runtime path
+	return std::pow(x, y);
 }
 
-_ALWAYS_INLINE_ double move_toward(double p_from, double p_to, double p_delta) {
-	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
-}
-_ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) {
-	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+template <std::floating_point T>
+_ALWAYS_INLINE_ T log(T x) noexcept {
+	return std::log(x);
 }
 
-_ALWAYS_INLINE_ double rotate_toward(double p_from, double p_to, double p_delta) {
-	double difference = angle_difference(p_from, p_to);
-	double abs_difference = abs(difference);
-	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - PI, abs_difference) * (difference >= 0.0 ? 1.0 : -1.0);
-}
-_ALWAYS_INLINE_ float rotate_toward(float p_from, float p_to, float p_delta) {
-	float difference = angle_difference(p_from, p_to);
-	float abs_difference = abs(difference);
-	// When `p_delta < 0` move no further than to PI radians away from `p_to` (as PI is the max possible angle distance).
-	return p_from + CLAMP(p_delta, abs_difference - (float)PI, abs_difference) * (difference >= 0.0f ? 1.0f : -1.0f);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T log1p(T x) noexcept {
+	return std::log1p(x);
 }
 
-_ALWAYS_INLINE_ double linear_to_db(double p_linear) {
-	return log(p_linear) * 8.6858896380650365530225783783321;
-}
-_ALWAYS_INLINE_ float linear_to_db(float p_linear) {
-	return log(p_linear) * (float)8.6858896380650365530225783783321;
+template <std::floating_point T>
+_ALWAYS_INLINE_ T log2(T x) noexcept {
+	return std::log2(x);
 }
 
-_ALWAYS_INLINE_ double db_to_linear(double p_db) {
-	return exp(p_db * 0.11512925464970228420089957273422);
-}
-_ALWAYS_INLINE_ float db_to_linear(float p_db) {
-	return exp(p_db * (float)0.11512925464970228420089957273422);
+template <std::floating_point T>
+_ALWAYS_INLINE_ T exp(T x) noexcept {
+	return std::exp(x);
 }
 
-_ALWAYS_INLINE_ double round(double p_val) {
-	return std::round(p_val);
-}
-_ALWAYS_INLINE_ float round(float p_val) {
-	return std::round(p_val);
-}
-
-_ALWAYS_INLINE_ double wrapf(double p_value, double p_min, double p_max) {
-	double range = p_max - p_min;
-	if (is_zero_approx(range)) {
-		return p_min;
-	}
-	double result = p_value - (range * floor((p_value - p_min) / range));
-	if (is_equal_approx(result, p_max)) {
-		return p_min;
-	}
-	return result;
-}
-_ALWAYS_INLINE_ float wrapf(float p_value, float p_min, float p_max) {
-	float range = p_max - p_min;
-	if (is_zero_approx(range)) {
-		return p_min;
-	}
-	float result = p_value - (range * floor((p_value - p_min) / range));
-	if (is_equal_approx(result, p_max)) {
-		return p_min;
-	}
-	return result;
+template <std::floating_point T>
+constexpr bool is_nan(T val) noexcept {
+	// Only NaN does not equal itself.
+	return val != val;
 }
 
-_ALWAYS_INLINE_ int64_t wrapi(int64_t p_value, int64_t p_min, int64_t p_max) {
-	int64_t range = p_max - p_min;
-	return range == 0 ? p_min : p_min + ((((p_value - p_min) % range) + range) % range);
+template <std::floating_point T>
+constexpr bool is_inf(T val) noexcept {
+	// std::isinf(val) isn't constexpr in C++20 [Made constexpr in C++23]
+	return val == std::numeric_limits<T>::infinity() || val == -std::numeric_limits<T>::infinity();
 }
 
-_ALWAYS_INLINE_ double fract(double p_value) {
-	return p_value - floor(p_value);
-}
-_ALWAYS_INLINE_ float fract(float p_value) {
-	return p_value - floor(p_value);
+template <std::floating_point T>
+constexpr bool is_finite(T val) noexcept {
+	return !is_inf(val) && !is_nan(val);
 }
 
-_ALWAYS_INLINE_ double pingpong(double p_value, double p_length) {
-	return (p_length != 0.0) ? abs(fract((p_value - p_length) / (p_length * 2.0)) * p_length * 2.0 - p_length) : 0.0;
-}
-_ALWAYS_INLINE_ float pingpong(float p_value, float p_length) {
-	return (p_length != 0.0f) ? abs(fract((p_value - p_length) / (p_length * 2.0f)) * p_length * 2.0f - p_length) : 0.0f;
-}
-
-/// double only, as these functions are mainly used by the editor and not performance-critical,
-double ease(double p_x, double p_c);
-int step_decimals(double p_step);
-/// Only meant for editor usage in float ranges, where a step of 0
-/// means that decimal digits should not be limited in String::num.
-int range_step_decimals(double p_step); // For editor use only.
-double snapped(double p_value, double p_step);
-
-uint32_t larger_prime(uint32_t p_val);
-
-void seed(uint64_t p_seed);
-void randomize();
-uint32_t rand_from_seed(uint64_t *p_seed);
-uint32_t rand();
-_ALWAYS_INLINE_ double randd() {
-	return (double)rand() / (double)UINT32_MAX;
-}
-_ALWAYS_INLINE_ float randf() {
-	return (float)rand() / (float)UINT32_MAX;
-}
-double randfn(double p_mean, double p_deviation);
-
-double random(double p_from, double p_to);
-float random(float p_from, float p_to);
-int random(int p_from, int p_to);
-
-/// This function should be as fast as possible and rounding mode should not matter.
-_ALWAYS_INLINE_ int fast_ftoi(float p_value) {
-	return std::rint(p_value);
-}
-
-_ALWAYS_INLINE_ uint32_t halfbits_to_floatbits(uint16_t p_half) {
-	uint16_t h_exp, h_sig;
-	uint32_t f_sgn, f_exp, f_sig;
-
-	h_exp = (p_half & 0x7c00u);
-	f_sgn = ((uint32_t)p_half & 0x8000u) << 16;
-	switch (h_exp) {
-		case 0x0000u: /* 0 or subnormal */
-			h_sig = (p_half & 0x03ffu);
-			/* Signed zero */
-			if (h_sig == 0) {
-				return f_sgn;
-			}
-			/* Subnormal */
-			h_sig <<= 1;
-			while ((h_sig & 0x0400u) == 0) {
-				h_sig <<= 1;
-				h_exp++;
-			}
-			f_exp = ((uint32_t)(127 - 15 - h_exp)) << 23;
-			f_sig = ((uint32_t)(h_sig & 0x03ffu)) << 13;
-			return f_sgn + f_exp + f_sig;
-		case 0x7c00u: /* inf or NaN */
-			/* All-ones exponent and a copy of the significand */
-			return f_sgn + 0x7f800000u + (((uint32_t)(p_half & 0x03ffu)) << 13);
-		default: /* normalized */
-			/* Just need to adjust the exponent and shift */
-			return f_sgn + (((uint32_t)(p_half & 0x7fffu) + 0x1c000u) << 13);
-	}
-}
-
-_ALWAYS_INLINE_ float halfptr_to_float(const uint16_t *p_half) {
-	union {
-		uint32_t u32;
-		float f32;
-	} u;
-
-	u.u32 = halfbits_to_floatbits(*p_half);
-	return u.f32;
-}
-
-_ALWAYS_INLINE_ float half_to_float(const uint16_t p_half) {
-	return halfptr_to_float(&p_half);
-}
-
-_ALWAYS_INLINE_ uint16_t make_half_float(float p_value) {
-	union {
-		float fv;
-		uint32_t ui;
-	} ci;
-	ci.fv = p_value;
-
-	uint32_t x = ci.ui;
-	uint32_t sign = (unsigned short)(x >> 31);
-	uint32_t mantissa;
-	uint32_t exponent;
-	uint16_t hf;
-
-	// get mantissa
-	mantissa = x & ((1 << 23) - 1);
-	// get exponent bits
-	exponent = x & (0xFF << 23);
-	if (exponent >= 0x47800000) {
-		// check if the original single precision float number is a NaN
-		if (mantissa && (exponent == (0xFF << 23))) {
-			// we have a single precision NaN
-			mantissa = (1 << 23) - 1;
-		} else {
-			// 16-bit half-float representation stores number as Inf
-			mantissa = 0;
-		}
-		hf = (((uint16_t)sign) << 15) | (uint16_t)((0x1F << 10)) |
-				(uint16_t)(mantissa >> 13);
-	}
-	// check if exponent is <= -15
-	else if (exponent <= 0x38000000) {
-		/*
-		// store a denorm half-float value or zero
-		exponent = (0x38000000 - exponent) >> 23;
-		mantissa >>= (14 + exponent);
-
-		hf = (((uint16_t)sign) << 15) | (uint16_t)(mantissa);
-		*/
-		hf = 0; //denormals do not work for 3D, convert to zero
+template <typename T>
+constexpr T abs(T value) noexcept {
+	if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+		// Use std::abs for float/double for hardware optimizations.
+		return std::abs(value);
+	} else if constexpr (std::is_signed_v<T>) {
+		// Manually compute abs for other signed types.
+		// Also avoids potential int8_t -> int issues.
+		return value < T(0) ? -value : value;
 	} else {
-		hf = (((uint16_t)sign) << 15) |
-				(uint16_t)((exponent - 0x38000000) >> 13) |
-				(uint16_t)(mantissa >> 13);
+		// unsigned is always positive! :^)
+		return value;
+	}
+}
+
+template <unsigned_integral T>
+constexpr T division_round_up(T p_num, T p_den) {
+	// for unsigned ints
+	return (p_num + p_den - 1) / p_den;
+}
+
+template <signed_integral T>
+constexpr T division_round_up(T p_num, T p_den) {
+	// for signed ints.
+	T offset = (p_num < 0 && p_den < 0) ? 1 : -1;
+	return (p_num + p_den + offset) / p_den;
+}
+
+template <std::floating_point T>
+constexpr T fposmod(T x, T y) noexcept {
+	T value = fmod(x, y);
+	// mask based on sign mismatch.
+	T mask = T(value != 0 && ((value < T(0))) != (y < T(0)));
+	// convert bool to 0.0 or 1.0
+	mask = static_cast<T>(mask);
+	return value + mask * y;
+}
+
+template <std::floating_point T>
+constexpr T fposmodp(T x, T y) noexcept {
+	T value = fmod(x, y);
+
+	value += (value < T(0)) ? y : T(0);
+
+	return value;
+}
+
+// keep overloads and avoid generic templates, otherwise it will slow things down.
+constexpr int64_t posmod(int64_t x, int64_t y) noexcept {
+	if (y == 0) {
+		// Division by zero undefined. Return 0 as fallback.
+		return 0;
 	}
 
-	return hf;
+	int64_t value = x % y;
+
+	value += (value != 0 && ((value < 0) != (y < 0))) ? y : 0;
+
+	return value;
 }
 
-_ALWAYS_INLINE_ float snap_scalar(float p_offset, float p_step, float p_target) {
-	return p_step != 0 ? snapped(p_target - p_offset, p_step) + p_offset : p_target;
+constexpr int32_t posmod(int32_t x, int32_t y) noexcept {
+	if (y == 0) {
+		// Division by zero undefined. Return 0 as fallback.
+		return 0;
+	}
+
+	int32_t value = x % y;
+
+	value += (value != 0 && ((value < 0) != (y < 0))) ? y : 0;
+
+	return value;
 }
 
-_ALWAYS_INLINE_ float snap_scalar_separation(float p_offset, float p_step, float p_target, float p_separation) {
-	if (p_step != 0) {
-		float a = snapped(p_target - p_offset, p_step + p_separation) + p_offset;
-		float b = a;
-		if (p_target >= 0) {
-			b -= p_separation;
-		} else {
-			b += p_step;
+template <std::floating_point T>
+constexpr T deg_to_rad(T y) noexcept {
+	return y * (T(PI) / T(180));
+}
+
+template <std::floating_point T>
+constexpr T rad_to_deg(T y) {
+	return y * (T(180) / T(PI));
+}
+
+template <std::floating_point T>
+constexpr T lerp(T from, T to, T weight) noexcept {
+	// TODO: AVX512 crushes float here via clang++
+	// and use scalar for doubles.
+	return from + (to - from) * weight;
+}
+
+template <std::floating_point T>
+constexpr T cubic_interpolate(T p_from, T p_to, T p_pre, T p_post, T p_weight) noexcept {
+	// weight squared.
+	T w2 = p_weight * p_weight;
+	// weight cubed.
+	T w3 = p_weight * w2;
+
+	// calculate coefficients.
+	T a = -p_pre + p_to;
+	T b = T(2) * p_pre - T(5) * p_from + T(4) * p_to - p_post;
+	T c = -p_pre + T(3) * p_from - T(3) * p_to + p_post;
+
+	// Catmull-Rom Interpolation:
+	// 0.5 * ((2 * p_from) + (a * w) + (b * w^2) + (c * w^3))
+
+	if (std::is_constant_evaluated()) {
+		// compile time
+		return T(0.5) * (T(2) * p_from) + (a * p_weight) + (b * w2) + (c * w3);
+	} else {
+		// runtime
+		return T(0.5) * std::fma(c, w3, std::fma(b, w2, std::fma(a, p_weight, T(2) * p_from)));
+	}
+}
+
+template <std::floating_point T>
+constexpr T cubic_interpolate_angle(T p_from, T p_to, T p_pre, T p_post, T p_weight) noexcept {
+	// Use fposmod instead of fmod to shorten path.
+	T from_rot = fposmod(p_from, T(TAU));
+
+	T pre_diff = fposmod(p_pre - from_rot, T(TAU));
+	T pre_rot = from_rot + fposmod(T(2) * pre_diff, T(TAU)) - pre_diff;
+
+	T to_diff = fposmod(p_to - from_rot, T(TAU));
+	T to_rot = from_rot + fposmod(T(2) * to_diff, T(TAU)) - to_diff;
+
+	T post_diff = fposmod(p_post - to_rot, T(TAU));
+	T post_rot = to_rot + fposmod(T(2) * post_diff, T(TAU)) - post_diff;
+
+	return cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
+}
+
+template <std::floating_point T>
+constexpr T cubic_interpolate_in_time(T p_from, T p_to, T p_pre, T p_post, T p_weight, T p_to_t, T p_pre_t, T p_post_t) noexcept {
+	/* Barry-Goldman method */
+	T t = lerp(T(0), p_to_t, p_weight);
+
+	// At least try to make this easier to parse for others.
+	T pre_scale = (p_pre_t == T(0)) ? T(0.0) : (t - p_pre_t) / -p_pre_t;
+	T to_scale = (p_to_t == T(0)) ? T(0.5) : t / p_to_t;
+	T post_range = p_post_t - p_to_t;
+	T post_scale = (post_range == T(0)) ? T(1) : (t - p_to_t) / post_range;
+
+	// First layer.
+	T a1 = lerp(p_pre, p_from, pre_scale);
+	T a2 = lerp(p_from, p_to, to_scale);
+	T a3 = lerp(p_to, p_post, post_scale);
+
+	// More parsing.
+	T mid_range = p_to_t - p_pre_t;
+	T from_to_scale = (mid_range == T(0)) ? T(0) : (t - p_pre_t) / mid_range;
+	T to_post_scale = (p_post_t == T(0)) ? T(1.0) : t / p_post_t;
+
+	// Second layer.
+	T b1 = lerp(a1, a2, from_to_scale);
+	T b2 = lerp(a2, a3, to_post_scale);
+
+	// One more for the road.
+	T final_range = p_to_t == T(0);
+	T final_scale = final_range ? T(0.5) : t / p_to_t;
+
+	return lerp(b1, b2, final_scale);
+}
+
+template <std::floating_point T>
+constexpr T cubic_interpolate_angle_in_time(T p_from, T p_to, T p_pre, T p_post, T p_weight, T p_to_t, T p_pre_t, T p_post_t) noexcept {
+	T from_rot = fposmod(p_from, T(TAU));
+
+	T pre_diff = fposmod(p_pre - from_rot, T(TAU));
+	T pre_rot = from_rot + fposmod(T(2.0) * pre_diff, T(TAU)) - pre_diff;
+
+	T to_diff = fposmod(p_to - from_rot, T(TAU));
+	T to_rot = from_rot + fposmod(T(2.0) * to_diff, T(TAU)) - to_diff;
+
+	T post_diff = fposmod(p_post - to_rot, T(TAU));
+	T post_rot = to_rot + fposmod(T(2.0) * post_diff, T(TAU)) - post_diff;
+
+	return cubic_interpolate_in_time(from_rot, to_rot, pre_rot, post_rot, p_weight, p_to_t, p_pre_t, p_post_t);
+}
+
+template <std::floating_point T>
+constexpr T bezier_interpolate(T p_start, T p_control_1, T p_control_2, T p_end, T p_t) noexcept {
+	/* Formula from Wikipedia article on Bezier curves. */
+	// one minus t.
+	T omt = T((1) - p_t);
+	T omt2 = omt * omt;
+	T omt3 = omt2 * omt;
+	T t2 = p_t * p_t;
+	T t3 = t2 * p_t;
+
+	// B(t) = (1-t)^3 * P_0 + 3(1 - t)^2 * t * P_1 + 3(1 - t) * t^2 * P_2 + t^3 * P_3
+	T d = p_start * omt3 + p_control_1 * omt2 * p_t * T(3) + p_control_2 * omt * t2 * T(3) + p_end * t3;
+	return d;
+}
+
+template <std::floating_point T>
+constexpr T bezier_derivative(T p_start, T p_control_1, T p_control_2, T p_end, T p_t) noexcept {
+	/* Formula from Wikipedia article on Bezier curves. */
+	T omt = (T(1) - p_t);
+	T omt2 = omt * omt;
+	T t2 = p_t * p_t;
+
+	T d = (p_control_1 - p_start) * T(3) * omt2 + (p_control_2 - p_control_1) * T(6) * omt * p_t + (p_end - p_control_2) * T(3) * t2;
+	return d;
+}
+
+template <std::floating_point T>
+constexpr T angle_difference(T p_from, T p_to) noexcept {
+	T diff = fmod(p_to - p_from, T(TAU));
+	return std::fmod(T(2) * diff, T(TAU)) - diff;
+}
+
+template <std::floating_point T>
+constexpr T lerp_angle(T p_from, T p_to, T p_weight) noexcept {
+	return p_from + angle_difference(p_from, p_to) * p_weight;
+}
+
+template <std::floating_point T>
+constexpr T inverse_lerp(T p_from, T p_to, T p_value) noexcept {
+	// Could divide by zero here..?
+	return (p_value - p_from) / (p_to - p_from);
+}
+
+template <std::floating_point T>
+constexpr T remap(T p_value, T p_istart, T p_istop, T p_ostart, T p_ostop) noexcept {
+	return lerp(p_ostart, p_ostop, inverse_lerp(p_istart, p_istop, p_value));
+}
+
+template <arithmetic T>
+constexpr bool is_equal_approx(T p_left, T p_right, T p_tolerance) noexcept {
+	// Check for exact equality first, required to handle "infinity" values.
+	if (p_left == p_right) {
+		return true;
+	}
+	// Then check for approximate equality.
+	return abs(p_left - p_right) <= p_tolerance;
+}
+
+template <std::floating_point T>
+constexpr bool is_equal_approx(T p_left, T p_right) noexcept {
+	// Check for exact equality first, required to handle "infinity" values.
+	if (p_left == p_right) {
+		return true;
+	}
+
+	// Compute tolerance by magnitude.
+	const T tolerance = (T(CMP_EPSILON) * abs(p_left) < T(CMP_EPSILON)) ? T(CMP_EPSILON) : T(CMP_EPSILON) * abs(p_left);
+
+	return abs(p_left - p_right) <= tolerance;
+}
+
+template <std::floating_point T, std::convertible_to<T> C>
+constexpr bool is_equal_approx(T p_left, C p_right) noexcept {
+	return is_equal_approx(p_left, static_cast<T>(p_right));
+}
+
+template <std::floating_point T, std::convertible_to<T> C>
+constexpr bool is_equal_approx(C p_left, T p_right) noexcept {
+	return is_equal_approx(static_cast<T>(p_left), p_right);
+}
+
+template <std::integral T1, std::integral T2>
+constexpr bool is_equal_approx(T1 p_left, T2 p_right) noexcept {
+	return p_left == p_right;
+}
+
+template <std::floating_point T>
+constexpr bool is_zero_approx(T p_value) noexcept {
+	return abs(p_value) < T(CMP_EPSILON);
+}
+
+template <std::integral T>
+constexpr bool is_zero_approx(T p_value) noexcept {
+	return p_value == T{ 0 };
+}
+
+template <std::floating_point T>
+constexpr bool is_same(T p_left, T p_right) noexcept {
+	return (p_left == p_right) || (is_nan(p_left) && is_nan(p_right));
+}
+
+template <std::floating_point T>
+constexpr T smoothstep(T p_from, T p_to, T p_s) noexcept {
+	if (is_equal_approx(p_from, p_to)) {
+		// Degenerate case AKA 3small5u.
+		return (p_s <= p_from) ? T(0) : T(1);
+	}
+
+	// note: CLAMP defined at core/typedefs.h
+	T s = CLAMP((p_s - p_from) / (p_to - p_from), T(0), T(1));
+
+	// Hermite interpolation: (3s^2 - 2s^3)
+	return s * s * (T(3) - T(2) * s);
+}
+
+template <std::floating_point T>
+constexpr T faststep(T p_from, T p_to, T p_s) noexcept {
+	if (p_from == p_to) {
+		// degenerate case.
+		return (p_s <= p_from) ? T(0) : T(1);
+	}
+
+	// clamp to [0,1]
+	T s = CLAMP((p_s - p_from) / (p_to - p_from), T(0), T(1));
+
+	// less smooth Hermite-like interpolation: (1.5s^2 - 0.5s^3)
+	return s * s * (T(1.5) - T(0.5) * s);
+}
+
+template <std::floating_point T>
+constexpr T move_toward(T p_from, T p_to, T p_delta) noexcept {
+	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
+}
+
+template <std::floating_point T>
+constexpr T rotate_toward(T p_from, T p_to, T p_delta) noexcept {
+	T diff = angle_difference(p_from, p_to);
+	T abs_diff = abs(diff);
+	T clamped = clamp(p_delta, abs_diff - T(PI), abs_diff);
+
+	return p_from + clamped * std::copysign(T(1), diff);
+	;
+}
+
+template <std::floating_point T>
+constexpr T linear_to_db(T p_linear) noexcept {
+	// Converting linear gain to decibals.
+	return log(p_linear) * T(DB_CONVERSION_GAIN);
+}
+
+template <std::floating_point T>
+constexpr T db_to_linear(T p_db) noexcept {
+	// Converting decibals to linear gain.
+	return exp(p_db * T(GAIN_CONVERSION_DB));
+}
+
+template <std::floating_point T>
+constexpr T round(T p_val) noexcept {
+	return p_val >= T{ 0 } ? static_cast<T>(static_cast<long long>(p_val + T{ .5f })) : static_cast<T>(static_cast<long long>(p_val - T{ .5f }));
+}
+
+template <std::floating_point T>
+constexpr T wrapf(T p_value, T p_min, T p_max) noexcept {
+	T range = p_max - p_min;
+
+	if (is_zero_approx(range)) {
+		return p_min;
+	}
+
+	T offset = p_value - p_min;
+	T result = offset - range * floor(offset / range);
+	// This is cheaper due to floor blocking.
+	result += p_min;
+
+	if (is_equal_approx(result, p_max)) {
+		return p_min;
+	}
+
+	return result;
+}
+
+template <std::integral T>
+constexpr T wrapi(T p_value, T p_min, T p_max) noexcept {
+	T range = p_max - p_min;
+
+	if (range == 0) {
+		return p_min;
+	}
+
+	return p_min + ((((p_value - p_min) % range) + range) % range);
+}
+
+template <std::floating_point T>
+constexpr T fract(T p_value) noexcept {
+	return p_value - floor(p_value);
+}
+
+template <std::floating_point T>
+constexpr T pingpong(T p_value, T p_length) noexcept {
+	if (p_length == T(0)) {
+		return 0;
+	}
+
+	// Calls twice, may as well.
+	const T double_len = p_length * T(2);
+	// for readability:
+	const T fr = fract((p_value - p_length) / double_len);
+
+	return abs(fr * double_len - p_length);
+}
+
+// double only, as these functions are mainly used by the editor and not performance-critical,
+double ease(double p_x, double p_c) noexcept;
+int step_decimals(double p_step) noexcept;
+int range_step_decimals(double p_step) noexcept; // For editor use only.
+double snapped(double p_value, double p_step) noexcept;
+
+uint32_t larger_prime(uint32_t p_val) noexcept;
+
+void seed(uint64_t p_seed) noexcept;
+void randomize() noexcept;
+uint32_t rand_from_seed(uint64_t *p_seed) noexcept;
+uint32_t rand() noexcept;
+
+_FORCE_INLINE_ double randd() noexcept {
+	return static_cast<double>(Math::rand()) * UINT32_MAX_D;
+}
+_FORCE_INLINE_ float randf() noexcept {
+	return static_cast<float>(Math::rand()) * UINT32_MAX_F;
+}
+double randfn(double p_mean, double p_deviation) noexcept;
+
+// TODO: Template + make this better (later.)
+double random(double p_from, double p_to) noexcept;
+float random(float p_from, float p_to) noexcept;
+int random(int p_from, int p_to) noexcept;
+
+// This function should be as fast as possible and rounding mode should not matter.
+constexpr int fast_ftoi(float p_value) noexcept {
+	return static_cast<int>(p_value);
+}
+
+/*
+ * Convert raw 16bit half-precision floating point pattern to 32-bit
+ * single-precision pattern.
+ *
+ * @param p_half - The 16-bit FP.
+ *
+ * @return - corresponding 32-bit FP.
+ */
+constexpr uint32_t halfbits_to_floatbits(uint16_t p_half) noexcept {
+	// TODO: We should just have one spot for these masks...
+	// FP16 bit masks
+	// Bit #15 (sign)
+	constexpr uint16_t FP16_SIGN_MASK = 0x8000u;
+	// Bits #10 to #14 (exponent)
+	constexpr uint16_t FP16_EXP_MASK = 0x7C00u;
+	// Bits #0 - #9 (fraction)
+	constexpr uint16_t FP16_FRAC_MASK = 0x03FFu;
+	constexpr uint16_t FP16_EXP_SHIFT = 10;
+	// Bit #10 (Normalized number)
+	constexpr uint16_t FP16_IMPLICIT_ONE = 0x0400u;
+	// Stored exponent bias goes here:
+	constexpr uint16_t FP16_EXP_BIAS = 15;
+
+	// FP32 masks
+	// Bit #31 (sign)
+	//constexpr uint32_t FP32_SIGN_MASK = 0x80000000u;
+	// Bit #23 - #30 (exponent)
+	constexpr uint32_t FP32_EXP_MASK = 0x7F800000u;
+	// Stored expontent bias for FP32
+	constexpr int FP32_EXP_BIAS = 127;
+
+	// Bias diff for FP16 - FP32.
+	constexpr int FP_EXP_BIAS_DIFF = FP32_EXP_BIAS - FP16_EXP_BIAS;
+
+	// extract sign, exponent, fraction:
+	uint32_t sign = static_cast<uint32_t>(p_half & FP16_SIGN_MASK) << 16;
+	uint32_t exponent16 = p_half & FP16_EXP_MASK;
+	uint32_t fraction16 = p_half & FP16_FRAC_MASK;
+
+	// zero || subnormal
+	if (exponent16 == 0) {
+		if (fraction16 == 0) {
+			// Signed zero: Only returns the sign.
+			return sign;
 		}
+
+		int shift = 0;
+
+		// normalize fraction:
+		while ((fraction16 & FP16_IMPLICIT_ONE) == 0) {
+			fraction16 <<= 1;
+			shift++;
+		}
+
+		// update (remove) implicit leading one
+		fraction16 &= FP16_FRAC_MASK;
+
+		// Adjust for float:
+		// Align to exponent:
+		uint32_t exponent32 = (FP_EXP_BIAS_DIFF - shift + 1) << 23;
+		// align fraction bits to float format:
+		uint32_t fraction32 = fraction16 << 13;
+		return sign | exponent32 | fraction32;
+	}
+
+	// infinity/NaN
+	if (exponent16 == FP16_EXP_MASK) {
+		// Map exponent directly, preserve NaN:
+		return sign | FP32_EXP_MASK | (fraction16 << 13);
+	}
+
+	// Normalize - Remember what bits 23 and 13 are? :^)
+	uint32_t exponent32 = ((exponent16 >> FP16_EXP_SHIFT) + FP_EXP_BIAS_DIFF) << 23;
+	uint32_t fraction32 = fraction16 << 13;
+
+	return sign | exponent32 | fraction32;
+}
+
+constexpr float halfptr_to_float(const uint16_t *p_half) noexcept {
+	uint32_t bits32 = halfbits_to_floatbits(*p_half);
+	return std::bit_cast<float>(bits32);
+}
+
+constexpr float half_to_float(const uint16_t p_half) noexcept {
+	uint32_t bits32 = halfbits_to_floatbits(p_half);
+	return std::bit_cast<float>(bits32);
+}
+
+constexpr uint16_t make_half_float(float p_value) noexcept {
+	// FP32 bits
+	// Bit #31
+	constexpr uint32_t FP32_SIGN_MASK = 0x80000000u;
+	// Bits #23 - #30
+	constexpr uint32_t FP32_EXP_MASK = 0x7F800000u;
+	// Bits #0 - #22
+	constexpr uint32_t FP32_FRAC_MASK = 0x007FFFFFu;
+	// FP32 exponent bias
+	constexpr int FP32_EXP_BIAS = 127;
+
+	// FP16 bits
+	// Bits #10 - #14
+	constexpr uint16_t FP16_EXP_MASK = 0x7C00u;
+	// Bits #0 - #9
+	//constexpr uint16_t FP16_FRAC_MASK = 0x03FFu; // unused?
+	// stored exponent bias
+	constexpr int FP16_EXP_BIAS = 15;
+
+	// Bias diff FP16-FP32
+	constexpr int FP_EXP_BIAS_DIFF = FP32_EXP_BIAS - FP16_EXP_BIAS;
+
+	// change given bits to uint32_t.
+	uint32_t bits32 = std::bit_cast<uint32_t>(p_value);
+
+	// Extract sign, exponent, fraction
+	uint32_t sign32 = bits32 & FP32_SIGN_MASK;
+	uint32_t exponent32 = bits32 & FP32_EXP_MASK;
+	uint32_t fraction32 = bits32 & FP32_FRAC_MASK;
+
+	uint16_t bits16;
+
+	if (exponent32 <= ((FP32_EXP_BIAS - FP16_EXP_BIAS) << 23)) {
+		// Zero
+		bits16 = static_cast<uint16_t>(sign32 >> 16);
+	} else if (exponent32 == FP32_EXP_MASK) {
+		// Infinity or NaN
+		uint32_t frac = fraction32 ? (fraction32 >> 13) : 0;
+		bits16 = static_cast<uint16_t>((sign32 >> 16) | FP16_EXP_MASK | frac);
+	} else {
+		// normalize
+		uint32_t half_exponent = ((exponent32 >> 23) - FP_EXP_BIAS_DIFF) << 10;
+		uint32_t half_fraction = fraction32 >> 13;
+		bits16 = static_cast<uint16_t>((sign32 >> 16) | half_exponent | half_fraction);
+	}
+
+	return bits16;
+}
+
+template <std::floating_point T>
+constexpr T snap_scalar(T p_offset, T p_step, T p_target) noexcept {
+	return p_step != T(0.0) ? snapped(p_target - p_offset, p_step) + p_offset : p_target;
+}
+
+template <std::floating_point T>
+constexpr T snap_scalar_separation(T p_offset, T p_step, T p_target, T p_separation) noexcept {
+	if (p_step == T(0)) {
+		// No snapping.
+		return p_target;
+	} else {
+		T a = snapped(p_target - p_offset, p_step + p_separation) + p_offset;
+		T b = (p_target >= T(0)) ? a - p_separation : a + p_step;
 		return (abs(p_target - a) < abs(p_target - b)) ? a : b;
 	}
-	return p_target;
 }
 
-static _ALWAYS_INLINE_ double sigmoid_affine(double p_x, double p_amplitude, double p_y_translation) {
-	return p_amplitude / (1.0 + ::exp(-p_x)) + p_y_translation;
-}
-static _ALWAYS_INLINE_ float sigmoid_affine(float p_x, float p_amplitude, float p_y_translation) {
-	return p_amplitude / (1.0f + expf(-p_x)) + p_y_translation;
+template <std::floating_point T>
+constexpr T sigmoid_affine(T p_x, T p_amplitude, T p_y_translation) noexcept {
+	return p_amplitude / (T(1.0) + exp(-p_x)) + p_y_translation;
 }
 
-static _ALWAYS_INLINE_ double sigmoid_affine_approx(double p_x, double p_amplitude, double p_y_translation) {
-	return p_amplitude * (0.5 + p_x / (4.0 + fabs(p_x))) + p_y_translation;
-}
-static _ALWAYS_INLINE_ float sigmoid_affine_approx(float p_x, float p_amplitude, float p_y_translation) {
-	return p_amplitude * (0.5f + p_x / (4.0f + fabsf(p_x))) + p_y_translation;
+template <std::floating_point T>
+constexpr T sigmoid_affine_approx(T p_x, T p_amplitude, T p_y_translation) noexcept {
+	return p_amplitude * (T(0.5) + p_x / (T(4.0) + fabs(p_x))) + p_y_translation;
 }
 
-// TODO once upgrade to >= C++20 add floating_point constraint to these templates
-template <typename T>
+template <std::floating_point T>
 constexpr T monotonic_cubic_interpolate(T p_from, T p_to, T p_pre, T p_post, T p_weight) {
 	const T d0 = p_from - p_pre;
 	const T d1 = p_to - p_from;
@@ -923,7 +910,7 @@ constexpr T monotonic_cubic_interpolate(T p_from, T p_to, T p_pre, T p_post, T p
 			h11 * m2);
 }
 
-template <typename T>
+template <std::floating_point T>
 constexpr T monotonic_cubic_interpolate_in_time(T p_from, T p_to, T p_pre, T p_post, T p_weight, T p_to_t, T p_pre_t, T p_post_t) {
 	if (is_zero_approx(p_to_t)) {
 		return (p_from + p_to) * (T)0.5;
@@ -976,7 +963,7 @@ constexpr T monotonic_cubic_interpolate_in_time(T p_from, T p_to, T p_pre, T p_p
 			h11 * h1 * m2;
 }
 
-template <typename T>
+template <std::floating_point T>
 constexpr T monotonic_cubic_interpolate_angle(T p_from, T p_to, T p_pre, T p_post, T p_weight) {
 	T from_rot = fmod(p_from, (T)TAU);
 
@@ -992,7 +979,7 @@ constexpr T monotonic_cubic_interpolate_angle(T p_from, T p_to, T p_pre, T p_pos
 	return monotonic_cubic_interpolate(from_rot, to_rot, pre_rot, post_rot, p_weight);
 }
 
-template <typename T>
+template <std::floating_point T>
 constexpr T monotonic_cubic_interpolate_angle_in_time(T p_from, T p_to, T p_pre, T p_post, T p_weight, T p_to_t, T p_pre_t, T p_post_t) {
 	T from_rot = fmod(p_from, (T)TAU);
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -40,7 +40,8 @@
 #include <bit>
 #include <cfloat>
 #include <cmath>
-#include <concepts> // std::floating_point
+#include <concepts>
+#include <limits>
 
 namespace Math {
 
@@ -146,13 +147,20 @@ _ALWAYS_INLINE_ T asinh(T x) noexcept {
 
 template <std::floating_point T>
 _ALWAYS_INLINE_ T acosh(T x) noexcept {
-	x = clamp(x, T(1), std::numeric_limits<T>::infinity());
+	if (x <= T{ 1.f }) {
+		return T{ 0.f };
+	}
 	return std::acosh(x);
 }
 
 template <std::floating_point T>
 _ALWAYS_INLINE_ T atanh(T x) noexcept {
-	x = clamp(x, T(-1) + CMP_EPSILON, T(1) - CMP_EPSILON);
+	if (x < T{ -1.f + CMP_EPSILON }) {
+		return -std::numeric_limits<T>::infinity();
+	}
+	if (x > T{ 1.f - CMP_EPSILON }) {
+		return std::numeric_limits<T>::infinity();
+	}
 	return std::atanh(x);
 }
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -32,6 +32,12 @@
 
 #pragma once
 
+/**
+ * @file math_funcs.h
+ *
+ * [Add any documentation that applies to the entire file here!]
+ */
+
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
 #include "core/typedefs.h"

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -51,7 +51,7 @@
 
 namespace Math {
 
-template <typename T>
+template <std::floating_point T>
 _ALWAYS_INLINE_ T sin(T p_x) {
 	return std::sin(p_x);
 }
@@ -400,7 +400,7 @@ constexpr T cubic_interpolate(T p_from, T p_to, T p_pre, T p_post, T p_weight) n
 
 	if (std::is_constant_evaluated()) {
 		// compile time
-		return T(0.5) * (T(2) * p_from) + (a * p_weight) + (b * w2) + (c * w3);
+		return T{ .5 } * ((T{ 2.f } * p_from) + (a * p_weight) + (b * w2) + (c * w3));
 	} else {
 		// runtime
 		return T(0.5) * std::fma(c, w3, std::fma(b, w2, std::fma(a, p_weight, T(2) * p_from)));

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -856,7 +856,7 @@ bool Projection::is_orthogonal() const {
 
 real_t Projection::get_fov() const {
 	if (columns[2][0] == 0) {
-		return Math::rad_to_deg(2 * Math::atan2(1, columns[0][0]));
+		return Math::rad_to_deg(2 * std::atan2(1, columns[0][0]));
 	} else {
 		// The frustum is asymmetrical so we need to calculate the left and right angles separately.
 		real_t right = Math::atan2(columns[2][0] + 1, columns[0][0]);

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -79,7 +79,7 @@ Quaternion Quaternion::normalized() const {
 }
 
 bool Quaternion::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); //use less epsilon
+	return Math::is_equal_approx(length_squared(), 1); //use less epsilon
 }
 
 Quaternion Quaternion::inverse() const {

--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -292,7 +292,7 @@ TransformInterpolator::Method TransformInterpolator::_test_basis(Basis p_basis, 
 	// Apply less stringent tests than the built in slerp, the standard Redot slerp
 	// is too susceptible to float error to be useful.
 	real_t det = p_basis.determinant();
-	if (!Math::is_equal_approx(det, 1)) {
+	if (!Math::is_equal_approx(det, static_cast<real_t>(1.f), static_cast<real_t>(.01f))) {
 		return INTERP_LERP;
 	}
 

--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -292,7 +292,7 @@ TransformInterpolator::Method TransformInterpolator::_test_basis(Basis p_basis, 
 	// Apply less stringent tests than the built in slerp, the standard Redot slerp
 	// is too susceptible to float error to be useful.
 	real_t det = p_basis.determinant();
-	if (!Math::is_equal_approx(det, 1, (real_t)0.01f)) {
+	if (!Math::is_equal_approx(det, 1)) {
 		return INTERP_LERP;
 	}
 

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -76,7 +76,7 @@ Vector2 Vector2::normalized() const {
 
 bool Vector2::is_normalized() const {
 	// use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON);
+	return Math::is_equal_approx(length_squared(), 1);
 }
 
 real_t Vector2::distance_to(const Vector2 &p_vector2) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -554,7 +554,7 @@ Vector3 Vector3::normalized() const {
 
 bool Vector3::is_normalized() const {
 	// use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON);
+	return Math::is_equal_approx(length_squared(), 1);
 }
 
 Vector3 Vector3::inverse() const {

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -87,16 +87,16 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 	{ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
 };
 
-#define UNIX_TIME_TO_HMS                                                     \
-	uint8_t hour, minute, second;                                            \
-	{                                                                        \
-		/* The time of the day (in seconds since start of day). */           \
-		uint32_t day_clock = Math::posmod(p_unix_time_val, SECONDS_PER_DAY); \
-		/* On x86 these 4 lines can be optimized to only 2 divisions. */     \
-		second = day_clock % 60;                                             \
-		day_clock /= 60;                                                     \
-		minute = day_clock % 60;                                             \
-		hour = day_clock / 60;                                               \
+#define UNIX_TIME_TO_HMS                                                                                                 \
+	uint8_t hour, minute, second;                                                                                        \
+	{                                                                                                                    \
+		/* The time of the day (in seconds since start of day). */                                                       \
+		uint32_t day_clock = Math::posmod(static_cast<int64_t>(p_unix_time_val), static_cast<int64_t>(SECONDS_PER_DAY)); \
+		/* On x86 these 4 lines can be optimized to only 2 divisions. */                                                 \
+		second = day_clock % 60;                                                                                         \
+		day_clock /= 60;                                                                                                 \
+		minute = day_clock % 60;                                                                                         \
+		hour = day_clock / 60;                                                                                           \
 	}
 
 #define UNIX_TIME_TO_YMD                                                                    \
@@ -222,7 +222,7 @@ Dictionary Time::get_datetime_dict_from_unix_time(int64_t p_unix_time_val) const
 	datetime[MONTH_KEY] = (uint8_t)month;
 	datetime[DAY_KEY] = day;
 	// Unix epoch was a Thursday (day 0 aka 1970-01-01).
-	datetime[WEEKDAY_KEY] = Math::posmod(day_number + WEEKDAY_THURSDAY, 7);
+	datetime[WEEKDAY_KEY] = Math::posmod(static_cast<int32_t>(day_number + WEEKDAY_THURSDAY), 7);
 	datetime[HOUR_KEY] = hour;
 	datetime[MINUTE_KEY] = minute;
 	datetime[SECOND_KEY] = second;
@@ -237,7 +237,7 @@ Dictionary Time::get_date_dict_from_unix_time(int64_t p_unix_time_val) const {
 	datetime[MONTH_KEY] = (uint8_t)month;
 	datetime[DAY_KEY] = day;
 	// Unix epoch was a Thursday (day 0 aka 1970-01-01).
-	datetime[WEEKDAY_KEY] = Math::posmod(day_number + WEEKDAY_THURSDAY, 7);
+	datetime[WEEKDAY_KEY] = Math::posmod(static_cast<int32_t>(day_number + WEEKDAY_THURSDAY), 7);
 
 	return datetime;
 }
@@ -279,7 +279,7 @@ Dictionary Time::get_datetime_dict_from_datetime_string(const String &p_datetime
 	if (p_weekday) {
 		YMD_TO_DAY_NUMBER
 		// Unix epoch was a Thursday (day 0 aka 1970-01-01).
-		dict[WEEKDAY_KEY] = Math::posmod(day_number + WEEKDAY_THURSDAY, 7);
+		dict[WEEKDAY_KEY] = Math::posmod(static_cast<int32_t>(day_number + WEEKDAY_THURSDAY), 7);
 	}
 	dict[HOUR_KEY] = hour;
 	dict[MINUTE_KEY] = minute;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -129,29 +129,40 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #undef CLAMP
 
 template <typename T>
-constexpr const T SIGN(const T m_v) {
+constexpr const T SIGN(const T m_v) noexcept {
 	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
 }
 
 template <typename T, typename T2>
-constexpr auto MIN(const T m_a, const T2 m_b) {
+constexpr auto MIN(const T m_a, const T2 m_b) noexcept {
 	return m_a < m_b ? m_a : m_b;
 }
 
+template <typename T, typename T2, typename T3>
+constexpr auto MIN(const T m_a, const T2 m_b, const T3 m_c) noexcept {
+	return MIN(m_a < m_b ? m_a : m_b, m_c);
+}
+
 template <typename T, typename T2>
-constexpr auto MAX(const T m_a, const T2 m_b) {
+constexpr auto MAX(const T m_a, const T2 m_b) noexcept {
 	return m_a > m_b ? m_a : m_b;
 }
 
 template <typename T, typename T2, typename T3>
-constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
+constexpr auto MAX(const T m_a, const T2 m_b, const T3 m_c) noexcept {
+	return MAX(m_a > m_b ? m_a : m_b, m_c);
+}
+
+template <typename T, typename T2, typename T3>
+constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) noexcept {
 	return m_a < m_min ? m_min : (m_a > m_max ? m_max : m_a);
 }
 
 // Generic swap template.
-#ifndef SWAP
-#define SWAP(m_x, m_y) std::swap((m_x), (m_y))
-#endif // SWAP
+template <typename T>
+constexpr void SWAP(T &m_x, T &m_y) noexcept {
+	std::swap(m_x, m_y);
+}
 
 /* Functions to handle powers of 2 and shifting. */
 
@@ -388,6 +399,17 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 
+/// Integral concepts
+template <typename T>
+concept unsigned_integral = std::integral<T> && std::is_unsigned_v<T>;
+
+template <typename T>
+concept signed_integral = std::integral<T> && std::is_signed_v<T>;
+
+/// Arithmetic type
+template <typename T>
+concept arithmetic = std::is_arithmetic_v<T>;
+
 /// Whether the default value of a type is just all-0 bytes.
 /// This can most commonly be exploited by using memset for these types instead of loop-construct.
 /// Trivially constructible types are also zero-constructible.
@@ -405,6 +427,13 @@ struct is_zero_constructible<const volatile T> : is_zero_constructible<T> {};
 
 template <typename T>
 inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
+
+template <typename T>
+concept zero_constructible = is_zero_constructible_v<T>;
+
+/// Trivial type (i.e., all characteristics of a POD type)
+template <typename T>
+concept trivial = std::is_trivial_v<T>;
 
 // Warning suppression helper macros.
 #if defined(__clang__)

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -401,10 +401,10 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 
 /// Integral concepts
 template <typename T>
-concept unsigned_integral = std::integral<T> && std::is_unsigned_v<T>;
+concept unsigned_integral = std::is_integral_v<T> && std::is_unsigned_v<T>;
 
 template <typename T>
-concept signed_integral = std::integral<T> && std::is_signed_v<T>;
+concept signed_integral = std::is_integral_v<T> && std::is_signed_v<T>;
 
 /// Arithmetic type
 template <typename T>

--- a/drivers/apple_embedded/tts_apple_embedded.mm
+++ b/drivers/apple_embedded/tts_apple_embedded.mm
@@ -80,12 +80,12 @@
 		AVSpeechUtterance *new_utterance = [[AVSpeechUtterance alloc] initWithString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
 		[new_utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:[NSString stringWithUTF8String:message.voice.utf8().get_data()]]];
 		if (message.rate > 1.f) {
-			[new_utterance setRate:Math::remap(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
+			[new_utterance setRate:Math::remap<real_t>(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
 		} else if (message.rate < 1.f) {
-			[new_utterance setRate:Math::remap(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
+			[new_utterance setRate:Math::remap<real_t>(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
 		}
 		[new_utterance setPitchMultiplier:message.pitch];
-		[new_utterance setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
+		[new_utterance setVolume:(Math::remap<real_t>(message.volume, 0.f, 100.f, 0.f, 1.f))];
 
 		ids[new_utterance] = message.id;
 		[av_synth speakUtterance:new_utterance];

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -155,10 +155,10 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 
 	for (int i = 0; i < color_samples.size() - 1; i++) {
 		Vector<Vector2> points = {
-			Vector2(Math::lerp(x_from, x_to, float(i) / (color_samples.size() - 1)), y_from),
-			Vector2(Math::lerp(x_from, x_to, float(i + 1) / (color_samples.size() - 1)), y_from),
-			Vector2(Math::lerp(x_from, x_to, float(i + 1) / (color_samples.size() - 1)), y_from + fh),
-			Vector2(Math::lerp(x_from, x_to, float(i) / (color_samples.size() - 1)), y_from + fh)
+			Vector2(Math::lerp<float>(x_from, x_to, float(i) / (color_samples.size() - 1)), y_from),
+			Vector2(Math::lerp<float>(x_from, x_to, float(i + 1) / (color_samples.size() - 1)), y_from),
+			Vector2(Math::lerp<float>(x_from, x_to, float(i + 1) / (color_samples.size() - 1)), y_from + fh),
+			Vector2(Math::lerp<float>(x_from, x_to, float(i) / (color_samples.size() - 1)), y_from + fh)
 		};
 
 		Vector<Color> colors = {

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -393,7 +393,7 @@ float EditorAudioBus::_normalized_volume_to_scaled_db(float normalized) {
 	} else if (normalized < 0.05f) {
 		return 830.72 * normalized - 80.0f;
 	} else {
-		return 45.0f * Math::pow(normalized - 1.0, 3);
+		return 45.0f * Math::pow(normalized - 1.f, 3.f);
 	}
 }
 

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -293,7 +293,7 @@ void EditorToaster::_draw_button() {
 void EditorToaster::_draw_progress(Control *panel) {
 	if (toasts.has(panel) && toasts[panel].remaining_time > 0 && toasts[panel].duration > 0) {
 		Size2 size = panel->get_size();
-		size.x *= MIN(1, Math::remap(toasts[panel].remaining_time, 0, toasts[panel].duration, 0, 2));
+		size.x *= MIN(1, Math::remap<real_t>(toasts[panel].remaining_time, 0, toasts[panel].duration, 0, 2));
 
 		Ref<StyleBoxFlat> stylebox;
 		switch (toasts[panel].severity) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -413,13 +413,13 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Impor
 
 			const real_t precision = real_t(precision_level - 1) / 9.0;
 
-			decomposition_settings->set_max_concavity(Math::lerp(real_t(1.0), real_t(0.001), precision));
-			decomposition_settings->set_min_volume_per_convex_hull(Math::lerp(real_t(0.01), real_t(0.0001), precision));
-			decomposition_settings->set_resolution(Math::lerp(10'000, 100'000, precision));
-			decomposition_settings->set_max_num_vertices_per_convex_hull(Math::lerp(32, 64, precision));
-			decomposition_settings->set_plane_downsampling(Math::lerp(3, 16, precision));
-			decomposition_settings->set_convex_hull_downsampling(Math::lerp(3, 16, precision));
-			decomposition_settings->set_max_convex_hulls(Math::lerp(1, 32, precision));
+			decomposition_settings->set_max_concavity(Math::lerp<float>(real_t(1.0), real_t(0.001), precision));
+			decomposition_settings->set_min_volume_per_convex_hull(Math::lerp<float>(real_t(0.01), real_t(0.0001), precision));
+			decomposition_settings->set_resolution(Math::lerp<float>(10'000, 100'000, precision));
+			decomposition_settings->set_max_num_vertices_per_convex_hull(Math::lerp<float>(32, 64, precision));
+			decomposition_settings->set_plane_downsampling(Math::lerp<float>(3, 16, precision));
+			decomposition_settings->set_convex_hull_downsampling(Math::lerp<float>(3, 16, precision));
+			decomposition_settings->set_max_convex_hulls(Math::lerp<float>(1, 32, precision));
 		}
 
 		return p_mesh->convex_decompose(decomposition_settings);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -4130,7 +4130,7 @@ void TileMapLayerEditor::_layers_select_next_or_previous(bool p_next) {
 				break;
 			}
 		}
-		new_selected_layer = tile_map_layers_in_scene_cache[Math::posmod(edited_index + inc, tile_map_layers_in_scene_cache.size())];
+		new_selected_layer = tile_map_layers_in_scene_cache[Math::posmod(static_cast<int64_t>(edited_index + inc), tile_map_layers_in_scene_cache.size())];
 	}
 
 	ERR_FAIL_NULL(new_selected_layer);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -356,7 +356,7 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 
 	const Color axis_color = axis_colors[direction];
 	const double min_alpha = 0.35;
-	const double alpha = focused ? 1.0 : Math::remap((p_axis.z_axis + 1.0) / 2.0, 0, 0.5, min_alpha, 1.0);
+	const double alpha = focused ? 1.0 : Math::remap((p_axis.z_axis + 1.0) / 2.0, 0., 0.5, min_alpha, 1.0);
 	const Color c = focused ? Color(axis_color.lightened(0.75), 1.0) : Color(axis_color, alpha);
 
 	if (positive) {
@@ -2394,7 +2394,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				}
 
 				if (_edit.numeric_next_decimal < 0) {
-					_edit.numeric_input = _edit.numeric_input + value * Math::pow(10.0, _edit.numeric_next_decimal--);
+					_edit.numeric_input = _edit.numeric_input + value * Math::pow<real_t>(10.f, _edit.numeric_next_decimal--);
 				} else {
 					_edit.numeric_input = _edit.numeric_input * 10 + value;
 				}
@@ -3273,7 +3273,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 				text += vformat(
 						TTR("Size: %s (%.1fMP)\n"),
 						viewport_size,
-						viewport->get_size().x * viewport->get_size().y * Math::pow(viewport->get_scaling_3d_scale(), 2) * 0.000001);
+						viewport->get_size().x * viewport->get_size().y * Math::pow(viewport->get_scaling_3d_scale(), 2.f) * 0.000001);
 
 				text += "\n";
 				text += vformat(TTR("Objects: %d\n"), viewport->get_render_info(Viewport::RENDER_INFO_TYPE_VISIBLE, Viewport::RENDER_INFO_OBJECTS_IN_FRAME));
@@ -3325,14 +3325,14 @@ void Node3DEditorViewport::_notification(int p_what) {
 				cpu_time_label->add_theme_color_override(
 						SceneStringName(font_color),
 						frame_time_gradient->get_color_at_offset(
-								Math::remap(cpu_time, 0, 30, 0, 1)));
+								Math::remap<real_t>(cpu_time, 0, 30, 0, 1)));
 
 				gpu_time_label->set_text(vformat(TTR("GPU Time: %s ms"), rtos(gpu_time).pad_decimals(2)));
 				// Middle point is at 15 ms.
 				gpu_time_label->add_theme_color_override(
 						SceneStringName(font_color),
 						frame_time_gradient->get_color_at_offset(
-								Math::remap(gpu_time, 0, 30, 0, 1)));
+								Math::remap<real_t>(gpu_time, 0, 30, 0, 1)));
 
 				const double fps = 1000.0 / gpu_time;
 				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
@@ -3340,7 +3340,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 				fps_label->add_theme_color_override(
 						SceneStringName(font_color),
 						frame_time_gradient->get_color_at_offset(
-								Math::remap(fps, 110, 10, 0, 1)));
+								Math::remap<real_t>(fps, 110, 10, 0, 1)));
 			}
 
 			if (lock_rotation) {
@@ -7938,13 +7938,15 @@ void Node3DEditor::_init_grid() {
 			}
 		}
 
-		real_t division_level = Math::log(Math::abs(camera_distance)) / Math::log((double)primary_grid_steps) + division_level_bias;
+		auto fsteps = static_cast<real_t>(primary_grid_steps);
+
+		real_t division_level = Math::log(Math::abs(camera_distance)) / Math::log(fsteps) + division_level_bias;
 
 		real_t clamped_division_level = CLAMP(division_level, division_level_min, division_level_max);
 		real_t division_level_floored = Math::floor(clamped_division_level);
 		real_t division_level_decimals = clamped_division_level - division_level_floored;
 
-		real_t small_step_size = Math::pow(primary_grid_steps, division_level_floored);
+		real_t small_step_size = Math::pow(fsteps, division_level_floored);
 		real_t large_step_size = small_step_size * primary_grid_steps;
 		real_t center_a = large_step_size * (int)(camera_position[a] / large_step_size);
 		real_t center_b = large_step_size * (int)(camera_position[b] / large_step_size);
@@ -7954,9 +7956,9 @@ void Node3DEditor::_init_grid() {
 		real_t bgn_b = center_b - grid_size * small_step_size;
 		real_t end_b = center_b + grid_size * small_step_size;
 
-		real_t fade_size = Math::pow(primary_grid_steps, division_level - 1.0);
-		real_t min_fade_size = Math::pow(primary_grid_steps, float(division_level_min));
-		real_t max_fade_size = Math::pow(primary_grid_steps, float(division_level_max));
+		real_t fade_size = Math::pow(fsteps, division_level - 1.f);
+		real_t min_fade_size = Math::pow(fsteps, float(division_level_min));
+		real_t max_fade_size = Math::pow(fsteps, float(division_level_max));
 		fade_size = CLAMP(fade_size, min_fade_size, max_fade_size);
 
 		real_t grid_fade_size = (grid_size - primary_grid_steps) * fade_size;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -7956,9 +7956,9 @@ void Node3DEditor::_init_grid() {
 		real_t bgn_b = center_b - grid_size * small_step_size;
 		real_t end_b = center_b + grid_size * small_step_size;
 
-		real_t fade_size = Math::pow(fsteps, division_level - 1.f);
-		real_t min_fade_size = Math::pow(fsteps, float(division_level_min));
-		real_t max_fade_size = Math::pow(fsteps, float(division_level_max));
+		real_t fade_size = Math::pow(fsteps, static_cast<real_t>(division_level - 1.f));
+		real_t min_fade_size = Math::pow(fsteps, static_cast<real_t>(division_level_min));
+		real_t max_fade_size = Math::pow(fsteps, static_cast<real_t>(division_level_max));
 		fade_size = CLAMP(fade_size, min_fade_size, max_fade_size);
 
 		real_t grid_fade_size = (grid_size - primary_grid_steps) * fade_size;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -483,8 +483,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 			}
 		}
 		Point2 grid_output;
-		grid_output.x = Math::snapped(p_target.x - offset.x, grid_step.x * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier))) + offset.x;
-		grid_output.y = Math::snapped(p_target.y - offset.y, grid_step.y * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier))) + offset.y;
+		grid_output.x = Math::snapped(p_target.x - offset.x, grid_step.x * Math::pow(static_cast<real_t>(2.f), static_cast<real_t>(grid_step_multiplier))) + offset.x;
+		grid_output.y = Math::snapped(p_target.y - offset.y, grid_step.y * Math::pow(static_cast<real_t>(2.f), static_cast<real_t>(grid_step_multiplier))) + offset.y;
 		_snap_if_closer_point(p_target, output, snap_target, grid_output, SNAP_TARGET_GRID, 0.0, -1.0);
 	}
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -483,8 +483,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 			}
 		}
 		Point2 grid_output;
-		grid_output.x = Math::snapped(p_target.x - offset.x, grid_step.x * Math::pow(2.0, grid_step_multiplier)) + offset.x;
-		grid_output.y = Math::snapped(p_target.y - offset.y, grid_step.y * Math::pow(2.0, grid_step_multiplier)) + offset.y;
+		grid_output.x = Math::snapped(p_target.x - offset.x, grid_step.x * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier))) + offset.x;
+		grid_output.y = Math::snapped(p_target.y - offset.y, grid_step.y * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier))) + offset.y;
 		_snap_if_closer_point(p_target, output, snap_target, grid_output, SNAP_TARGET_GRID, 0.0, -1.0);
 	}
 
@@ -529,7 +529,7 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 				viewport->queue_redraw();
 			} else if (divide_grid_step_shortcut.is_valid() && divide_grid_step_shortcut->matches_event(p_ev)) {
 				// Divide the grid size
-				Point2 new_grid_step = grid_step * Math::pow(2.0, grid_step_multiplier - 1);
+				Point2 new_grid_step = grid_step * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier - 1));
 				if (new_grid_step.x >= 1.0 && new_grid_step.y >= 1.0) {
 					grid_step_multiplier--;
 				}
@@ -2354,12 +2354,12 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 				dir += Vector2(1, 0);
 			}
 			if (k->is_shift_pressed()) {
-				dir *= grid_step * Math::pow(2.0, grid_step_multiplier);
+				dir *= grid_step * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier));
 			}
 
 			drag_to += dir;
 			if (k->is_shift_pressed()) {
-				drag_to = drag_to.snapped(grid_step * Math::pow(2.0, grid_step_multiplier));
+				drag_to = drag_to.snapped(grid_step * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)));
 			}
 
 			Point2 previous_pos;
@@ -3100,10 +3100,10 @@ void CanvasItemEditor::_draw_rulers() {
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (snap_relative && selection.size() > 0) {
 			ruler_transform.translate_local(_get_encompassing_rect_from_list(selection).position);
-			ruler_transform.scale_basis(grid_step * Math::pow(2.0, grid_step_multiplier));
+			ruler_transform.scale_basis(grid_step * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)));
 		} else {
 			ruler_transform.translate_local(grid_offset);
-			ruler_transform.scale_basis(grid_step * Math::pow(2.0, grid_step_multiplier));
+			ruler_transform.scale_basis(grid_step * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)));
 		}
 		while ((transform * ruler_transform).get_scale().x < 50.0 * ruler_tick_scale || (transform * ruler_transform).get_scale().y < 50.0 * ruler_tick_scale) {
 			ruler_transform.scale_basis(Point2(2, 2));
@@ -3183,8 +3183,8 @@ void CanvasItemEditor::_draw_grid() {
 
 		if (snap_relative && selection.size() > 0) {
 			const Vector2 topleft = _get_encompassing_rect_from_list(selection).position;
-			real_grid_offset.x = std::fmod(topleft.x, grid_step.x * (real_t)Math::pow(2.0, grid_step_multiplier));
-			real_grid_offset.y = std::fmod(topleft.y, grid_step.y * (real_t)Math::pow(2.0, grid_step_multiplier));
+			real_grid_offset.x = std::fmod(topleft.x, grid_step.x * (real_t)Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)));
+			real_grid_offset.y = std::fmod(topleft.y, grid_step.y * (real_t)Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)));
 		} else {
 			real_grid_offset = grid_offset;
 		}
@@ -3202,7 +3202,7 @@ void CanvasItemEditor::_draw_grid() {
 		if (grid_step.x != 0) {
 			for (int i = 0; i < viewport_size.width; i++) {
 				const int cell =
-						Math::fast_ftoi(Math::floor((xform.xform(Vector2(i, 0)).x - real_grid_offset.x) / (grid_step.x * Math::pow(2.0, grid_step_multiplier))));
+						Math::fast_ftoi(Math::floor((xform.xform(Vector2(i, 0)).x - real_grid_offset.x) / (grid_step.x * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)))));
 
 				if (i == 0) {
 					last_cell = cell;
@@ -3225,7 +3225,7 @@ void CanvasItemEditor::_draw_grid() {
 		if (grid_step.y != 0) {
 			for (int i = 0; i < viewport_size.height; i++) {
 				const int cell =
-						Math::fast_ftoi(Math::floor((xform.xform(Vector2(0, i)).y - real_grid_offset.y) / (grid_step.y * Math::pow(2.0, grid_step_multiplier))));
+						Math::fast_ftoi(Math::floor((xform.xform(Vector2(0, i)).y - real_grid_offset.y) / (grid_step.y * Math::pow(2.f, static_cast<real_t>(grid_step_multiplier)))));
 
 				if (i == 0) {
 					last_cell = cell;

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -642,7 +642,7 @@ Variant EditorAutoloadSettings::get_drag_data_fw(const Point2 &p_point, Control 
 
 	for (int i = 0; i < max_size; i++) {
 		Label *label = memnew(Label(autoloads[i]));
-		label->set_self_modulate(Color(1, 1, 1, Math::lerp(1, 0, float(i) / PREVIEW_LIST_MAX_SIZE)));
+		label->set_self_modulate(Color(1, 1, 1, Math::lerp(1.f, 0.f, float(i) / PREVIEW_LIST_MAX_SIZE)));
 		label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
 		preview->add_child(label);

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1101,13 +1101,13 @@ void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
 		for (int j = -GRID_CURSOR_SIZE; j <= GRID_CURSOR_SIZE; j++) {
 			for (int k = -GRID_CURSOR_SIZE; k <= GRID_CURSOR_SIZE; k++) {
 				Vector3 p = axis_n1 * j + axis_n2 * k;
-				float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2);
+				float trans = Math::pow(MAX(0.f, 1.f - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2.f);
 
 				Vector3 pj = axis_n1 * (j + 1) + axis_n2 * k;
-				float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2);
+				float transj = Math::pow(MAX(0.f, 1.f - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2.f);
 
 				Vector3 pk = axis_n1 * j + axis_n2 * (k + 1);
-				float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2);
+				float transk = Math::pow(MAX(0.f, 1.f - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2.f);
 
 				grid_points[i].push_back(p);
 				grid_points[i].push_back(pk);

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -296,7 +296,8 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitF
 	src_image.resize(src_image_len);
 
 	uint8_t *w = src_image.ptrw();
-	f->get_buffer(&w[0], src_image_len);
+	const uint64_t bytes_read = f->get_buffer(&w[0], src_image_len);
+	ERR_FAIL_COND_V(bytes_read != src_image_len, ERR_FILE_CANT_READ);
 	const std::span buffer{ w, src_image_len };
 
 	return load_image_from_buffer(p_image, buffer, p_flags, p_scale);

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -42,15 +42,9 @@
 
 #include "thirdparty/tinyexr/tinyexr.h"
 
-Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
-	Vector<uint8_t> src_image;
-	uint64_t src_image_len = f->get_length();
-	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
-	src_image.resize(src_image_len);
-
-	uint8_t *w = src_image.ptrw();
-
-	f->get_buffer(&w[0], src_image_len);
+Error ImageLoaderTinyEXR::load_image_from_buffer(Ref<Image> p_image, std::span<const unsigned char> buffer, BitField<LoaderFlags> p_flags, float) {
+	const uint8_t *w = buffer.data();
+	uint64_t src_image_len = buffer.size();
 
 	// Re-implementation of tinyexr's LoadEXRFromMemory using Godot types to store the Image data
 	// and Godot's error codes.
@@ -293,6 +287,19 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitF
 	FreeEXRImage(&exr_image);
 
 	return OK;
+}
+
+Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<LoaderFlags> p_flags, float p_scale) {
+	Vector<uint8_t> src_image;
+	uint64_t src_image_len = f->get_length();
+	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
+	src_image.resize(src_image_len);
+
+	uint8_t *w = src_image.ptrw();
+	f->get_buffer(&w[0], src_image_len);
+	const std::span buffer{ w, src_image_len };
+
+	return load_image_from_buffer(p_image, buffer, p_flags, p_scale);
 }
 
 void ImageLoaderTinyEXR::get_recognized_extensions(List<String> *p_extensions) const {

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -39,10 +39,12 @@
  */
 
 #include "core/io/image_loader.h"
+#include <span>
 
 class ImageLoaderTinyEXR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	Error load_image_from_buffer(Ref<Image> p_image, std::span<const unsigned char> buffer, BitField<LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.f);
 	ImageLoaderTinyEXR();
 };

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -128,12 +128,12 @@
 			AVSpeechUtterance *new_utterance = [[AVSpeechUtterance alloc] initWithString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
 			[new_utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:[NSString stringWithUTF8String:message.voice.utf8().get_data()]]];
 			if (message.rate > 1.f) {
-				[new_utterance setRate:Math::remap(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
+				[new_utterance setRate:Math::remap<real_t>(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
 			} else if (message.rate < 1.f) {
-				[new_utterance setRate:Math::remap(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
+				[new_utterance setRate:Math::remap<real_t>(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
 			}
 			[new_utterance setPitchMultiplier:message.pitch];
-			[new_utterance setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
+			[new_utterance setVolume:(Math::remap<real_t>(message.volume, 0.f, 100.f, 0.f, 1.f))];
 
 			ids[new_utterance] = message.id;
 			[av_synth speakUtterance:new_utterance];
@@ -143,7 +143,7 @@
 			[ns_synth setVoice:[NSString stringWithUTF8String:message.voice.utf8().get_data()]];
 			int base_pitch = [[ns_synth objectForProperty:NSSpeechPitchBaseProperty error:nil] intValue];
 			[ns_synth setObject:[NSNumber numberWithInt:(base_pitch * (message.pitch / 2.f + 0.5f))] forProperty:NSSpeechPitchBaseProperty error:nullptr];
-			[ns_synth setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
+			[ns_synth setVolume:(Math::remap<real_t>(message.volume, 0.f, 100.f, 0.f, 1.f))];
 			[ns_synth setRate:(message.rate * 200)];
 
 			last_utterance = message.id;

--- a/scene/3d/spline_ik_3d.cpp
+++ b/scene/3d/spline_ik_3d.cpp
@@ -472,7 +472,7 @@ void SplineIK3D::_process_joints(double p_delta, Skeleton3D *p_skeleton, SplineI
 				continue;
 			}
 		}
-		uint32_t nearest_next = p_curve->is_closed() ? Math::posmod(nearest + 1, point_count) : CLAMP(nearest + 1, (uint32_t)0, point_last);
+		uint32_t nearest_next = p_curve->is_closed() ? Math::posmod(static_cast<int64_t>(nearest + 1), point_count) : CLAMP(nearest + 1, (uint32_t)0, point_last);
 		p_setting->update_chain_coordinate(p_skeleton, TAIL, limit_length(p_setting->chain[HEAD], p_curve_space.xform(points[nearest].lerp(points[nearest_next], interpolate)), solver_info->length));
 		if (!is_fitting_first) {
 			p_setting->twists[HEAD] = Math::lerp((double)tilts[last_nearest], (double)tilts[last_nearest_next], last_interpolate);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -709,7 +709,7 @@ Color ColorPicker::_color_apply_intensity(const Color &col) const {
 	}
 	Color linear_color = col.srgb_to_linear();
 	Color result;
-	float multiplier = Math::pow(2, intensity);
+	float multiplier = Math::pow(2.f, intensity);
 	for (int i = 0; i < 3; i++) {
 		result.components[i] = linear_color.components[i] * multiplier;
 	}

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -252,7 +252,7 @@ int ColorPickerShape::get_edge_h_change(const Vector2 &p_color_change_vector) {
 float ColorPickerShape::get_h_on_circle_edge(const Vector2 &p_color_change_vector) {
 	int h_change = get_edge_h_change(p_color_change_vector);
 
-	float target_h = Math::wrapf(color_picker->h + h_change / 360.0, 0, 1);
+	float target_h = Math::wrapf(color_picker->h + h_change / 360.0, 0., 1.);
 	int current_quarter = color_picker->h * 4;
 	int future_quarter = target_h * 4;
 	if (p_color_change_vector.y > 0 && ((future_quarter == 0 && current_quarter == 1) || (future_quarter == 1 && current_quarter == 0))) {
@@ -581,7 +581,7 @@ void ColorPickerShapeOKHLRectangle::_value_slider_draw() {
 float ColorPickerShapeWheel::_get_h_on_wheel(const Vector2 &p_color_change_vector) {
 	int h_change = get_edge_h_change(p_color_change_vector);
 
-	float target_h = Math::wrapf(color_picker->h + h_change / 360.0, 0, 1);
+	float target_h = Math::wrapf(color_picker->h + h_change / 360.0, 0., 1.);
 	int current_quarter = color_picker->h * 4;
 	int future_quarter = target_h * 4;
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -3187,9 +3187,9 @@ GraphEdit::GraphEdit() {
 	// Allow dezooming 8 times from the default zoom level.
 	// At low zoom levels, text is unreadable due to its small size and poor filtering,
 	// but this is still useful for previewing and navigation.
-	zoom_min = (1 / Math::pow(zoom_step, 8));
+	zoom_min = (1 / Math::pow(zoom_step, 8.f));
 	// Allow zooming 4 times from the default zoom level.
-	zoom_max = (1 * Math::pow(zoom_step, 4));
+	zoom_max = (1 * Math::pow(zoom_step, 4.f));
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &GraphEdit::_pan_callback), callable_mp(this, &GraphEdit::_zoom_callback));

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -53,7 +53,7 @@ double Range::_snapped_r128(double p_value, double p_step) {
 	// so a step size finer than 2^-11 will lose precision, and in practice even 1e-3 can be problematic.
 	// By rescaling the value and step, we can shift precision into the higher bits (effectively turning R128 into a makeshift float).
 	const int decimals = MIN(18, 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step))));
-	const double scale = Math::pow(10.0, decimals);
+	const double scale = Math::pow(10., static_cast<double>(decimals));
 	p_value *= scale;
 	p_step *= scale;
 	// All these lines are the equivalent of: p_value = Math::floor(p_value / p_step + 0.5) * p_step;
@@ -297,7 +297,7 @@ void Range::set_as_ratio(double p_value) {
 	if (shared->exp_ratio && get_min() >= 0) {
 		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
 		double exp_max = Math::log(get_max()) / Math::log((double)2);
-		v = Math::pow(2, exp_min + (exp_max - exp_min) * p_value);
+		v = Math::pow(2., exp_min + (exp_max - exp_min) * p_value);
 	} else {
 		double percent = (get_max() - get_min()) * p_value;
 		if (get_step() > 0) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1321,8 +1321,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 								uint64_t char_current_rand = item_shake->offset_random(glyphs[i].start);
 								uint64_t char_previous_rand = item_shake->offset_previous_random(glyphs[i].start);
 								uint64_t max_rand = 2147483647;
-								double current_offset = Math::remap(char_current_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
-								double previous_offset = Math::remap(char_previous_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
+								double current_offset = Math::remap<double>(char_current_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
+								double previous_offset = Math::remap<double>(char_previous_rand % max_rand, 0, max_rand, 0.0f, 2.f * (float)Math::PI);
 								double n_time = (double)(item_shake->elapsed_time / (0.5f / item_shake->rate));
 								n_time = (n_time > 1.0) ? 1.0 : n_time;
 								item_shake->prev_off = Point2(Math::lerp(Math::sin(previous_offset), Math::sin(current_offset), n_time), Math::lerp(Math::cos(previous_offset), Math::cos(current_offset), n_time)) * (float)item_shake->strength / 10.0f;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -957,8 +957,8 @@ void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color
 
 		PackedVector2Array uvs = p_uvs;
 		for (Vector2 &p : uvs) {
-			p.x = Math::remap(p.x, 0, 1, remap_min.x, remap_max.x);
-			p.y = Math::remap(p.y, 0, 1, remap_min.y, remap_max.y);
+			p.x = Math::remap<real_t>(p.x, 0, 1, remap_min.x, remap_max.x);
+			p.y = Math::remap<real_t>(p.y, 0, 1, remap_min.y, remap_max.y);
 		}
 		RenderingServer::get_singleton()->canvas_item_add_polygon(canvas_item, p_points, p_colors, uvs, texture->get_rid());
 	} else {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3524,9 +3524,9 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 									vertices_ptr[p_idx + m] = quad_faces[m];
 									normals_ptr[p_idx + m] = Vector3(d.y, d.x, 0.0);
 									if (m < 2) {
-										uvs_ptr[p_idx + m] = Vector2(Math::remap(u_pos, 0, ps_info.length, real_t(0.0), real_t(1.0)), (ps_info.ccw) ? 0.8 : 0.9);
+										uvs_ptr[p_idx + m] = Vector2(Math::remap<real_t>(u_pos, 0, ps_info.length, real_t(0.0), real_t(1.0)), (ps_info.ccw) ? 0.8 : 0.9);
 									} else {
-										uvs_ptr[p_idx + m] = Vector2(Math::remap(u_pos, 0, ps_info.length, real_t(0.0), real_t(1.0)), (ps_info.ccw) ? 0.9 : 1.0);
+										uvs_ptr[p_idx + m] = Vector2(Math::remap<real_t>(u_pos, 0, ps_info.length, real_t(0.0), real_t(1.0)), (ps_info.ccw) ? 0.9 : 1.0);
 									}
 									tangents_ptr[(p_idx + m) * 4 + 0] = d.x;
 									tangents_ptr[(p_idx + m) * 4 + 1] = -d.y;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4576,7 +4576,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 }
 
 void Animation::optimize(real_t p_allowed_velocity_err, real_t p_allowed_angular_err, int p_precision) {
-	real_t precision = Math::pow(0.1, p_precision);
+	real_t precision = Math::pow(0.1f, static_cast<real_t>(p_precision));
 	for (int i = 0; i < tracks.size(); i++) {
 		if (track_is_compressed(i)) {
 			continue; //not possible to optimize compressed track

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4576,7 +4576,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 }
 
 void Animation::optimize(real_t p_allowed_velocity_err, real_t p_allowed_angular_err, int p_precision) {
-	real_t precision = Math::pow(0.1f, static_cast<real_t>(p_precision));
+	real_t precision = Math::pow(static_cast<real_t>(0.1f), static_cast<real_t>(p_precision));
 	for (int i = 0; i < tracks.size(); i++) {
 		if (track_is_compressed(i)) {
 			continue; //not possible to optimize compressed track

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -853,7 +853,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			if (hint_subtype_separator >= 0) {
 				String subtype_string = E.hint_string.substr(0, hint_subtype_separator);
 				int slash_pos = subtype_string.find_char('/');
-				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+				PropertyHint subtype_hint = PROPERTY_HINT_NONE;
 				if (slash_pos >= 0) {
 					subtype_hint = PropertyHint(subtype_string.get_slicec('/', 1).to_int());
 					subtype_string = subtype_string.substr(0, slash_pos);
@@ -883,7 +883,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				int key_subtype_separator = E.hint_string.find_char(':');
 				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
 				int key_slash_pos = key_subtype_string.find_char('/');
-				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+				PropertyHint key_subtype_hint = PROPERTY_HINT_NONE;
 				if (key_slash_pos >= 0) {
 					key_subtype_hint = PropertyHint(key_subtype_string.get_slicec('/', 1).to_int());
 					key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
@@ -894,7 +894,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				int value_subtype_separator = E.hint_string.find_char(':', key_value_separator) - (key_value_separator + 1);
 				String value_subtype_string = E.hint_string.substr(key_value_separator + 1, value_subtype_separator);
 				int value_slash_pos = value_subtype_string.find_char('/');
-				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+				PropertyHint value_subtype_hint = PROPERTY_HINT_NONE;
 				if (value_slash_pos >= 0) {
 					value_subtype_hint = PropertyHint(value_subtype_string.get_slicec('/', 1).to_int());
 					value_subtype_string = value_subtype_string.substr(0, value_slash_pos);

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1224,7 +1224,7 @@ void CopyEffects::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture,
 
 	RD::get_singleton()->compute_list_set_push_constant(compute_list, &roughness.push_constant, sizeof(CubemapRoughnessPushConstant));
 
-	int x_groups = Math::division_round_up(p_size, 8);
+	int x_groups = Math::division_round_up(static_cast<unsigned int>(p_size), 8u);
 	int y_groups = x_groups;
 
 	RD::get_singleton()->compute_list_dispatch(compute_list, x_groups, y_groups, p_face_id > 9 ? 6 : 1);

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -559,7 +559,7 @@ TEST_CASE("[Math] wrapi") {
 	CHECK(Math::wrapi(-30, -20, 160) == 150);
 	CHECK(Math::wrapi(30, -20, 160) == 30);
 	CHECK(Math::wrapi(300, -20, 160) == 120);
-	CHECK(Math::wrapi(300'000'000'000, -20, 160) == 120);
+	CHECK(Math::wrapi<long int>(300'000'000'000, -20, 160) == 120);
 }
 
 TEST_CASE_TEMPLATE("[Math] wrapf", T, float, double) {

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -559,7 +559,7 @@ TEST_CASE("[Math] wrapi") {
 	CHECK(Math::wrapi(-30, -20, 160) == 150);
 	CHECK(Math::wrapi(30, -20, 160) == 30);
 	CHECK(Math::wrapi(300, -20, 160) == 120);
-	CHECK(Math::wrapi<long int>(300'000'000'000, -20, 160) == 120);
+	CHECK(Math::wrapi<long long>(300'000'000'000, -20, 160) == 120);
 }
 
 TEST_CASE_TEMPLATE("[Math] wrapf", T, float, double) {

--- a/tests/core/templates/test_list.h
+++ b/tests/core/templates/test_list.h
@@ -522,11 +522,11 @@ TEST_CASE("[List] Swap front and back (values check)") {
 	List<Variant>::Element *n_color = list.push_back(color);
 
 	CHECK(list.front()->get() == "Redot");
-	CHECK(list.back()->get() == Color(0, 0, 1));
+	CHECK(list.back()->get() == color);
 
 	list.swap(n_str, n_color);
 
-	CHECK(list.front()->get() == Color(0, 0, 1));
+	CHECK(list.front()->get() == color);
 	CHECK(list.back()->get() == "Redot");
 }
 

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -4082,9 +4082,9 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK((int)option["kind"] == (int)CodeEdit::CodeCompletionKind::KIND_CLASS);
 			CHECK(option["display_text"] == "item_0.");
 			CHECK(option["insert_text"] == "item_0");
-			CHECK(option["font_color"] == Variant{ Color(1, 0, 0) });
+			CHECK(option["font_color"] == static_cast<Variant>(Color(1, 0, 0)));
 			CHECK(option["icon"] == Ref<Resource>());
-			CHECK(option["default_value"] == Variant{ Color(1, 0, 0) });
+			CHECK(option["default_value"] == static_cast<Variant>(Color(1, 0, 0)));
 
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -4082,9 +4082,9 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK((int)option["kind"] == (int)CodeEdit::CodeCompletionKind::KIND_CLASS);
 			CHECK(option["display_text"] == "item_0.");
 			CHECK(option["insert_text"] == "item_0");
-			CHECK(option["font_color"] == Color(1, 0, 0));
+			CHECK(option["font_color"] == Variant{ Color(1, 0, 0) });
 			CHECK(option["icon"] == Ref<Resource>());
-			CHECK(option["default_value"] == Color(1, 0, 0));
+			CHECK(option["default_value"] == Variant{ Color(1, 0, 0) });
 
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));


### PR DESCRIPTION
Changes some math functions to templates, and a few of them `constexpr` as well.
Includes some changes, such as making Color `constexpr` and support for TinyEXR read into a std::span buffer, both of which are requirements for the terrain editor module.

Superseeds #1297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TinyEXR image loading from in-memory buffers.
  * Expanded the set of built-in named colors.
* **Bug Fixes**
  * Improved numeric consistency for rotation/normalization checks, FOV, snapping, date/time computations, and several editor/viewport/grid rendering calculations.
  * Refined color intensity scaling used by the color picker.
* **Refactor**
  * Modernized math utilities with stronger typing plus more `constexpr`/`noexcept` behavior.
  * Streamlined the `Color` API by removing multiple packing/HSV/utility helpers and updating related conversions.
* **Tests / Chores**
  * Updated math/UI tests and ignore rules (now ignores `uv.lock`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->