### PR TITLE
Fix decreasing `ReflectionProbe`'s intensity property below `1.0` not reducing the strength of its ambient light condition

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -971,6 +971,7 @@ void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal
 
 			ambient_out.rgb = hvec3(textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_amb_vec, reflections.data[ref_index].index), MAX_ROUGHNESS_LOD).rgb);
 			ambient_out.rgb *= half(reflections.data[ref_index].exposure_normalization);
+			ambient_out.rgb *= half(reflections.data[ref_index].intensity);
 			ambient_out.a = ambient_blend;
 			ambient_out.rgb *= ambient_out.a;
 			ambient_accum += ambient_out;
@@ -980,6 +981,7 @@ void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal
 			half ambient_blend = max(half(0.0), blend - ambient_accum.a);
 
 			ambient_out.rgb = hvec3(reflections.data[ref_index].ambient);
+			ambient_out.rgb *= half(reflections.data[ref_index].intensity);
 			ambient_out.a = ambient_blend;
 			ambient_out.rgb *= ambient_out.a;
 			ambient_accum += ambient_out;


### PR DESCRIPTION
The Forward+/Mobile shader never multiplies the ambient lighting contribution by `reflections.data[ref_index].intensity`. As a result, reducing a `ReflectionProbe`'s intensity below `1.0` only affects reflected light, while the ambient contribution remains unchanged. This PR applies the intensity multiplier to the ambient contribution as well.

<table>
  <tr>
    <th align="center">Before (Forward+/Mobile)</th>
    <th align="center">After (Forward+/Mobile)</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/f1e32e14-32fc-440c-a1fc-1db092672d51" width="100%" alt="Before View" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/07b92dc3-aa55-47c1-91ab-eb1c28cd9503" width="100%" alt="After View" />
    </td>
  </tr>
</table>

### MRP

[test_reflection_probe_intensity.zip](https://github.com/user-attachments/files/31714865/test_reflection_probe_intensity.zip)


### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃