### PR TITLE
Update REDOT_AUTHORS.md

### DIFF
--- a/REDOT_AUTHORS.md
+++ b/REDOT_AUTHORS.md
@@ -35,10 +35,11 @@ name is available.
     Andevrs (tindrew)
     Arctis Fireblight
     ChocolateChipAussie (Logan-ReXDev)
+	DaveTheEggman
     DAShoe1
     decryptedchaos
+	GeneralProtectionFault
     George L Albany (spartan322)
     Jon (JoltedJon)
     McDubh (mcdubhghlas)
     Skogi (SkogiB)
-    Shakai (Shakai-Dev)


### PR DESCRIPTION
Added @GeneralProtectionFault to the authors file and updated @DaveTheEggman's entry to reflect his new GitHub username.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Developers list to add DaveTheEggman and GeneralProtectionFault.
  * Removed Shakai (Shakai-Dev) from the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->