### PR TITLE
Make ProjectList visually consistent with the ProjectManager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -240,7 +240,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		main_vbox->add_theme_constant_override("separation", top_bar_separation);
 
 		background_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("Background"), EditorStringName(EditorStyles)));
-		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("TabContainer")));
+		main_view_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("panel"), SNAME("ProjectManager")));
 
 		title_bar_logo->set_button_icon(get_editor_theme_icon(SNAME("TitleBarLogo")));
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -730,6 +730,19 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 			} else {
 				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
 			}
+
+			// Project Manager panel.
+
+			p_config.project_manager_panel_style = p_config.base_style->duplicate();
+			p_config.project_manager_panel_style->set_bg_color(p_config.dark_color_1);
+			p_config.project_manager_panel_style->set_border_color(p_config.dark_color_2);
+
+			if (p_config.draw_extra_borders) {
+				p_config.project_manager_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.project_manager_panel_style->set_border_color(p_config.extra_border_color_1);
+			} else {
+				p_config.project_manager_panel_style->set_border_width_all(0);
+			}
 		}
 	}
 }
@@ -1887,6 +1900,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 	// Project manager.
 	{
 		p_theme->set_stylebox("project_list", "ProjectManager", p_config.tree_panel_style);
+		p_theme->set_stylebox("panel", "ProjectManager", p_config.project_manager_panel_style);
 		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
 		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
@@ -1897,24 +1911,27 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 
 			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
 			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
+			const int tag_corner_radius = Math::round(p_config.corner_radius * EDSCALE);
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, p_config.corner_radius);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, p_config.corner_radius);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, tag_corner_radius);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, tag_corner_radius);
 			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_hover->duplicate();
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, tag_corner_radius);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, tag_corner_radius);
 			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_pressed->duplicate();
 			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
 			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius(CORNER_TOP_RIGHT, tag_corner_radius);
+			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, tag_corner_radius);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
 		}
 	}

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -157,6 +157,7 @@ class EditorThemeManager {
 		Ref<StyleBoxFlat> panel_container_style;
 		Ref<StyleBoxFlat> content_panel_style;
 		Ref<StyleBoxFlat> tree_panel_style;
+		Ref<StyleBoxFlat> project_manager_panel_style;
 
 		Vector2 widget_margin;
 


### PR DESCRIPTION
A little something that I found when working on something completely unrelated. Makes ProjectList visually consistent with the ProjectManager

### 26.3 beta 1:
<img width="1366" height="603" alt="image" src="https://github.com/user-attachments/assets/a95b01a1-a1d7-4b53-8689-81e20d3e1a5a" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/794a4fbc-601e-4324-8069-8f0543c90ae6" />

### This PR:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4ae42171-ea14-413b-b4cd-7865759f83bb" />
<img width="1366" height="605" alt="image" src="https://github.com/user-attachments/assets/9cea5e69-cbdf-4eb3-bc0f-669163ba1a0c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Visual Updates

* Updated the Project Manager panel with dedicated theme styling.
* Refined panel background and border colors, including support for optional extra editor borders.
* Project tag buttons now consistently follow the configured corner-radius setting across their visual states.
* Improved consistency between Project Manager styling and the active editor theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->