### PR TITLE
GH-1307 Fix AtlasTexture not appearing until restart

### DIFF
--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -82,11 +82,11 @@ void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
 		return;
 	}
 	// Support recursive AtlasTextures.
-	if (Ref<AtlasTexture>(atlas).is_valid()) {
+	if (atlas.is_valid()) {
 		atlas->disconnect_changed(callable_mp((Resource *)this, &AtlasTexture::emit_changed));
 	}
 	atlas = p_atlas;
-	if (Ref<AtlasTexture>(atlas).is_valid()) {
+	if (atlas.is_valid()) {
 		atlas->connect_changed(callable_mp((Resource *)this, &AtlasTexture::emit_changed));
 	}
 


### PR DESCRIPTION
fixes #1307 

The guard for this only checked for AtlasTexture but if other types of textures were inputted in it would not connect the function to cause it to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atlas texture updates when switching between different atlas resources.
  * Ensured change notifications are correctly disconnected from the previous atlas and connected to the newly assigned one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->