### PR TITLE
fix: add margin to file thumbnails in file explorer window

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -967,7 +967,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_column_width(thumbnail_size * 3 / 2);
 		files->set_max_text_lines(2);
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
-		files->add_theme_constant_override("h_separation", 10);
+		files->add_theme_constant_override("h_separation", 10 * EDSCALE);
 
 		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 		files->set_fixed_tag_icon_size(Size2(icon_size, icon_size));

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -967,6 +967,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_column_width(thumbnail_size * 3 / 2);
 		files->set_max_text_lines(2);
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
+		files->add_theme_constant_override("h_separation", 10);
 
 		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 		files->set_fixed_tag_icon_size(Size2(icon_size, icon_size));


### PR DESCRIPTION
This should fix #670 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing between items in the file browser’s thumbnail view for clearer visual separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->