### PR TITLE
Fix worldscape mingw compilation and add CI job

### DIFF
--- a/modules/worldscape_3d/constants.h
+++ b/modules/worldscape_3d/constants.h
@@ -67,11 +67,7 @@
 #define ASSERT(cond, ret)
 #endif
 
-#ifdef VOID
-#undef VOID
-#endif
-
-#define VOID // a return value for void, to avoid compiler warnings
+#define WS3D_RETURN_VOID // Empty return expression for validation macros.
 
 #define IS_INIT(ret) \
 	if (!_terrain) { \

--- a/modules/worldscape_3d/editor/worldscape_3d_editor.cpp
+++ b/modules/worldscape_3d/editor/worldscape_3d_editor.cpp
@@ -610,7 +610,7 @@ void WorldScape3DEditor::_operate_map(const Vector3 &p_global_position, const re
 }
 
 void WorldScape3DEditor::_store_undo() {
-	IS_INIT_COND_MESG(!_terrain->get_plugin(), "_terrain isn't initialized, returning", VOID);
+	IS_INIT_COND_MESG(!_terrain->get_plugin(), "_terrain isn't initialized, returning", WS3D_RETURN_VOID);
 	if (_tool < 0 || _tool >= TOOL_MAX) {
 		return;
 	}
@@ -659,7 +659,7 @@ void WorldScape3DEditor::_store_undo() {
 }
 
 void WorldScape3DEditor::_apply_undo(const Dictionary &p_data) {
-	IS_INIT_COND_MESG(!_terrain->get_plugin(), "_terrain isn't initialized, returning", VOID);
+	IS_INIT_COND_MESG(!_terrain->get_plugin(), "_terrain isn't initialized, returning", WS3D_RETURN_VOID);
 	LOG(INFO, "Applying Undo/Redo data");
 
 	WorldScape3DData *data = _terrain->get_data();
@@ -824,7 +824,7 @@ void WorldScape3DEditor::set_tool(const Tool p_tool) {
 
 // Called on mouse click
 void WorldScape3DEditor::start_operation(const Vector3 &p_global_position) {
-	IS_DATA_INIT_MESG("Terrain isn't initialized", VOID);
+	IS_DATA_INIT_MESG("Terrain isn't initialized", WS3D_RETURN_VOID);
 	LOG(INFO, "Setting up undo snapshot");
 	_undo_data.clear();
 	_undo_data["region_locations"] = _terrain->get_data()->get_region_locations().duplicate();
@@ -841,7 +841,7 @@ void WorldScape3DEditor::start_operation(const Vector3 &p_global_position) {
 
 // Called on mouse movement with left mouse button down
 void WorldScape3DEditor::operate(const Vector3 &p_global_position, const real_t p_camera_direction) {
-	IS_DATA_INIT_MESG("Terrain isn't initialized", VOID);
+	IS_DATA_INIT_MESG("Terrain isn't initialized", WS3D_RETURN_VOID);
 	if (!_is_operating) {
 		LOG(ERROR, "Run start_operation() before operating");
 		return;
@@ -881,7 +881,7 @@ void WorldScape3DEditor::backup_region(const Ref<WorldScape3DRegion> &p_region) 
 
 // Called on left mouse button released
 void WorldScape3DEditor::stop_operation() {
-	IS_DATA_INIT_MESG("The terrain isn't initialized", VOID);
+	IS_DATA_INIT_MESG("The terrain isn't initialized", WS3D_RETURN_VOID);
 	// If undo was created and terrain actually modified, store it
 	LOG(DEBUG, "Backed up regions: ", _original_regions.size(), ", Edited regions: ", _edited_regions.size(),
 			", Added/Removed regions: ", _added_removed_locations.size());

--- a/modules/worldscape_3d/worldscape_3d_assets.cpp
+++ b/modules/worldscape_3d/worldscape_3d_assets.cpp
@@ -189,7 +189,7 @@ void WorldScape3DAssets::_set_asset(const AssetType p_type, const int p_id, cons
 }
 
 void WorldScape3DAssets::_update_texture_files() {
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	LOG(DEBUG, "Received texture_changed signal");
 	_generated_albedo_textures.clear();
 	_generated_normal_textures.clear();
@@ -383,7 +383,7 @@ void WorldScape3DAssets::_update_texture_settings() {
 }
 
 void WorldScape3DAssets::_setup_thumbnail_creation() {
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	if (_scenario.is_valid()) {
 		return;
 	}
@@ -536,7 +536,7 @@ void WorldScape3DAssets::set_mesh_asset(const int p_id, const Ref<WorldScape3DMe
 	LOG(INFO, "Setting mesh id: ", p_id, ", ", p_mesh_asset);
 	_set_asset(TYPE_MESH, p_id, p_mesh_asset);
 	if (p_mesh_asset.is_null()) {
-		IS_INSTANCER_INIT(VOID);
+		IS_INSTANCER_INIT(WS3D_RETURN_VOID);
 		_terrain->get_instancer()->clear_by_mesh(p_id);
 	}
 	update_mesh_list();
@@ -634,7 +634,7 @@ void WorldScape3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &
 }
 
 void WorldScape3DAssets::update_mesh_list() {
-	IS_INSTANCER_INIT(VOID);
+	IS_INSTANCER_INIT(WS3D_RETURN_VOID);
 	LOG(INFO, "Updating mesh list");
 	if (_mesh_list.size() == 0) {
 		LOG(DEBUG, "Mesh list empty, clearing instancer and adding a default mesh");

--- a/modules/worldscape_3d/worldscape_3d_collision.cpp
+++ b/modules/worldscape_3d/worldscape_3d_collision.cpp
@@ -236,7 +236,7 @@ void WorldScape3DCollision::initialize(WorldScape3D *p_terrain) {
 }
 
 void WorldScape3DCollision::build() {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	if (!_terrain->is_inside_world()) {
 		LOG(ERROR, "Terrain isn't inside world. Returning.");
 		return;

--- a/modules/worldscape_3d/worldscape_3d_data.cpp
+++ b/modules/worldscape_3d/worldscape_3d_data.cpp
@@ -895,7 +895,7 @@ void WorldScape3DData::calc_height_range(const bool p_recursive) {
  *	p_scale - Scale all height values by this factor (applied after offset)
  */
 void WorldScape3DData::import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position, const real_t p_offset, const real_t p_scale) {
-	IS_INIT_MESG("Data not initialized", VOID);
+	IS_INIT_MESG("Data not initialized", WS3D_RETURN_VOID);
 	if (p_images.size() != TYPE_MAX) {
 		LOG(ERROR, "p_images.size() is ", p_images.size(), ". It should be ", TYPE_MAX, " even if some Images are blank or null");
 		return;

--- a/modules/worldscape_3d/worldscape_3d_instancer.cpp
+++ b/modules/worldscape_3d/worldscape_3d_instancer.cpp
@@ -50,7 +50,7 @@
 
 // Creates MMIs based on stored Multimesh data
 void WorldScape3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_mesh_id) {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	LOG(INFO, "Updating MMIs for ", (p_region_loc.x == INT32_MAX) ? "all regions" : "region " + String(p_region_loc),
 			(p_mesh_id == -1) ? ", all meshes" : ", mesh " + String::num_int64(p_mesh_id));
 
@@ -275,7 +275,7 @@ void WorldScape3DInstancer::_setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, co
 }
 
 void WorldScape3DInstancer::_update_vertex_spacing(const real_t p_vertex_spacing) {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	Array region_locations = _terrain->get_data()->get_region_locations();
 	for (int r = 0; r < region_locations.size(); r++) {
 		Vector2i region_loc = region_locations[r];
@@ -501,13 +501,13 @@ void WorldScape3DInstancer::initialize(WorldScape3D *p_terrain) {
 	if (p_terrain) {
 		_terrain = p_terrain;
 	}
-	IS_DATA_INIT_MESG("WorldScape3D not initialized yet", VOID);
+	IS_DATA_INIT_MESG("WorldScape3D not initialized yet", WS3D_RETURN_VOID);
 	LOG(INFO, "Initializing Instancer");
 	_update_mmis();
 }
 
 void WorldScape3DInstancer::destroy() {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	LOG(INFO, "Destroying all MMIs");
 
 	// Iterate over keys as subfunction will invalidate standard iterator
@@ -558,7 +558,7 @@ void WorldScape3DInstancer::clear_by_region(const Ref<WorldScape3DRegion> &p_reg
 }
 
 void WorldScape3DInstancer::add_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 
 	int mesh_id = p_params.get("asset_id", 0);
 	if (mesh_id < 0 || mesh_id >= _terrain->get_assets()->get_mesh_count()) {
@@ -669,7 +669,7 @@ void WorldScape3DInstancer::add_instances(const Vector3 &p_global_position, cons
 }
 
 void WorldScape3DInstancer::remove_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 
 	int mesh_id = p_params.get("asset_id", 0);
 	int mesh_count = _terrain->get_assets()->get_mesh_count();
@@ -821,7 +821,7 @@ void WorldScape3DInstancer::add_multimesh(const int p_mesh_id, const Ref<MultiMe
 
 // Expects transforms in global space
 void WorldScape3DInstancer::add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const PackedColorArray &p_colors, const bool p_update) {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 	if (p_xforms.size() == 0) {
 		return;
 	}
@@ -872,7 +872,7 @@ void WorldScape3DInstancer::add_transforms(const int p_mesh_id, const TypedArray
 // Appends new global transforms to existing cells, offsetting transforms to region space, scaled by vertex spacing
 void WorldScape3DInstancer::append_location(const Vector2i &p_region_loc, const int p_mesh_id,
 		const TypedArray<Transform3D> &p_xforms, const PackedColorArray &p_colors, const bool p_update) {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	Ref<WorldScape3DRegion> region = _terrain->get_data()->get_region(p_region_loc);
 	if (region.is_null()) {
 		return;
@@ -945,7 +945,7 @@ void WorldScape3DInstancer::append_region(const Ref<WorldScape3DRegion> &p_regio
 
 // Review all transforms in one area and adjust their transforms w/ the current height
 void WorldScape3DInstancer::update_transforms(const AABB &p_aabb) {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 	Rect2 rect = aabb2rect(p_aabb);
 	LOG(EXTREME, "Updating transforms within ", rect);
 	Vector2 global_position = rect.get_center();
@@ -1127,7 +1127,7 @@ void WorldScape3DInstancer::copy_paste_dfr(const WorldScape3DRegion *p_src_regio
 // Changes the ID of a mesh, without changing the mesh on the ground
 // Called when the mesh asset id has changed. Updates Multimeshes and MMIs dictionary keys
 void WorldScape3DInstancer::swap_ids(const int p_src_id, const int p_dst_id) {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 	Ref<WorldScape3DAssets> assets = _terrain->get_assets();
 	int mesh_count = assets->get_mesh_count();
 	LOG(INFO, "Swapping IDs of multimeshes: ", p_src_id, " and ", p_dst_id);
@@ -1181,7 +1181,7 @@ void WorldScape3DInstancer::update_mmis(const bool p_rebuild) {
 }
 
 void WorldScape3DInstancer::dump_data() {
-	IS_DATA_INIT_MESG("Instancer isn't initialized.", VOID);
+	IS_DATA_INIT_MESG("Instancer isn't initialized.", WS3D_RETURN_VOID);
 	Array region_locations = _terrain->get_data()->get_region_locations();
 	LOG(WARN, "Dumping Instancer data for ", region_locations.size(), " active regions");
 	for (int i = 0; i < region_locations.size(); i++) {

--- a/modules/worldscape_3d/worldscape_3d_material.cpp
+++ b/modules/worldscape_3d/worldscape_3d_material.cpp
@@ -430,7 +430,7 @@ String WorldScape3DMaterial::_inject_editor_code(const String &p_shader) const {
 }
 
 void WorldScape3DMaterial::_update_shader() {
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	LOG(INFO, "Updating shader");
 	String code;
 	Ref<RegEx> regex;
@@ -521,7 +521,7 @@ void WorldScape3DMaterial::_update_shader() {
 }
 
 void WorldScape3DMaterial::_update_maps() {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	LOG(EXTREME, "Updating maps in shader");
 
 	WorldScape3DData *data = _terrain->get_data();
@@ -570,7 +570,7 @@ void WorldScape3DMaterial::_update_maps() {
 
 // Called from signal connected in WorldScape3D, emitted by texture_list
 void WorldScape3DMaterial::_update_texture_arrays() {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	Ref<WorldScape3DAssets> asset_list = _terrain->get_assets();
 	LOG(INFO, "Updating texture arrays in shader");
 	if (asset_list.is_null() || !asset_list->is_initialized()) {
@@ -892,7 +892,7 @@ Error WorldScape3DMaterial::save(const String &p_path) {
 // Add shader uniforms to properties. Hides uniforms that begin with _
 void WorldScape3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 	Resource::_get_property_list(p_list);
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	List<PropertyInfo> param_list;
 	if (_shader_override_enabled && _shader_override.is_valid()) {
 		// Get shader parameters from custom shader

--- a/modules/worldscape_3d/worldscape_3d_mesher.cpp
+++ b/modules/worldscape_3d/worldscape_3d_mesher.cpp
@@ -351,7 +351,7 @@ void WorldScape3DMesher::destroy() {
 }
 
 void WorldScape3DMesher::snap(const Vector3 &p_tracked_pos) {
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	const real_t mesh_density = _terrain->get_vertex_spacing();
 	Vector3 pos = Vector3{ 0.f, 0.f, 0.f };
 
@@ -429,7 +429,7 @@ void WorldScape3DMesher::snap(const Vector3 &p_tracked_pos) {
 
 // Iterates over every instance of every mesh and updates all properties.
 void WorldScape3DMesher::update() {
-	IS_INIT(VOID);
+	IS_INIT(WS3D_RETURN_VOID);
 	if (!_terrain->is_inside_world()) {
 		LOG(DEBUG, "WorldScape3D's world3D is null");
 		return;
@@ -479,7 +479,7 @@ void WorldScape3DMesher::update() {
 // Iterates over all meshes and updates their AABBs
 // All instances of each mesh inherit the updated AABB
 void WorldScape3DMesher::update_aabbs() {
-	IS_DATA_INIT(VOID);
+	IS_DATA_INIT(WS3D_RETURN_VOID);
 	real_t cull_margin = _terrain->get_cull_margin();
 	Vector2 height_range = _terrain->get_data()->get_height_range();
 	height_range.y += Math::abs(height_range.x);


### PR DESCRIPTION
Urgent fix to fix cross-compiling the editor on Linux for Windows.

Worldscape defined a `VOID` macro in its constants header, which conflicts with MinGW's windows SDK, causing compilation to fail due to loss of common types like `CHAR`.

This prevents the Windows Editor specifically from being able to be compiled on a Linux host, preventing our release infrastructure from working.

~Also added a GH Action for building the Editor with MinGW to prevent issues like this from happening again in the future. As the existing GH Action that tests MinGW only compiles the release template, not the editor. Which is why this was not caught during review and testing of the Worldscape3D PR, as this was not an issue with MSVC, Clang, or GCC.~

Tested locally and I was able to compile the editor with MinGW with this fix.

I will be merging this as soon as all GHA jobs complete as this is currently holding up the 26.3 beta.

EDIT: The workflow that was added to build the editor using MinGW took an hour and a half.
I have removed that commit from this PR as that sort of compile time is completely unacceptable.

Going forward I want to explore other options for cross compiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build coverage by adding an Editor build using GCC/MinGW.
  * Improved reliability of WorldScape 3D initialization checks and early-exit handling across terrain editing, asset processing, collision, meshing, materials, and instancing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->