### PR TITLE
reduces unnecessary narrow-phase collision checks and broadphase pair churn in scenes with large and overlapping shapes

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -94,6 +94,11 @@ public:
 		BVH_LOCKED_FUNCTION
 		tree.params_set_pairing_expansion(p_value);
 	}
+
+	void params_set_size_relative_margin(bool p_enable, real_t p_ratio = -1.0) {
+		BVH_LOCKED_FUNCTION
+		tree.params_set_size_relative_margin(p_enable, p_ratio);
+	}
 	/// @}
 
 	void set_pair_callback(PairCallback p_callback, void *p_userdata) {

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -90,11 +90,23 @@ public:
 		}
 	}
 
+	/// @brief Sets the margin by which leaf AABBs are expanded to keep collision
+	/// pairs alive between frames, reducing broadphase pair churn.
+	/// @param p_value Expansion margin in world units. A negative value restores
+	/// automatic expansion (when @c BVH_ALLOW_AUTO_EXPANSION is enabled).
 	void params_set_pairing_expansion(real_t p_value) {
 		BVH_LOCKED_FUNCTION
 		tree.params_set_pairing_expansion(p_value);
 	}
 
+	/// @brief Enables a size-relative pairing margin, where each item's expansion
+	/// scales with its own average extent (capped at the pairing expansion) instead
+	/// of scaling with its current pair count.
+	/// @details Keeps small objects from pairing with distant neighbors while still
+	/// giving large objects useful hysteresis.
+	/// @param p_enable Whether to use the size-relative margin.
+	/// @param p_ratio Fraction of an item's average extent used as its margin.
+	/// Negative values leave the current ratio unchanged.
 	void params_set_size_relative_margin(bool p_enable, real_t p_ratio = -1.0) {
 		BVH_LOCKED_FUNCTION
 		tree.params_set_size_relative_margin(p_enable, p_ratio);

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -115,7 +115,11 @@ bool item_move(BVHHandle p_handle, const BOUNDS &p_aabb) {
 		if (_size_relative_margin) {
 			// Margin proportional to object size (capped), so small objects don't
 			// pair with far-away neighbors while large ones still get hysteresis.
-			const real_t extent = (p_aabb.size.x + p_aabb.size.y) * 0.5;
+			real_t extent = 0.0;
+			for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+				extent += p_aabb.size[axis];
+			}
+			extent /= POINT::AXIS_COUNT;
 			abb.expand(MIN(_pairing_expansion, extent * _pairing_expansion_ratio));
 		} else {
 			// scale the pairing expansion by the number of pairs.

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -112,8 +112,15 @@ bool item_move(BVHHandle p_handle, const BOUNDS &p_aabb) {
 
 #ifdef BVH_EXPAND_LEAF_AABBS
 	if (USE_PAIRS) {
-		// scale the pairing expansion by the number of pairs.
-		abb.expand(_pairs[ref_id].scale_expansion_margin(_pairing_expansion));
+		if (_size_relative_margin) {
+			// Margin proportional to object size (capped), so small objects don't
+			// pair with far-away neighbors while large ones still get hysteresis.
+			const real_t extent = (p_aabb.size.x + p_aabb.size.y) * 0.5;
+			abb.expand(MIN(_pairing_expansion, extent * _pairing_expansion_ratio));
+		} else {
+			// scale the pairing expansion by the number of pairs.
+			abb.expand(_pairs[ref_id].scale_expansion_margin(_pairing_expansion));
+		}
 	} else {
 		abb.expand(_pairing_expansion);
 	}
@@ -467,6 +474,13 @@ void params_set_pairing_expansion(real_t p_value) {
 	// calculate shrinking threshold
 	const real_t fudge_factor = 1.1;
 	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0 * fudge_factor;
+}
+
+void params_set_size_relative_margin(bool p_enable, real_t p_ratio) {
+	_size_relative_margin = p_enable;
+	if (p_ratio >= 0.0) {
+		_pairing_expansion_ratio = p_ratio;
+	}
 }
 
 // This routine is not just an enclose check, it also checks for special case of shrinkage

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -202,6 +202,14 @@ bool _auto_node_expansion = true;
 // we can either use auto mode, where the expansion is based on the root node size, or specify manually
 real_t _pairing_expansion = 0.1;
 
+// Size-relative pairing margin. When enabled, each object's margin is
+// (average AABB extent * _pairing_expansion_ratio), capped at _pairing_expansion.
+// This gives large objects (e.g. sensor areas) useful hysteresis while keeping
+// small objects (e.g. bullets) near-zero margin, so dense small-object scenes
+// don't suffer pair-count blow-up. Used by 2D physics.
+bool _size_relative_margin = false;
+real_t _pairing_expansion_ratio = 0.05;
+
 #ifdef BVH_ALLOW_AUTO_EXPANSION
 bool _auto_pairing_expansion = true;
 #endif

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2505,6 +2505,9 @@
 			Default solver bias for all physics contacts. Defines how much bodies react to enforce contact separation. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS].
 			Individual shapes can have a specific bias value (see [member Shape2D.custom_solver_bias]).
 		</member>
+		<member name="physics/2d/solver/pairing_expansion" type="float" setter="" getter="" default="25.0">
+			Maximum broadphase pairing margin, in pixels. Each object's collision pairs are kept alive within a margin that scales with its size (up to this maximum), so large moving objects (such as big [Area2D] sensors) re-pair less often, improving performance in scenes with many large overlapping shapes. Small objects keep a proportionally tiny margin so dense scenes do not accumulate excess pairs. Set to [code]0[/code] to disable and use the legacy pair-count-based margin.
+		</member>
 		<member name="physics/2d/solver/solver_iterations" type="int" setter="" getter="" default="16">
 			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS].
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2507,6 +2507,7 @@
 		</member>
 		<member name="physics/2d/solver/pairing_expansion" type="float" setter="" getter="" default="25.0">
 			Maximum broadphase pairing margin, in pixels. Each object's collision pairs are kept alive within a margin that scales with its size (up to this maximum), so large moving objects (such as big [Area2D] sensors) re-pair less often, improving performance in scenes with many large overlapping shapes. Small objects keep a proportionally tiny margin so dense scenes do not accumulate excess pairs. Set to [code]0[/code] to disable and use the legacy pair-count-based margin.
+			[b]Note:[/b] This value is read when a physics space is created, so changing it at runtime does not affect existing physics spaces.
 		</member>
 		<member name="physics/2d/solver/solver_iterations" type="int" setter="" getter="" default="16">
 			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS].

--- a/modules/godot_physics_2d/godot_area_pair_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_pair_2d.cpp
@@ -41,7 +41,7 @@
 
 bool GodotAreaPair2D::setup(real_t p_step) {
 	bool result = false;
-	if (area->collides_with(body) && GodotCollisionSolver2D::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), nullptr, this)) {
+	if (area->collides_with(body) && body->get_shape_tight_aabb(body_shape).intersects(area->get_shape_tight_aabb(area_shape), true) && GodotCollisionSolver2D::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), nullptr, this)) {
 		result = true;
 	}
 
@@ -130,7 +130,7 @@ GodotAreaPair2D::~GodotAreaPair2D() {
 bool GodotArea2Pair2D::setup(real_t p_step) {
 	bool result_a = area_a->collides_with(area_b);
 	bool result_b = area_b->collides_with(area_a);
-	if ((result_a || result_b) && !GodotCollisionSolver2D::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), nullptr, this)) {
+	if ((result_a || result_b) && !(area_a->get_shape_tight_aabb(shape_a).intersects(area_b->get_shape_tight_aabb(shape_b), true) && GodotCollisionSolver2D::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), nullptr, this))) {
 		result_a = false;
 		result_b = false;
 	}

--- a/modules/godot_physics_2d/godot_broad_phase_2d.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d.h
@@ -72,5 +72,7 @@ public:
 
 	virtual void update() = 0;
 
+	virtual void set_pairing_expansion(real_t p_expansion) {}
+
 	virtual ~GodotBroadPhase2D();
 };

--- a/modules/godot_physics_2d/godot_broad_phase_2d.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d.h
@@ -72,6 +72,12 @@ public:
 
 	virtual void update() = 0;
 
+	/// @brief Sets the broadphase pairing margin used to keep collision pairs alive
+	/// between frames, reducing pair churn for large or overlapping shapes.
+	/// @details Read once when a physics space is created (see GodotSpace2D). The base
+	/// implementation is a no-op; backends that support it override this.
+	/// @param p_expansion Maximum pairing margin in pixels. Values <= 0 disable the
+	/// feature and fall back to the backend's default margin behavior.
 	virtual void set_pairing_expansion(real_t p_expansion) {}
 
 	virtual ~GodotBroadPhase2D();

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.cpp
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.cpp
@@ -121,6 +121,19 @@ void GodotBroadPhase2DBVH::update() {
 	bvh.update();
 }
 
+void GodotBroadPhase2DBVH::set_pairing_expansion(real_t p_expansion) {
+	if (p_expansion <= 0.0) {
+		// Disabled: keep the BVH's stock pair-count margin scaling.
+		return;
+	}
+	// Use a size-relative margin (capped at p_expansion) instead of the BVH's
+	// pair-count scaling: large objects (e.g. sensor areas) get useful hysteresis
+	// so they don't re-pair every frame, while small objects keep a tiny margin so
+	// dense small-object scenes don't blow up their pair counts.
+	bvh.params_set_pairing_expansion(p_expansion);
+	bvh.params_set_size_relative_margin(true);
+}
+
 GodotBroadPhase2D *GodotBroadPhase2DBVH::_create() {
 	return memnew(GodotBroadPhase2DBVH);
 }

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.cpp
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.cpp
@@ -124,6 +124,7 @@ void GodotBroadPhase2DBVH::update() {
 void GodotBroadPhase2DBVH::set_pairing_expansion(real_t p_expansion) {
 	if (p_expansion <= 0.0) {
 		// Disabled: keep the BVH's stock pair-count margin scaling.
+		bvh.params_set_size_relative_margin(false);
 		return;
 	}
 	// Use a size-relative margin (capped at p_expansion) instead of the BVH's

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
@@ -101,6 +101,8 @@ public:
 
 	virtual void update() override;
 
+	virtual void set_pairing_expansion(real_t p_expansion) override;
+
 	static GodotBroadPhase2D *_create();
 	GodotBroadPhase2DBVH();
 };

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
@@ -101,6 +101,11 @@ public:
 
 	virtual void update() override;
 
+	/// @brief Configures the BVH to use a size-relative pairing margin capped at
+	/// @p p_expansion, so large objects gain hysteresis while small objects keep a
+	/// tiny margin.
+	/// @param p_expansion Maximum pairing margin in pixels. Values <= 0 leave the
+	/// BVH's default pair-count-based margin scaling in place.
 	virtual void set_pairing_expansion(real_t p_expansion) override;
 
 	static GodotBroadPhase2D *_create();

--- a/modules/godot_physics_2d/godot_collision_object_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_object_2d.cpp
@@ -180,6 +180,7 @@ void GodotCollisionObject2D::_update_shapes() {
 		Rect2 shape_aabb = s.shape->get_aabb();
 		Transform2D xform = transform * s.xform;
 		shape_aabb = xform.xform(shape_aabb);
+		s.aabb_tight = shape_aabb;
 		shape_aabb.grow_by((s.aabb_cache.size.x + s.aabb_cache.size.y) * 0.5 * 0.05);
 		s.aabb_cache = shape_aabb;
 
@@ -208,6 +209,7 @@ void GodotCollisionObject2D::_update_shapes_with_motion(const Vector2 &p_motion)
 		Transform2D xform = transform * s.xform;
 		shape_aabb = xform.xform(shape_aabb);
 		shape_aabb = shape_aabb.merge(Rect2(shape_aabb.position + p_motion, shape_aabb.size)); //use motion
+		s.aabb_tight = shape_aabb;
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {

--- a/modules/godot_physics_2d/godot_collision_object_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_object_2d.cpp
@@ -208,8 +208,8 @@ void GodotCollisionObject2D::_update_shapes_with_motion(const Vector2 &p_motion)
 		Rect2 shape_aabb = s.shape->get_aabb();
 		Transform2D xform = transform * s.xform;
 		shape_aabb = xform.xform(shape_aabb);
-		shape_aabb = shape_aabb.merge(Rect2(shape_aabb.position + p_motion, shape_aabb.size)); //use motion
 		s.aabb_tight = shape_aabb;
+		shape_aabb = shape_aabb.merge(Rect2(shape_aabb.position + p_motion, shape_aabb.size)); //use motion
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -64,7 +64,8 @@ private:
 		Transform2D xform;
 		Transform2D xform_inv;
 		GodotBroadPhase2D::ID bpid = 0;
-		Rect2 aabb_cache; ///< For rayqueries
+		Rect2 aabb_cache; ///< Grown, for broadphase and rayqueries
+		Rect2 aabb_tight; ///< Ungrown world AABB, for narrow-phase reject
 		GodotShape2D *shape = nullptr;
 		bool disabled = false;
 		bool one_way_collision = false;
@@ -135,6 +136,10 @@ public:
 	_FORCE_INLINE_ const Rect2 &get_shape_aabb(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
+	}
+	_FORCE_INLINE_ const Rect2 &get_shape_tight_aabb(int p_index) const {
+		CRASH_BAD_INDEX(p_index, shapes.size());
+		return shapes[p_index].aabb_tight;
 	}
 
 	_FORCE_INLINE_ const Transform2D &get_transform() const { return transform; }

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -1230,6 +1230,7 @@ GodotSpace2D::GodotSpace2D() {
 	broadphase = GodotBroadPhase2D::create_func();
 	broadphase->set_pair_callback(_broadphase_pair, this);
 	broadphase->set_unpair_callback(_broadphase_unpair, this);
+	broadphase->set_pairing_expansion(GLOBAL_GET("physics/2d/solver/pairing_expansion"));
 
 	direct_access = memnew(GodotPhysicsDirectSpaceState2D);
 	direct_access->space = this;

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -925,6 +925,7 @@ PhysicsServer2D::PhysicsServer2D() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_max_allowed_penetration", PROPERTY_HINT_RANGE, "0.01,10,0.01,or_greater"), 0.3);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/default_contact_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.8);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/default_constraint_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.2);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/pairing_expansion", PROPERTY_HINT_RANGE, "0,200,0.1,or_greater,suffix:px"), 25.0);
 }
 
 PhysicsServer2D::~PhysicsServer2D() {


### PR DESCRIPTION
It made a slight performance increase.

BEFORE:
```
[bench] fps=143 steps/s=60 max_iter=2.40ms pairs=11163 enters/s=4113 exits/s=4154 hits=4990
[bench] fps=142 steps/s=60 max_iter=2.22ms pairs=10807 enters/s=3466 exits/s=3367 hits=6585
[bench] fps=142 steps/s=60 max_iter=2.39ms pairs=11072 enters/s=3318 exits/s=3299 hits=8199
[bench] fps=139 steps/s=60 max_iter=2.39ms pairs=10747 enters/s=3709 exits/s=3708 hits=9749
[bench] fps=140 steps/s=60 max_iter=2.12ms pairs=10896 enters/s=3900 exits/s=3935 hits=11381
[bench] fps=143 steps/s=60 max_iter=2.61ms pairs=11350 enters/s=3898 exits/s=3886 hits=13098
[bench] RESULT avg_max_iter_ms=2.436 avg_pairs=10984 avg_steps_per_s=60.2 avg_fps=142 enters=110799 exits=110774 hits=9800
```
AFTER:
```
[bench] fps=142 steps/s=60 max_iter=2.17ms pairs=11641 enters/s=4269 exits/s=4288 hits=4975
[bench] fps=142 steps/s=60 max_iter=2.16ms pairs=11342 enters/s=3334 exits/s=3297 hits=6592
[bench] fps=141 steps/s=61 max_iter=2.11ms pairs=11565 enters/s=3327 exits/s=3302 hits=8209
[bench] fps=142 steps/s=61 max_iter=2.03ms pairs=11283 enters/s=3748 exits/s=3770 hits=9752
[bench] fps=142 steps/s=60 max_iter=2.37ms pairs=11441 enters/s=3785 exits/s=3801 hits=11404
[bench] fps=143 steps/s=60 max_iter=2.25ms pairs=11948 enters/s=3814 exits/s=3765 hits=13093
[bench] RESULT avg_max_iter_ms=2.220 avg_pairs=11511 avg_steps_per_s=60.2 avg_fps=141 enters=110800 exits=110770 hits=9822
```

per this LLM generated benchmark: 
[bench.zip](https://github.com/user-attachments/files/31713754/bench.zip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `physics/2d/solver/pairing_expansion` project setting, configurable from 0 to 100 pixels, with a default of 25 pixels.
  * Improved 2D physics broad-phase pairing by scaling margins relative to object size, with configurable expansion limits. A value of 0 retains the previous behavior.

* **Bug Fixes**
  * Added tighter bounds checks before solving area-body and area-area collisions, preventing invalid collision results.
  * Improved shape-bound tracking for more accurate collision filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->