### PR TITLE
Revert broken is_normalized checks

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -79,7 +79,7 @@ Quaternion Quaternion::normalized() const {
 }
 
 bool Quaternion::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1); //use less epsilon
+	return Math::is_equal_approx(length_squared(), 1.f, static_cast<real_t>(UNIT_EPSILON)); //use less epsilon
 }
 
 Quaternion Quaternion::inverse() const {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -76,7 +76,7 @@ Vector2 Vector2::normalized() const {
 
 bool Vector2::is_normalized() const {
 	// use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
-	return Math::is_equal_approx(length_squared(), 1);
+	return Math::is_equal_approx(length_squared(), 1.f, static_cast<real_t>(UNIT_EPSILON));
 }
 
 real_t Vector2::distance_to(const Vector2 &p_vector2) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -554,7 +554,7 @@ Vector3 Vector3::normalized() const {
 
 bool Vector3::is_normalized() const {
 	// use length_squared() instead of length() to avoid sqrt(), makes it more stringent.
-	return Math::is_equal_approx(length_squared(), 1);
+	return Math::is_equal_approx(length_squared(), 1.f, static_cast<real_t>(UNIT_EPSILON));
 }
 
 Vector3 Vector3::inverse() const {

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -91,7 +91,7 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 	uint8_t hour, minute, second;                                                                                        \
 	{                                                                                                                    \
 		/* The time of the day (in seconds since start of day). */                                                       \
-		uint32_t day_clock = Math::posmod(static_cast<int64_t>(p_unix_time_val), static_cast<int64_t>(SECONDS_PER_DAY)); \
+		uint32_t day_clock = Math::posmod(static_cast<int32_t>(p_unix_time_val), static_cast<int32_t>(SECONDS_PER_DAY)); \
 		/* On x86 these 4 lines can be optimized to only 2 divisions. */                                                 \
 		second = day_clock % 60;                                                                                         \
 		day_clock /= 60;                                                                                                 \

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -91,7 +91,7 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 	uint8_t hour, minute, second;                                                                                        \
 	{                                                                                                                    \
 		/* The time of the day (in seconds since start of day). */                                                       \
-		uint32_t day_clock = Math::posmod(static_cast<int32_t>(p_unix_time_val), static_cast<int32_t>(SECONDS_PER_DAY)); \
+		uint32_t day_clock = Math::posmod(static_cast<int64_t>(p_unix_time_val), static_cast<int64_t>(SECONDS_PER_DAY)); \
 		/* On x86 these 4 lines can be optimized to only 2 divisions. */                                                 \
 		second = day_clock % 60;                                                                                         \
 		day_clock /= 60;                                                                                                 \


### PR DESCRIPTION
Revert normalization checks that were changed.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when determining whether 2D and 3D vectors, or quaternions, are normalized by applying a precise tolerance.
  * Improved time-of-day calculations to ensure seconds are handled consistently during timestamp conversion.
  * Reduced potential inaccuracies around unit-length checks and daily time boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->