### PR TITLE
Fix `EditorSpinSlider::get_minimum_size()` & `EditorSpinSlider::_draw_spin_slider()`

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -41,6 +41,7 @@
 #include "core/input/input.h"
 #include "core/math/expression.h"
 #include "core/os/keyboard.h"
+#include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/theme/theme_db.h"
@@ -526,13 +527,26 @@ Size2 EditorSpinSlider::get_minimum_size() const {
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("LineEdit"));
 
 	Size2 ms = sb->get_minimum_size();
+
+	const int sep = 4 * EDSCALE + sb->get_offset().x;
+	const int label_width = font->get_string_size(label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width;
+
+	ms.width += label_width + sep;
+
+	if (!hide_slider && editing_integer) {
+		Ref<Texture2D> updown = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
+		ms.width += updown->get_width();
+	}
+
 	ms.height += font->get_height(font_size);
+	ms.height = MAX(ms.height, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor)));
 
 	return ms;
 }
 
 void EditorSpinSlider::set_hide_slider(bool p_hide) {
 	hide_slider = p_hide;
+	update_minimum_size();
 	queue_redraw();
 }
 
@@ -546,6 +560,7 @@ void EditorSpinSlider::set_editing_integer(bool p_editing_integer) {
 	}
 
 	editing_integer = p_editing_integer;
+	update_minimum_size();
 	queue_redraw();
 }
 
@@ -555,6 +570,7 @@ bool EditorSpinSlider::is_editing_integer() const {
 
 void EditorSpinSlider::set_label(const String &p_label) {
 	label = p_label;
+	update_minimum_size();
 	queue_redraw();
 }
 
@@ -657,6 +673,7 @@ void EditorSpinSlider::set_read_only(bool p_enable) {
 		value_input->release_focus();
 	}
 
+	update_minimum_size();
 	queue_redraw();
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
This PR solves 2 problems.

### The first issue:
Firstly, `EditorSpinSlider::get_minimum_size()` only accounts for the stylebox & the up/down buttons when reporting its minimum width. As a result, the control can report a minimum width that is too small to display its contents correctly. When the control is constrained by a layout container (such as in sub-inspectors), the numeric value overlaps the up/down buttons because no width is reserved for the label, separator or editable numeric text.
This issue became noticeable when four `EditorSpinSlider`s were laid out horizontally in `Vector4/Vector4i` property editors, but it also affects standalone `EditorSpinSlider`s when their width is reduced sufficiently.

### The first issue in Editor:
<img width="163" height="289" alt="image" src="https://github.com/user-attachments/assets/aed1ca0b-6661-4887-9261-31f7ceabfc70" />
<img width="196" height="277" alt="image" src="https://github.com/user-attachments/assets/fbecb9d0-33a8-4229-89fa-971b7bc67394" />

### The solution for the first issue in Editor:
<img width="228" height="484" alt="image" src="https://github.com/user-attachments/assets/2ab3bd07-5428-4fa9-b3a7-0f6c446b982b" />

### The second issue:
Secondly, although the minimum size change prevents the value from overlapping the up/down buttons under normal layouts, the numeric text could still extend into the arrow button area if the control was made narrower than its minimum size or if the value contained enough digits. This happened because `EditorSpinSlider::_draw_spin_slider()` manually drew each glyph without limiting the drawing region. As a result, the value continued rendering underneath the up/down buttons instead of stopping at their left edge.
### The second issue in Editor:
<img width="1366" height="723" alt="image" src="https://github.com/user-attachments/assets/9d817735-f43c-45e1-babd-e0686636f99b" />

### The solution for the second issue in Editor:
https://github.com/user-attachments/assets/747c16b1-6138-4b10-8030-98af80d965be


https://github.com/user-attachments/assets/33ff3cc6-0161-4fe0-9f22-a1464a8f0937

### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor spin slider sizing to account for labels, separators, conditional up/down icons, and the editor’s minimum property height.
  * Ensured slider dimensions update correctly when visibility, integer-editing mode, labels, or read-only state change.
  * Improved layout consistency and helped prevent clipped or overly constrained inspector controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->