### PR TITLE
GH-1354 Modern Godot Animations not importing Properly

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -527,7 +527,7 @@ constexpr bool is_equal_approx(T p_left, T p_right, T p_tolerance) noexcept {
 		return true;
 	}
 	// Then check for approximate equality.
-	return abs(p_left - p_right) <= p_tolerance;
+	return abs(p_left - p_right) < p_tolerance;
 }
 
 template <std::floating_point T>
@@ -540,7 +540,7 @@ constexpr bool is_equal_approx(T p_left, T p_right) noexcept {
 	// Compute tolerance by magnitude.
 	const T tolerance = (T(CMP_EPSILON) * abs(p_left) < T(CMP_EPSILON)) ? T(CMP_EPSILON) : T(CMP_EPSILON) * abs(p_left);
 
-	return abs(p_left - p_right) <= tolerance;
+	return abs(p_left - p_right) < tolerance;
 }
 
 template <std::floating_point T, std::convertible_to<T> C>

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -77,10 +77,7 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 			al = get_animation_library(StringName());
 		}
 		al->add_animation(which, anim);
-	} else if (name.begins_with("libraries")) {
-#else
-	if (name.begins_with("libraries")) {
-#endif // DISABLE_DEPRECATED
+	} else if (name == "libraries") {
 		Dictionary d = p_value;
 		while (animation_libraries.size()) {
 			remove_animation_library(animation_libraries[0].name);
@@ -90,10 +87,28 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 			add_animation_library(kv.key, lib);
 		}
 		emit_signal(SNAME("animation_libraries_updated"));
-
+	} else if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			remove_animation_library(which);
+		}
+		add_animation_library(which, p_value);
+		emit_signal(SNAME("animation_libraries_updated"));
 	} else {
 		return false;
 	}
+#else
+	if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			remove_animation_library(which);
+		}
+		add_animation_library(which, p_value);
+		emit_signal(SNAME("animation_libraries_updated"));
+	} else {
+		return false;
+	}
+#endif // DISABLE_DEPRECATED
 
 	return true;
 }
@@ -101,12 +116,13 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 bool AnimationMixer::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
 
-	if (name.begins_with("libraries")) {
-		Dictionary d;
-		for (const AnimationLibraryData &lib : animation_libraries) {
-			d[lib.name] = lib.library;
+	if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			r_ret = get_animation_library(which);
+		} else {
+			return false;
 		}
-		r_ret = d;
 	} else {
 		return false;
 	}
@@ -119,7 +135,10 @@ uint32_t AnimationMixer::_get_libraries_property_usage() const {
 }
 
 void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries"), PROPERTY_HINT_DICTIONARY_TYPE, "StringName;AnimationLibrary", _get_libraries_property_usage()));
+	for (uint32_t i = 0; i < animation_libraries.size(); i++) {
+		const String path = vformat("libraries/%s", animation_libraries[i].name);
+		p_list->push_back(PropertyInfo(Variant::OBJECT, path, PROPERTY_HINT_RESOURCE_TYPE, "AnimationLibrary", _get_libraries_property_usage()));
+	}
 }
 
 void AnimationMixer::_validate_property(PropertyInfo &p_property) const {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -186,21 +186,21 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 		} break;
 
 		case Animation::LOOP_LINEAR: {
-			if (Animation::is_less_approx(next_pos, start) && Animation::is_greater_or_equal_approx(cd.pos, start)) {
+			if (next_pos < start && Animation::is_greater_or_equal_approx(cd.pos, start)) {
 				looped_flag = Animation::LOOPED_FLAG_START;
 			}
-			if (Animation::is_greater_approx(next_pos, end) && Animation::is_less_or_equal_approx(cd.pos, end)) {
+			if (next_pos > end && Animation::is_less_or_equal_approx(cd.pos, end)) {
 				looped_flag = Animation::LOOPED_FLAG_END;
 			}
 			next_pos = Math::fposmod(next_pos - start, end - start) + start;
 		} break;
 
 		case Animation::LOOP_PINGPONG: {
-			if (Animation::is_less_approx(next_pos, start) && Animation::is_greater_or_equal_approx(cd.pos, start)) {
+			if (next_pos < start && Animation::is_greater_or_equal_approx(cd.pos, start)) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_START;
 			}
-			if (Animation::is_greater_approx(next_pos, end) && Animation::is_less_or_equal_approx(cd.pos, end)) {
+			if (next_pos > end && Animation::is_less_or_equal_approx(cd.pos, end)) {
 				cd.speed_scale *= -1.0;
 				looped_flag = Animation::LOOPED_FLAG_END;
 			}


### PR DESCRIPTION
Fixes #1354 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation library property handling, including clearer access to individual libraries.
  * Corrected loop detection for linear and ping-pong animations so loops trigger only after crossing playback boundaries.
  * Refined approximate-equality checks for more precise arithmetic and floating-point behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->