### PR TITLE
Import error in EmbeddedGodotGame.kt during Android editor build

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
@@ -42,7 +42,7 @@ import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
 import android.view.WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
 import org.godotengine.editor.GodotGame
 import org.godotengine.editor.R
-import org.godotengine.godot.utils.GameMenuUtils
+import org.godotengine.godot.editor.utils.GameMenuUtils
 
 /**
  * Host the Godot game from the editor when the embedded mode is enabled.


### PR DESCRIPTION
Hi! I was building the Android editor from the 26.2 stable source on Windows and ran into a small issue.

EmbeddedGodotGame.kt imports:

import org.godotengine.godot.utils.GameMenuUtils

but GameMenuUtils.kt is actually located in:

package org.godotengine.godot.editor.utils

Changing the import to:

import org.godotengine.godot.editor.utils.GameMenuUtils

fixed the build, and editor:assembleDebug completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting embedded game functionality on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->