### PR TITLE
MCP: Fix scene_action connect not persisting signal connections

### DIFF
--- a/modules/mcp/mcp_tools.cpp
+++ b/modules/mcp/mcp_tools.cpp
@@ -517,9 +517,13 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 				if (script_res.is_valid()) {
 					_ensure_callback_exists(script_res->get_path(), method);
 				}
-				source->connect(sig, Callable(target, method));
-				should_save = true;
-				result.add_text("Connected signal '" + sig + "' to '" + method + "'");
+				Error err = source->connect(sig, Callable(target, method), CONNECT_PERSIST);
+				if (err != OK) {
+					result.set_error("Failed to connect signal '" + sig + "': " + itos(err));
+				} else {
+					should_save = true;
+					result.add_text("Connected signal '" + sig + "' to '" + method + "'");
+				}
 			}
 		}
 	} else if (action == "reparent") {


### PR DESCRIPTION
## Problem

The `scene_action` tool's `connect` action reported success ("Connected signal…") but never persisted the connection: no `[connection]` entry was written to the `.tscn` file (verified by grepping both existing and freshly created scenes). The connection existed only in memory for the running session, so AI agents wiring up signals got a misleading success message plus a generated callback stub while the actual wire-up silently vanished on save/reload.

## Root cause

`MCPTools::tool_scene_action()` connected signals with default flags:

```cpp
source->connect(sig, Callable(target, method));
```

`PackedScene::pack()` → `SceneState::_parse_connections()` skips every connection without `CONNECT_PERSIST` (`scene/resources/packed_scene.cpp:1086`), so the packed scene dropped it. The editor's Connections dialog sets this flag (`editor/scene/connections_dialog.cpp:950`); the MCP tool did not.

## Fix

- Pass `CONNECT_PERSIST` when connecting (`modules/mcp/mcp_tools.cpp`).
- Check `connect()`'s return value and surface an error instead of a success message on failure.

## Verification

Ran the editor binary headless as an MCP server and drove it over stdio JSON-RPC:

1. `initialize` handshake
2. `scene_action create` → fresh `res://test.tscn` (Node2D root)
3. `scene_action add` → Button child
4. `scene_action connect` → `pressed` → `on_pressed`

Before: `.tscn` contained no `[connection]` section.
After:

```
[connection signal="pressed" from="MyButton" to="." method="on_pressed"]
```
