### PR TITLE
Change default project setting `keep_screen_on` to false

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1582,7 +1582,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_width_override", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"), 0); // 8K resolution
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_height_override", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"), 0); // 8K resolution
 
-	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
+	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", false);
 	GLOBAL_DEF("animation/warnings/check_invalid_track_paths", true);
 	GLOBAL_DEF("animation/warnings/check_angle_interpolation_type_conflicting", true);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -941,7 +941,7 @@
 			If [code]true[/code], allows HiDPI display on Windows, macOS, Android, iOS and Web. If [code]false[/code], the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
 			[b]Note:[/b] This setting has no effect on Linux as DPI-awareness fallbacks are not supported there.
 		</member>
-		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="true">
+		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], keeps the screen on (even in case of inactivity), so the screensaver does not take over. Works on desktop and mobile platforms.
 		</member>
 		<member name="display/window/frame_pacing/android/enable_frame_pacing" type="bool" setter="" getter="" default="true">


### PR DESCRIPTION
This PR changes the default project setting display/window/energy_saving/keep_screen_on to false
This aligns the default value to what seems to be the standard among game engines, as "do not inhibit sleep", and avoids overriding and disregarding user preference for system sleep.

This is a port of https://github.com/godotengine/godot/pull/121351, and https://github.com/godotengine/godot-proposals/issues/15187

It seems that in most cases, inhibiting sleep is not explicitly desired, and thus it's less intrusive to not intervene with the system's power-saving measures.
\
\
\
\
\
\
\
Because it's relevant, I will share some data I created on "sleep inhibition by default" is normal or warranted for games (it seems to be a tense subject for many)

> NOTE: This is not an exhaustive list (lol), and consists of the games that I currently have installed on my system.
I verified the sleep inhibitor status using `powercfg /requests` in an elevated PowerShell. On Linux, the same can be checked with `systemd-inhibit --list`
I did not test games that are demos, playtests, or otherwise irrelevant

Out of 37 games tested, only 4 actively inhibited system sleep:
- Counter Strike 2
- Deadlock
- Overwatch
- Helldivers 2

The 33 games that did not inhibit sleep included games made in Unity, Unreal, Source, as well as numerous proprietary engines/frameworks.

> As a small anecdote, I asked a few people about their expectations regarding games and system sleep. A common response was that they believed preventing sleep was simply the "industry standard" and had been that way for as long as they could remember. 
\
I was given very similar responses from multiple individuals, which to me suggests one of two things: Those that responded do not recall their systems sleeping unexpectedly while in-game and therefore assumed games were explicitly inhibiting sleep, or, that some other mechanism prevented system sleep, possibly a similar issue to #28039 where silent audio plays, which the OS registers as "playing content" and prevents sleep. If so, this may be more of a Windows behavior than a Godot-specific issue.


<img width="959" height="738" alt="image" src="https://github.com/user-attachments/assets/149d27fd-5152-474d-ac2d-3ae1113d52cc" />

<details>
<body>

Game | Inhibits sleep | Engine | Notes:
-- | -- | -- | --
Minecraft | No | Proprietary |  
BattleBit Remastered | No | Unity |  
Phasmophobia | No | Unity |  
Peak | No | Unity |  
War Thunder | No | Proprietary (Dagor Engine) |  
BeamNG.Drive | No | Proprietary |  
Counter-Strike 2 | Yes | Source 2 |  
Golf It! | No | Unreal Engine 4 |  
Garry’s Mod | No | Source |  
MECCHA CHAMELEON | No | Unreal Engine 5 |  
Bellum | No | Unreal Engine 5 |  
Yap Uap | No | Unity |  
RISK: Global Domination | No | Unity |  
Squad | No | Unreal Engine 5 |  
Overwatch | Yes | Proprietary | Keep awake reason is shown as: SYSTEM: [PROCESS] \Device\HarddiskVolume3\Program Files (x86)\Steam\steamapps\common\Overwatch\Overwatch.exe, meaning the screen can turn off, but the system cannot suspend
Brawlhalla | No | Proprietary |  
Deadlock | Yes | Source 2 |  
Portal 2 | No | Source |  
Stormworks: Build and Rescue | No | Proprietary |  
VRChat | No | Unity |  
Satisfactory | No | Unreal Engine 5 |  
Splitgate | No | Unreal Engine 4 |  
Rocket League | No | Unreal Engine 3 |  
Helldivers 2 | Yes | Proprietary | Keep awake reason is shown as: SYSTEM: [PROCESS] \Device\HarddiskVolume3\Program Files (x86)\Steam\steamapps\common\Helldivers 2\bin\helldivers2.exe, meaning the screen can turn off, but the system cannot suspend
Beyond The Wire | No | Unreal Engine 4 |  
Insurgency: Sandstorm | No | Unreal Engine 4 |  
Automation – The Car Company Tycoon Game | No | Unreal Engine 4 |  
Burglin’ Gnomes | No | Unity |  
Cheese Rolling | No | Unity |  
Deep Rock Galactic | No | Unreal Engine 4 |  
Gamble With Your Friends | No | Unity |  
A Game About Digging A Hole | No | Unreal Engine 5 |  
Juno: New Origins | No | Unity |  
R.E.P.O. | No | Unity |  
Restaurats | No | Unity |  
RV There Yet? | No | Unreal Engine 5 |  
Ultimate Chicken Horse | No | Unity |  


</body>

</details>

Redot appears to be an outlier among the major game engines by enabling sleep inhibition by default through a global project setting, whereas both Unity and Unreal require explicit API calls to prevent system sleep:
- Unity: `Screen.sleepTimeout = SleepTimeout.NeverSleep;`
- Unreal: `FPlatformMisc::ControlScreensaver(FPlatformMisc::EScreenSaverAction::Disable);`

In this way Unity and Unreal nudge developers to only enable sleep inhibitors in contexts where they are actually needed, instead of at all times. This helps to ensure that the user's system power settings are respected by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The default project setting for keeping the screen on during energy-saving mode is now disabled.
  * Updated the setting’s documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->