### PR TITLE
Changing animation in sprite or sprite frames editor is undo-able

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -430,7 +430,25 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 	String current = _get_current();
 
 	if (!current.is_empty()) {
-		player->set_assigned_animation(current);
+		String previous = player->get_assigned_animation();
+		// Only record an undo step for an actual user re-selection.
+		// - Skip when nothing changed.
+		// - Skip when there was no previously assigned animation: set_assigned_animation("")
+		//   is rejected by AnimationPlayer (ERR_FAIL_COND on animation_set.has("")), so there is
+		//   no way to undo back to the "unassigned" state; recording it would create a dead
+		//   undo entry that silently does nothing when triggered (e.g. from _update_player()
+		//   auto-selecting the first animation on a fresh player).
+		if (previous != current && !previous.is_empty()) {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Change Animation"), UndoRedo::MERGE_DISABLE);
+			undo_redo->add_do_method(player, "set_assigned_animation", current);
+			undo_redo->add_do_method(player, "stop", false);
+			undo_redo->add_undo_method(player, "set_assigned_animation", previous);
+			undo_redo->add_undo_method(player, "stop", false);
+			undo_redo->commit_action();
+		} else {
+			player->set_assigned_animation(current);
+		}
 
 		Ref<Animation> anim = player->get_animation(current);
 		ERR_FAIL_COND(anim.is_null());

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1033,8 +1033,21 @@ void SpriteFramesEditor::_animation_selected() {
 	edited_anim = selected->get_text(0);
 
 	if (animated_sprite) {
+		String previous = animated_sprite->call("get_animation");
 		sprite_node_updating = true;
-		animated_sprite->call("set_animation", edited_anim);
+		// Only record an undo step for an actual change with a valid previous animation to
+		// restore to. AnimatedSprite2D/3D::set_animation() rejects names not present in
+		// `frames` (ERR_FAIL_MSG), so if `previous` is empty or no longer valid there is no
+		// way to undo back to it; just apply the change directly in that case.
+		if (previous != edited_anim && !previous.is_empty() && frames.is_valid() && frames->has_animation(previous)) {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Change Animation"), UndoRedo::MERGE_DISABLE, animated_sprite);
+			undo_redo->add_do_method(animated_sprite, "set_animation", edited_anim);
+			undo_redo->add_undo_method(animated_sprite, "set_animation", previous);
+			undo_redo->commit_action();
+		} else {
+			animated_sprite->call("set_animation", edited_anim);
+		}
 		sprite_node_updating = false;
 	}
 


### PR DESCRIPTION
Fixed #1349 

Just an update so changing the selected animation is added to the undo/redo history.
Should eliminate unexpected "edits" made before selecting an animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animation selection changes in the editor can now be undone and redone.
  * Undo history preserves the previously selected animation for both animation players and sprite frame editors.
  * Reverting an animation selection also restores the corresponding playback state.

* **Bug Fixes**
  * Selecting the already active animation no longer creates an unnecessary undo history entry.
  * Invalid or unavailable previous animations are handled without adding an undo action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->