### PR TITLE
MCP: Fix scene_action connect persistence and callback stubs

### DIFF
--- a/modules/mcp/mcp_tools.cpp
+++ b/modules/mcp/mcp_tools.cpp
@@ -57,6 +57,7 @@
 
 #ifdef MODULE_GDSCRIPT_ENABLED
 #include "modules/gdscript/gdscript_parser.h"
+#include "modules/gdscript/gdscript_tokenizer.h"
 #endif
 
 #include "core/doc_data.h"
@@ -134,7 +135,9 @@ Error MCPTools::_ensure_callback_exists(const String &p_script_path, const Strin
 		content += "\n";
 	}
 	content += "\nfunc " + p_callback_name + "():\n\tpass # Added by MCP\n";
-	f->store_string(content);
+	if (!f->store_string(content)) {
+		return ERR_FILE_CANT_WRITE;
+	}
 	return OK;
 }
 
@@ -201,7 +204,7 @@ Array MCPTools::get_tool_definitions() {
 		props["value"] = MCPSchemaBuilder::make_object_property("Value (supports numbers, strings, and objects like {x:0, y:0})");
 		props["signal"] = MCPSchemaBuilder::make_string_property("Signal name");
 		props["target_node"] = MCPSchemaBuilder::make_string_property("Target node path for connect/reparent");
-		props["method"] = MCPSchemaBuilder::make_string_property("Method name for connect");
+		props["method"] = MCPSchemaBuilder::make_string_property("Valid GDScript method identifier for connect");
 		props["instance_path"] = MCPSchemaBuilder::make_string_property("Path to scene to instance");
 
 		Array required;
@@ -503,8 +506,23 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 		String sig = p_args.get("signal", "");
 		String target_path = p_args.get("target_node", ".");
 		String method = p_args.get("method", "");
+		bool valid_method = method.is_valid_unicode_identifier();
+#ifdef MODULE_GDSCRIPT_ENABLED
+		if (valid_method) {
+			GDScriptTokenizerText tokenizer;
+			tokenizer.set_source_code(method);
+			GDScriptTokenizer::Token identifier = tokenizer.scan();
+			GDScriptTokenizer::Token end = tokenizer.scan();
+			if (end.type == GDScriptTokenizer::Token::NEWLINE) {
+				end = tokenizer.scan();
+			}
+			valid_method = identifier.is_identifier() && end.type == GDScriptTokenizer::Token::TK_EOF;
+		}
+#endif
 		if (sig.is_empty() || method.is_empty()) {
 			result.set_error("Missing signal or method");
+		} else if (!valid_method) {
+			result.set_error("Invalid method identifier: " + method);
 		} else {
 			Node *source = (node_path == "." || node_path.is_empty()) ? root : root->get_node_or_null(node_path);
 			Node *target = (target_path == "." || target_path.is_empty()) ? root : root->get_node_or_null(target_path);
@@ -514,12 +532,21 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 				result.set_error("Signal '" + sig + "' does not exist on " + source->get_class());
 			} else {
 				Ref<Resource> script_res = target->get_script();
-				if (script_res.is_valid()) {
-					_ensure_callback_exists(script_res->get_path(), method);
+				Error callback_err = OK;
+				if (script_res.is_valid() && !target->has_method(method)) {
+					callback_err = _ensure_callback_exists(script_res->get_path(), method);
 				}
-				source->connect(sig, Callable(target, method));
-				should_save = true;
-				result.add_text("Connected signal '" + sig + "' to '" + method + "'");
+				if (callback_err != OK) {
+					result.set_error("Failed to create callback '" + method + "': " + itos(callback_err));
+				} else {
+					Error err = source->connect(sig, Callable(target, method), CONNECT_PERSIST);
+					if (err != OK) {
+						result.set_error("Failed to connect signal '" + sig + "': " + itos(err));
+					} else {
+						should_save = true;
+						result.add_text("Connected signal '" + sig + "' to '" + method + "'");
+					}
+				}
 			}
 		}
 	} else if (action == "reparent") {
@@ -542,8 +569,10 @@ MCPTools::ToolResult MCPTools::tool_scene_action(const Dictionary &p_args) {
 		Ref<PackedScene> new_scene;
 		new_scene.instantiate();
 		if (new_scene.is_valid()) {
-			new_scene->pack(root);
-			Error err = ResourceSaver::save(new_scene, normalized_scene);
+			Error err = new_scene->pack(root);
+			if (err == OK) {
+				err = ResourceSaver::save(new_scene, normalized_scene);
+			}
 			if (err != OK) {
 				result.set_error("Failed to save scene: " + itos(err));
 			}


### PR DESCRIPTION
## What this fixes

I found these issues while testing [Redot-Engine/redot-engine#1358](https://github.com/Redot-Engine/redot-engine/pull/1358), which changes how the MCP host and game process shut down.

The changes in that PR are fine and these bugs are unrelated to it. Testing it just led me to run a more complete end-to-end pass over every MCP tool, which exposed a couple of older problems in `scene_action.connect`.

Both bugs appear to date back to my original MCP implementation.

## What I found

### Signal connections were not actually being saved

`scene_action.connect` returned a successful response such as:

> Connected signal 'pressed' to 'on_pressed'

However, the connection was only registered in memory. No `[connection]` entry was written to the `.tscn`, so it disappeared after reloading the scene.

This was caused by calling `connect()` without `CONNECT_PERSIST`. `PackedScene::pack()` intentionally ignores connections that do not have that flag.

This one was particularly surprising because I have tested this workflow before and received successful responses. The success message and temporary in-memory connection made it look like everything had worked, so the problem was easy to miss unless the scene file was inspected or reloaded immediately. The symptoms also appeared inconsistent during initial testing, but tracing the save path confirmed the missing persistence flag.

### Native methods could generate conflicting GDScript stubs

While retesting the first fix, I found that connecting a signal to a native method such as `queue_free` caused MCP to append this to the target script:

```gdscript
func queue_free():
    pass # Added by MCP
```

That conflicts with `Node.queue_free()` and causes a parse failure when native-method override warnings are treated as errors.

The same behavior could also unnecessarily duplicate a method inherited from another script.

## Changes

- Use `CONNECT_PERSIST` for connections created through `scene_action.connect`.
- Check the result of `connect()` instead of always reporting success.
- Check `target->has_method()` before generating a callback stub.
  - Native methods are used directly.
  - Existing custom and inherited methods are not duplicated.
  - Missing custom callbacks are still generated.
- Validate callback names as GDScript identifiers before modifying any files.
- Return an MCP error if callback generation or writing fails.
- Check `PackedScene::pack()` before saving the scene.

## Testing

I rebuilt the editor and tested the changes through the MCP JSON-RPC interface using disposable projects.

Confirmed:

- Connections persist immediately in newly created scenes.
- Connections persist immediately in pre-existing scenes.
- Connections remain after reloading the scene.
- Connecting to native `queue_free` does not modify the attached script.
- Existing custom methods are not duplicated.
- Missing custom methods receive exactly one generated callback.
- The resulting GDScript passes parser validation.
- All generated connections appear as `[connection]` entries in the `.tscn`.
- Malformed and reserved callback names are rejected without modifying either file.

A full end-to-end MCP pass was also completed while investigating this:

- `project_config`: all 11 actions
- `code_intel`: all 4 actions
- `scene_action`: all 8 actions
- `resource_action`: all 5 actions
- `game_control`: all 6 actions

## AI disclosure

AI tools were used to assist with investigating the MCP behavior, tracing the relevant engine code, implementing the fixes, creating disposable regression tests, and drafting this PR description.

I reviewed the final changes, understand the issues being fixed and why the changes work, and manually verified the corrected behavior before submission. No external or proprietary code was used.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid method names are now rejected with a clear error instead of creating unsuccessful connections.
  - Connection setup and callback-creation failures are now reported directly, making errors easier to understand and troubleshoot.
  - Connections created through the scene action are now saved persistently.
  - Scene changes are no longer saved when scene packaging fails, preventing incomplete or invalid saves.
  - Callback updates now report file-write failures instead of proceeding as though the operation succeeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


