### PR TITLE
Fix trait type constraint validation in GDScript GH-1361

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4677,21 +4677,40 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 	p_call->set_datatype(call_type);
 }
 
-bool GDScriptAnalyzer::can_type_overlap_trait(const GDScriptParser::DataType &p_type, const GDScriptParser::DataType &p_trait) {
-	if (p_trait.kind != GDScriptParser::DataType::TRAIT || p_trait.class_type == nullptr) {
+GDScriptParser::DataType GDScriptAnalyzer::get_type_constraint_for_overlap(const GDScriptParser::DataType &p_type) {
+	if (p_type.kind != GDScriptParser::DataType::TRAIT || p_type.class_type == nullptr) {
+		return p_type;
+	}
+
+	if (p_type.class_type->extends_used) {
+		return p_type.class_type->base_type;
+	}
+
+	// Traits reuse the class default of RefCounted internally, but an unconstrained
+	// trait can be used by classes from any Object-derived inheritance branch.
+	GDScriptParser::DataType object_type;
+	object_type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+	object_type.kind = GDScriptParser::DataType::NATIVE;
+	object_type.builtin_type = Variant::OBJECT;
+	object_type.native_type = SNAME("Object");
+	return object_type;
+}
+
+bool GDScriptAnalyzer::can_types_overlap(const GDScriptParser::DataType &p_left, const GDScriptParser::DataType &p_right) {
+	if (p_left.kind != GDScriptParser::DataType::TRAIT && p_right.kind != GDScriptParser::DataType::TRAIT) {
+		return false;
+	}
+	if (p_left.is_meta_type || p_right.is_meta_type) {
+		return false;
+	}
+	if ((p_left.kind == GDScriptParser::DataType::TRAIT && p_left.class_type == nullptr) ||
+			(p_right.kind == GDScriptParser::DataType::TRAIT && p_right.class_type == nullptr)) {
 		return false;
 	}
 
-	GDScriptParser::DataType type_constraint = p_type;
-	if (type_constraint.kind == GDScriptParser::DataType::TRAIT) {
-		if (type_constraint.class_type == nullptr) {
-			return false;
-		}
-		type_constraint = type_constraint.class_type->base_type;
-	}
-
-	const GDScriptParser::DataType &trait_constraint = p_trait.class_type->base_type;
-	return is_type_compatible(type_constraint, trait_constraint) || is_type_compatible(trait_constraint, type_constraint);
+	GDScriptParser::DataType left_constraint = get_type_constraint_for_overlap(p_left);
+	GDScriptParser::DataType right_constraint = get_type_constraint_for_overlap(p_right);
+	return is_type_compatible(left_constraint, right_constraint) || is_type_compatible(right_constraint, left_constraint);
 }
 
 void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
@@ -4732,7 +4751,7 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 			if (operand_type.class_type && cast_type.class_type) {
 				is_using_trait = operand_type.class_type->traits_fqtn.has(cast_type.class_type->fqcn);
 			}
-			if (operand_type.is_hard_type() && !is_using_trait && !can_type_overlap_trait(operand_type, cast_type) && operand_type.kind != GDScriptParser::DataType::VARIANT) {
+			if (operand_type.is_hard_type() && !is_using_trait && !can_types_overlap(operand_type, cast_type) && operand_type.kind != GDScriptParser::DataType::VARIANT) {
 				push_error(vformat(R"(Invalid cast. Cannot convert from "%s" to "%s".)", p_cast->operand->get_datatype().to_string(), cast_type.to_string()), p_cast->cast_type);
 			} else {
 				mark_node_unsafe(p_cast);
@@ -4759,6 +4778,10 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 				valid = Variant::can_convert_strict(op_type.builtin_type, cast_type.builtin_type);
 			} else if (op_type.kind != GDScriptParser::DataType::BUILTIN && cast_type.kind != GDScriptParser::DataType::BUILTIN) {
 				valid = is_type_compatible(cast_type, op_type) || is_type_compatible(op_type, cast_type);
+				if (!valid && can_types_overlap(op_type, cast_type)) {
+					mark_node_unsafe(p_cast);
+					valid = true;
+				}
 			}
 
 			if (!valid) {
@@ -6225,7 +6248,7 @@ void GDScriptAnalyzer::reduce_type_test(GDScriptParser::TypeTestNode *p_type_tes
 				push_error(vformat(R"(Expression is of type "%s" so it can't be of type "%s".)", operand_type.to_string(), test_type.to_string()), p_type_test->operand);
 			}
 		} else {
-			if (operand_type.is_hard_type() && !is_using_trait && !can_type_overlap_trait(operand_type, test_type) && operand_type.kind != GDScriptParser::DataType::VARIANT) {
+			if (operand_type.is_hard_type() && !is_using_trait && !can_types_overlap(operand_type, test_type) && operand_type.kind != GDScriptParser::DataType::VARIANT) {
 				push_error(vformat(R"(Expression is of type "%s" so it can't be of type "%s".)", operand_type.to_string(), test_type.to_string()), p_type_test->operand);
 			} else if (!operand_type.is_hard_type()) {
 				// Only weakly-typed operands get their type source downgraded; a hard-typed
@@ -6249,7 +6272,7 @@ void GDScriptAnalyzer::reduce_type_test(GDScriptParser::TypeTestNode *p_type_tes
 		return;
 	}
 
-	if (!is_type_compatible(test_type, operand_type) && !is_type_compatible(operand_type, test_type)) {
+	if (!is_type_compatible(test_type, operand_type) && !is_type_compatible(operand_type, test_type) && !can_types_overlap(operand_type, test_type)) {
 		if (operand_type.is_hard_type()) {
 			push_error(vformat(R"(Expression is of type "%s" so it can't be of type "%s".)", operand_type.to_string(), test_type.to_string()), p_type_test->operand);
 		} else {
@@ -7298,17 +7321,37 @@ bool GDScriptAnalyzer::check_type_compatibility(const GDScriptParser::DataType &
 			}
 			break;
 		case GDScriptParser::DataType::TRAIT:
+			if (p_source.is_meta_type) {
+				src_native = GDScript::get_class_static();
+			} else {
+				src_class = p_source.class_type;
+				if (src_class != nullptr && !src_class->extends_used) {
+					src_native = SNAME("Object");
+					break;
+				}
+				const GDScriptParser::ClassNode *base = src_class;
+				while (base != nullptr && base->base_type.kind == GDScriptParser::DataType::CLASS) {
+					base = base->base_type.class_type;
+				}
+				if (base != nullptr) {
+					src_native = base->base_type.native_type;
+					src_script = base->base_type.script_type;
+				}
+			}
+			break;
 		case GDScriptParser::DataType::CLASS:
 			if (p_source.is_meta_type) {
 				src_native = GDScript::get_class_static();
 			} else {
 				src_class = p_source.class_type;
 				const GDScriptParser::ClassNode *base = src_class;
-				while (base->base_type.kind == GDScriptParser::DataType::CLASS) {
+				while (base != nullptr && base->base_type.kind == GDScriptParser::DataType::CLASS) {
 					base = base->base_type.class_type;
 				}
-				src_native = base->base_type.native_type;
-				src_script = base->base_type.script_type;
+				if (base != nullptr) {
+					src_native = base->base_type.native_type;
+					src_script = base->base_type.script_type;
+				}
 			}
 			break;
 		case GDScriptParser::DataType::VARIANT:

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -177,7 +177,8 @@ class GDScriptAnalyzer {
 	/// This function determines which type is that (if any).
 	void update_dictionary_literal_element_type(GDScriptParser::DictionaryNode *p_dictionary, const GDScriptParser::DataType &p_key_element_type, const GDScriptParser::DataType &p_value_element_type);
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false, const GDScriptParser::Node *p_source_node = nullptr);
-	bool can_type_overlap_trait(const GDScriptParser::DataType &p_type, const GDScriptParser::DataType &p_trait);
+	GDScriptParser::DataType get_type_constraint_for_overlap(const GDScriptParser::DataType &p_type);
+	bool can_types_overlap(const GDScriptParser::DataType &p_left, const GDScriptParser::DataType &p_right);
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin = nullptr);
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);
 	void downgrade_node_type_source(GDScriptParser::Node *p_node);

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -100,7 +100,7 @@ struct Second:
 /// @todo Handle some cases failing on release builds. See: https://github.com/godotengine/godot/pull/88452
 #ifdef TOOLS_ENABLED
 TEST_SUITE("[Modules][GDScript]") {
-	TEST_CASE("Script compilation and runtime") {
+	TEST_CASE("[SceneTree] Script compilation and runtime") {
 		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;
 		bool use_binary_tokens = OS::get_singleton()->get_cmdline_args().find("--use-binary-tokens") != nullptr;
 		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true, print_filenames, use_binary_tokens);

--- a/modules/gdscript/tests/scripts/Traits/analyzer/errors/trait_type_constraint_mismatches.gd
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/errors/trait_type_constraint_mismatches.gd
@@ -1,0 +1,22 @@
+trait Unconstrained:
+	func ping() -> void:
+		pass
+
+trait RefCountedOnly extends RefCounted:
+	func ping() -> void:
+		pass
+
+class NodeImplementation extends Node:
+	uses Unconstrained
+
+func test() -> void:
+	var implementation := NodeImplementation.new()
+	var parent_typed: Node = implementation
+	parent_typed as RefCountedOnly
+	parent_typed is RefCountedOnly
+
+	var trait_typed: Unconstrained = implementation
+	var ref_counted: RefCounted = trait_typed
+	var node: Node = trait_typed
+	print(ref_counted, node)
+	implementation.free()

--- a/modules/gdscript/tests/scripts/Traits/analyzer/errors/trait_type_constraint_mismatches.out
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/errors/trait_type_constraint_mismatches.out
@@ -1,0 +1,5 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 15: Invalid cast. Cannot convert from "Node" to "RefCountedOnly".
+>> ERROR at line 16: Expression is of type "Node" so it can't be of type "RefCountedOnly".
+>> ERROR at line 19: Cannot assign a value of type Unconstrained to variable "ref_counted" with specified type RefCounted.
+>> ERROR at line 20: Cannot assign a value of type Unconstrained to variable "node" with specified type Node.

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_runtime_type_checks.gd
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_runtime_type_checks.gd
@@ -7,6 +7,19 @@ trait Damageable extends Node:
 class Enemy extends Node:
 	uses Damageable
 
+trait UnconstrainedDamageable:
+	func take_damage() -> void:
+		print("damaged")
+
+class UnconstrainedEnemy extends Node2D:
+	uses UnconstrainedDamageable
+
+func can_use_unconstrained_trait_from_node_2d(parent_typed: Node2D) -> bool:
+	return parent_typed is UnconstrainedDamageable and (parent_typed as UnconstrainedDamageable) != null
+
+func can_downcast_unconstrained_trait_to_node_2d(trait_typed: UnconstrainedDamageable) -> bool:
+	return trait_typed is Node2D and (trait_typed as Node2D) != null
+
 func accept_damageable(_value: Damageable) -> void:
 	print("accepted")
 
@@ -22,8 +35,30 @@ func test() -> void:
 	accept_damageable(other)
 	accept_damageable(damageable)
 	accept_damageable(null)
+	var base_node: Node = damageable
+	print(base_node == value)
 	var empty: Damageable = null
 	print(empty == null)
 	print(null_damageable() == null)
 	other.free()
 	value.free()
+
+	var implementation := UnconstrainedEnemy.new()
+	var parent_typed: Node2D = implementation
+	print(can_use_unconstrained_trait_from_node_2d(implementation))
+	var unconstrained := parent_typed as UnconstrainedDamageable
+	print(unconstrained != null)
+	unconstrained.take_damage()
+	print(parent_typed is UnconstrainedDamageable)
+
+	var plain_node := Node2D.new()
+	print((plain_node as UnconstrainedDamageable) == null)
+	print(plain_node is UnconstrainedDamageable)
+
+	var trait_typed: UnconstrainedDamageable = implementation
+	print(can_downcast_unconstrained_trait_to_node_2d(trait_typed))
+	var downcast := trait_typed as Node2D
+	print(downcast == implementation)
+	print(trait_typed is Node2D)
+	implementation.free()
+	plain_node.free()

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_runtime_type_checks.out
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_runtime_type_checks.out
@@ -6,3 +6,13 @@ accepted
 accepted
 true
 true
+true
+true
+true
+damaged
+true
+true
+false
+true
+true
+true


### PR DESCRIPTION
## Summary

Fixes #1361-- Trait casts and type checks after an object has been upcast to a parent type.

## Root cause

Traits without an explicit `extends` clause internally use `RefCounted` as a default base type. The type analyzer mistakenly treated this internal default as a real trait constraint.

As a result, an object typed as `Node` or `Node2D` was considered incompatible with an unconstrained trait, even when its actual class implemented that trait. Runtime trait detection already worked correctly, which is why casting through `Variant` avoided the error.

## Solution

Unconstrained traits are now treated as compatible with any `Object`-derived type when checking whether two types could overlap.

The updated checks:

- Allow parent-typed objects to use `as Trait` and `is Trait`.
- Allow checked casts from trait types back to compatible object types.
- Continue rejecting casts between types with explicitly incompatible constraints.
- Prevent unconstrained traits from being treated as guaranteed `RefCounted` values.

Regression tests were added for valid casts, runtime checks, reverse casts, and incompatible trait constraints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GDScript type compatibility analysis for traits without explicit base-type constraints.
  - Corrected compatibility checks involving traits, classes, and `Object`-based types.
  - Allowed valid casts between overlapping non-built-in types while marking potentially unsafe casts appropriately.

- **Tests**
  - Added coverage for trait constraint mismatches.
  - Added runtime checks for casting between unconstrained traits and node types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->