### PR TITLE
[Parallax2D] Expose manual scroll for manual control of infinite scrolling

### DIFF
--- a/doc/classes/Parallax2D.xml
+++ b/doc/classes/Parallax2D.xml
@@ -26,6 +26,9 @@
 		<member name="limit_end" type="Vector2" setter="set_limit_end" getter="get_limit_end" default="Vector2(10000000, 10000000)">
 			Bottom-right limits for scrolling to end. If the camera is outside of this limit, the [Parallax2D] will stop scrolling. Must be higher than [member limit_begin] and the viewport size combined to work.
 		</member>
+		<member name="manual_scroll" type="Vector2" setter="set_manual_scroll" getter="get_manual_scroll" default="Vector2(0, 0)">
+			Manual scroll offset applied to this [Parallax2D], in pixels. This property exposes programmatic infinite scroll behavior outside [member autoscroll].
+		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 		<member name="repeat_size" type="Vector2" setter="set_repeat_size" getter="get_repeat_size" default="Vector2(0, 0)">
 			Repeats the [Texture2D] of each of this node's children and offsets them by this value. When scrolling, the node's position loops, giving the illusion of an infinite scrolling background if the values are larger than the screen size. If an axis is set to [code]0[/code], the [Texture2D] will not be repeated.

--- a/scene/2d/parallax_2d.cpp
+++ b/scene/2d/parallax_2d.cpp
@@ -115,34 +115,30 @@ void Parallax2D::_update_scroll() {
 	Point2 scroll_ofs = screen_offset;
 
 	if (!Engine::get_singleton()->is_editor_hint()) {
-		Size2 vps = get_viewport_rect().size;
+		Size2 viewport_size = get_viewport_rect().size;
 
-		if (limit_begin.x <= limit_end.x - vps.x) {
-			scroll_ofs.x = CLAMP(scroll_ofs.x, limit_begin.x, limit_end.x - vps.x);
+		if (limit_begin.x <= limit_end.x - viewport_size.x) {
+			scroll_ofs.x = CLAMP(scroll_ofs.x, limit_begin.x, limit_end.x - viewport_size.x);
 		}
-		if (limit_begin.y <= limit_end.y - vps.y) {
-			scroll_ofs.y = CLAMP(scroll_ofs.y, limit_begin.y, limit_end.y - vps.y);
+		if (limit_begin.y <= limit_end.y - viewport_size.y) {
+			scroll_ofs.y = CLAMP(scroll_ofs.y, limit_begin.y, limit_end.y - viewport_size.y);
 		}
 	}
 
 	scroll_ofs *= scroll_scale;
 
 	if (repeat_size.x) {
-		real_t mod = Math::fposmod(scroll_ofs.x - scroll_offset.x, repeat_size.x * get_scale().x);
+		real_t mod = Math::fposmod(scroll_ofs.x - scroll_offset.x - manual_scroll.x, repeat_size.x * get_scale().x);
 		scroll_ofs.x = screen_offset.x - mod;
 	} else {
-		scroll_ofs.x = screen_offset.x + scroll_offset.x - scroll_ofs.x;
+		scroll_ofs.x = screen_offset.x + scroll_offset.x + manual_scroll.x - scroll_ofs.x;
 	}
 
 	if (repeat_size.y) {
-		real_t mod = Math::fposmod(scroll_ofs.y - scroll_offset.y, repeat_size.y * get_scale().y);
+		real_t mod = Math::fposmod(scroll_ofs.y - scroll_offset.y - manual_scroll.y, repeat_size.y * get_scale().y);
 		scroll_ofs.y = screen_offset.y - mod;
 	} else {
-		scroll_ofs.y = screen_offset.y + scroll_offset.y - scroll_ofs.y;
-	}
-
-	if (!follow_viewport) {
-		scroll_ofs -= screen_offset;
+		scroll_ofs.y = screen_offset.y + scroll_offset.y + manual_scroll.y - scroll_ofs.y;
 	}
 
 	set_position(scroll_ofs);
@@ -224,6 +220,29 @@ Point2 Parallax2D::get_autoscroll() const {
 	return autoscroll;
 }
 
+void Parallax2D::set_manual_scroll(const Point2 &p_scroll) {
+	Point2 wrapped = p_scroll;
+
+	if (repeat_size.x) {
+		wrapped.x = Math::fposmod(wrapped.x, repeat_size.x * get_scale().x);
+	}
+	if (repeat_size.y) {
+		wrapped.y = Math::fposmod(wrapped.y, repeat_size.y * get_scale().y);
+	}
+
+	if (wrapped == manual_scroll) {
+		return;
+	}
+
+	manual_scroll = wrapped;
+
+	_update_scroll();
+}
+
+Point2 Parallax2D::get_manual_scroll() const {
+	return manual_scroll;
+}
+
 void Parallax2D::set_screen_offset(const Point2 &p_offset) {
 	if (p_offset == screen_offset) {
 		return;
@@ -280,6 +299,8 @@ void Parallax2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_repeat_times"), &Parallax2D::get_repeat_times);
 	ClassDB::bind_method(D_METHOD("set_autoscroll", "autoscroll"), &Parallax2D::set_autoscroll);
 	ClassDB::bind_method(D_METHOD("get_autoscroll"), &Parallax2D::get_autoscroll);
+	ClassDB::bind_method(D_METHOD("set_manual_scroll", "scroll"), &Parallax2D::set_manual_scroll);
+	ClassDB::bind_method(D_METHOD("get_manual_scroll"), &Parallax2D::get_manual_scroll);
 	ClassDB::bind_method(D_METHOD("set_scroll_offset", "offset"), &Parallax2D::set_scroll_offset);
 	ClassDB::bind_method(D_METHOD("get_scroll_offset"), &Parallax2D::get_scroll_offset);
 	ClassDB::bind_method(D_METHOD("set_screen_offset", "offset"), &Parallax2D::set_screen_offset);
@@ -299,6 +320,7 @@ void Parallax2D::_bind_methods() {
 	ADD_GROUP("Repeat", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "repeat_size"), "set_repeat_size", "get_repeat_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "autoscroll", PROPERTY_HINT_NONE, "suffix:px/s"), "set_autoscroll", "get_autoscroll");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "manual_scroll", PROPERTY_HINT_NONE, "suffix:px"), "set_manual_scroll", "get_manual_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "repeat_times"), "set_repeat_times", "get_repeat_times");
 
 	ADD_GROUP("Limit", "limit_");

--- a/scene/2d/parallax_2d.h
+++ b/scene/2d/parallax_2d.h
@@ -48,6 +48,7 @@ class Parallax2D : public Node2D {
 	String group_name;
 	Size2 scroll_scale = Size2(1, 1);
 	Point2 scroll_offset;
+	Point2 manual_scroll;
 	Point2 screen_offset;
 	Vector2 repeat_size;
 	int repeat_times = 1;
@@ -82,6 +83,14 @@ public:
 
 	void set_autoscroll(const Point2 &p_autoscroll);
 	Point2 get_autoscroll() const;
+
+	/// Manually scrolls this [Parallax2D]'s position by the given offset, in pixels.
+	/// Unlike [member autoscroll], which continuously moves the node each frame,
+	/// this allows programmatic control over scrolling for infinite scroll behavior
+	/// without relying on the camera or auto-scroll system.
+	void set_manual_scroll(const Point2 &p_scroll);
+	/// Returns the current manual scroll offset, in pixels.
+	Point2 get_manual_scroll() const;
 
 	void set_scroll_offset(const Point2 &p_offset);
 	Point2 get_scroll_offset() const;


### PR DESCRIPTION
Currently, the Parallax2D node can only provide infinite scrolling of a (repeating) background by use of the Autoscroll property.  This is a bit limited because it essentially presumes the desire is to let the camera handle the scrolling, and from testing, it did not seem setting the autoscroll property directly worked.

This exposes a "manual scroll" property that will simply augment the autoscroll if there is one, but allows direct control of the scroll behavior regardless, while utilizing the implicit infinite scrolling ability.
<img width="620" height="647" alt="image" src="https://github.com/user-attachments/assets/f68cdc41-72b8-43aa-90b4-4ee81118ac63" />

Currently, setting the scroll offset or the autoscroll at runtime doesn't work if you want infinite scrolling.  An example use case is, you have autoscrolling, but you want a temporary speed burst and have the background speed up in tandem, or you simply want to control it based on events, and not a constant pan, etc...

Existing properties were left in tact so it shouldn't break stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual scroll offset setting to Parallax2D for applying programmatic pixel offsets.
  * Manual offsets can be adjusted independently of automatic scrolling.
  * Offsets are supported with repeated backgrounds and wrap appropriately when repetition is enabled.
  * The setting is available through scripting and the editor inspector, with a default offset of zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->