### PR TITLE
Replace text unescapes escape sequences

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -712,7 +712,7 @@ String FindReplaceBar::get_search_text() const {
 }
 
 String FindReplaceBar::get_replace_text() const {
-	return replace_text->get_text();
+	return replace_text->get_text().c_unescape();
 }
 
 bool FindReplaceBar::is_case_sensitive() const {


### PR DESCRIPTION
Currently in the find and replace for the editor if you were to try to do something like `'\t` in the replace section it will keep it escaped. This PR makes it so that it will instead replace it with the unescaped version of an actual tab character. Useful for cases where you copy from one editor that uses spaces and you want to replace those spaces with tab characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replacement text in the find-and-replace tool now correctly interprets C-style escape sequences before applying replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->