### PR TITLE
Fix Vulkan garbage data in frame (and grammar update =D)

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1763,7 +1763,7 @@ ProjectManager::ProjectManager() {
 		ask_update_label->set_v_size_flags(SIZE_EXPAND_FILL);
 		ask_update_vb->add_child(ask_update_label);
 		ask_update_backup = memnew(CheckBox);
-		ask_update_backup->set_text(TTRC("Backup project first"));
+		ask_update_backup->set_text(TTRC("Back up project first"));
 		ask_update_backup->set_h_size_flags(SIZE_SHRINK_CENTER);
 		ask_update_vb->add_child(ask_update_backup);
 		ask_update_settings->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_open_selected_projects_with_migration));

--- a/editor/translations/editor/de.po
+++ b/editor/translations/editor/de.po
@@ -9006,7 +9006,7 @@ msgstr "Normal bearbeiten"
 msgid "Edit in Recovery Mode"
 msgstr "Bearbeiten im Wiederherstellungsmodus"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Zuerst Sicherheitskopie des Projekts anlegen"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/es.po
+++ b/editor/translations/editor/es.po
@@ -9010,7 +9010,7 @@ msgstr "Editar normalmente"
 msgid "Edit in Recovery Mode"
 msgstr "Editar en Modo de Recuperación"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Haz una copia de seguridad del proyecto primero"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/fa.po
+++ b/editor/translations/editor/fa.po
@@ -8758,7 +8758,7 @@ msgstr "ویرایش به طور معمول"
 msgid "Edit in Recovery Mode"
 msgstr "ویرایش در حالت بازیابی"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "نخست، گرفتن پشتیبانی از پروژه"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/fr.po
+++ b/editor/translations/editor/fr.po
@@ -9117,7 +9117,7 @@ msgstr "Éditer normalement"
 msgid "Edit in Recovery Mode"
 msgstr "Éditer en mode de récupération"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Backup le projet d'abord"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/ga.po
+++ b/editor/translations/editor/ga.po
@@ -8872,7 +8872,7 @@ msgstr "Cuir in eagar de ghnáth"
 msgid "Edit in Recovery Mode"
 msgstr "Cuir in Eagar i Mód Aisghabhála"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Cúltaca den tionscadal ar dtús"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/it.po
+++ b/editor/translations/editor/it.po
@@ -8988,7 +8988,7 @@ msgstr "Modifica normalmente"
 msgid "Edit in Recovery Mode"
 msgstr "Modifica in modalità di recupero"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Fai prima un backup del progetto"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/ja.po
+++ b/editor/translations/editor/ja.po
@@ -8844,7 +8844,7 @@ msgstr "通常の編集"
 msgid "Edit in Recovery Mode"
 msgstr "リカバリーモードで編集"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "先にプロジェクトをバックアップ"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/ko.po
+++ b/editor/translations/editor/ko.po
@@ -8723,7 +8723,7 @@ msgstr "평범하게 편집"
 msgid "Edit in Recovery Mode"
 msgstr "복구 모드에서 편집"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "프로젝트를 먼저 백업"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/pl.po
+++ b/editor/translations/editor/pl.po
@@ -8864,7 +8864,7 @@ msgstr "Edytuj normalnie"
 msgid "Edit in Recovery Mode"
 msgstr "Edytuj w Trybie awaryjnym"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Zrób najpierw kopię zapasową"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/pt_BR.po
+++ b/editor/translations/editor/pt_BR.po
@@ -8979,7 +8979,7 @@ msgstr "Editar normalmente"
 msgid "Edit in Recovery Mode"
 msgstr "Editar em Modo de Recuperação"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Fazer backup do projeto antes"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/ru.po
+++ b/editor/translations/editor/ru.po
@@ -9010,7 +9010,7 @@ msgstr "Редактировать обычно"
 msgid "Edit in Recovery Mode"
 msgstr "Редактировать в режиме восстановления"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Сначала сделать резервную копию проекта"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/sv.po
+++ b/editor/translations/editor/sv.po
@@ -8782,7 +8782,7 @@ msgstr "Redigera normalt"
 msgid "Edit in Recovery Mode"
 msgstr "Redigera i återställningsläge"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Säkerhetskopiera projektet först"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/ta.po
+++ b/editor/translations/editor/ta.po
@@ -8555,7 +8555,7 @@ msgstr "சாதாரணமாகத் திருத்தவும்"
 msgid "Edit in Recovery Mode"
 msgstr "மீட்பு பயன்முறையில் திருத்து"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "முதலில் காப்புப்பிரதி திட்டம்"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/tr.po
+++ b/editor/translations/editor/tr.po
@@ -8919,7 +8919,7 @@ msgstr "Normal şekilde düzenle"
 msgid "Edit in Recovery Mode"
 msgstr "Kurtarma Kipinde Düzenle"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Önce projeyi yedekle"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/uk.po
+++ b/editor/translations/editor/uk.po
@@ -8844,7 +8844,7 @@ msgstr "Відредагуйте нормально"
 msgid "Edit in Recovery Mode"
 msgstr "Редагувати в режимі відновлення"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "Спочатку резервне копіювання проекту"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/zh_Hans.po
+++ b/editor/translations/editor/zh_Hans.po
@@ -8525,7 +8525,7 @@ msgstr "正常编辑"
 msgid "Edit in Recovery Mode"
 msgstr "在恢复模式中编辑"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "事先备份项目"
 
 msgid "Convert Full Project"

--- a/editor/translations/editor/zh_Hant.po
+++ b/editor/translations/editor/zh_Hant.po
@@ -8477,7 +8477,7 @@ msgstr "正常編輯"
 msgid "Edit in Recovery Mode"
 msgstr "在恢復模式中編輯"
 
-msgid "Backup project first"
+msgid "Back up project first"
 msgstr "先備份專案"
 
 msgid "Convert Full Project"

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3375,6 +3375,16 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 	rt->color = RD::get_singleton()->texture_create(rd_color_attachment_format, rd_view);
 	ERR_FAIL_COND(rt->color.is_null());
 
+	// Vulkan (and Metal) textures are uninitialized on creation, unlike OpenGL which
+	// zero-initializes. RD's own lazy pending-clear mechanism (Texture::pending_clear /
+	// _texture_check_pending_clear) is only armed when the driver trait
+	// API_TRAIT_TEXTURE_OUTPUTS_REQUIRE_CLEARS is true, which D3D12 sets but Vulkan and
+	// Metal do not, so it never fires for this texture on those backends. Without an
+	// explicit clear here, a consumer (e.g. Sprite3D) can sample this texture before
+	// any draw ever writes to it (e.g. SubViewport with VIEWPORT_UPDATE_WHEN_VISIBLE,
+	// whose was_used starts false), reading uninitialized VRAM garbage for one frame.
+	RD::get_singleton()->texture_clear(rt->color, Color(0, 0, 0, 0), 0, 1, 0, rd_color_attachment_format.array_layers);
+
 	if (rt->msaa != RS::VIEWPORT_MSAA_DISABLED) {
 		// Use the texture format of the color attachment for the multisample color attachment.
 		RD::TextureFormat rd_color_multisample_format = rd_color_attachment_format;
@@ -3390,10 +3400,11 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 		rd_color_multisample_format.is_resolve_buffer = false;
 		rt->color_multisample = RD::get_singleton()->texture_create(rd_color_multisample_format, rd_view_multisample);
 		ERR_FAIL_COND(rt->color_multisample.is_null());
+
+		RD::get_singleton()->texture_clear(rt->color_multisample, Color(0, 0, 0, 0), 0, 1, 0, rd_color_multisample_format.array_layers);
 	}
 
 	{ //update texture
-
 		Texture *tex = get_texture(rt->texture);
 
 		//free existing textures
@@ -4322,9 +4333,9 @@ RD::DataFormat TextureStorage::render_target_get_color_format(bool p_use_hdr, bo
 
 uint32_t TextureStorage::render_target_get_color_usage_bits(bool p_msaa) {
 	if (p_msaa) {
-		return RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+		return RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	} else {
 		/// @todo FIXME: Storage bit should only be requested when FSR is required.
-		return RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+		return RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -462,6 +462,8 @@ private:
 	RenderTarget *get_render_target(RID p_rid) const { return render_target_owner.get_or_null(p_rid); }
 
 	void _clear_render_target(RenderTarget *rt);
+	/// Allocate GPU image (RenderTarget::color) and wires it to RenderTarget::texture,
+	/// which is the wrapper that gets exposed
 	void _update_render_target(RenderTarget *rt);
 	void _create_render_target_backbuffer(RenderTarget *rt);
 	void _render_target_allocate_sdf(RenderTarget *rt);


### PR DESCRIPTION
fixes #1308 
This **partially** addresses this issue.
The crux is, a (Vulkan) frame is not initialized in the same frame as a scene/subviewport being added to the tree.  This might also overlap the previous fix #1303 , which did fix the "hope-based" sibling subviewport ordering.  However, immediately when added to the tree, there's a potential for more than 1 sibling subviewport to have no dependencies.

The above basically results in rendering garbage data from the GPU in some cases.  This PR just blanks that out so we don't get bugged visuals in the subviewport.  Before we could actually see visual artifacts/textures , but this makes it a blank/transparent frame.

If we change the example project so the timout on the background_3d scene is 1.0 instead of 0.1, then we see the blank frame even after this PR, but no garbage data.

It looks like it's more than 1 frame in some cases, so this might be good to note for posterity, if we have non-deterministic behavior in the Vulkan layer, but this should alleviate the problem in the majority of cases.

Anyhoo, also changed "Backup" to "Back up" for the migration pop-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Render targets now initialize newly created color textures to transparent black, preventing undefined visual results on first use.
  * Corrected the recovery-mode prompt wording to “Back up project first” across supported languages.

* **Documentation**
  * Added clarification for the relationship between internal render-target images and their exposed textures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->