### PR TITLE
Fix Cannot access inner struct of a trait or assign struct as a type alias

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5216,6 +5216,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 
 				case GDScriptParser::ClassNode::Member::STRUCT: {
 					p_identifier->set_datatype(member.get_datatype());
+					p_identifier->is_constant = true;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
 					return;
 				}
@@ -5790,7 +5791,9 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 
 		GDScriptParser::DataType base_type = p_subscript->base->get_datatype();
 
-		if (base_type.is_constant && base_type.kind == GDScriptParser::DataType::TRAIT) {
+		const GDScriptParser::ClassNode *trait_class = base_type.class_type;
+		const bool is_trait_struct = trait_class != nullptr && trait_class->has_member(p_subscript->attribute->name) && trait_class->get_member(p_subscript->attribute->name).type == GDScriptParser::ClassNode::Member::STRUCT;
+		if (base_type.is_constant && base_type.kind == GDScriptParser::DataType::TRAIT && !is_trait_struct) {
 			push_error(vformat(R"*(Cannot access a trait's members directly; access through a class that uses it instead.)*"), p_subscript->attribute);
 			return;
 		}
@@ -7707,6 +7710,10 @@ void GDScriptAnalyzer::extend_class(GDScriptParser::ClassNode *p_class, const GD
 				case GDScriptParser::ClassNode::Member::ENUM_VALUE:
 					// Copied over trait enum_values.
 					p_class->add_member(trait_member.enum_value);
+					break;
+				case GDScriptParser::ClassNode::Member::STRUCT:
+					// Copied over trait struct.
+					p_class->add_member(trait_member.m_struct);
 					break;
 				case GDScriptParser::ClassNode::Member::SIGNAL:
 					// Copied over trait signal.

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_struct_access.gd
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_struct_access.gd
@@ -1,0 +1,26 @@
+const TraitStruct := FooTrait.Bar
+const ClassStruct := FooClass.Bar
+
+class FooClass:
+	struct Bar:
+		var value: String
+
+trait FooTrait:
+	struct Bar:
+		var value: String
+
+class FooTraitImpl:
+	uses FooTrait
+
+func test() -> void:
+	var direct_trait := FooTrait.Bar.new("direct trait")
+	var direct_class := FooClass.Bar.new("direct class")
+	var aliased_trait: TraitStruct = TraitStruct.new("aliased trait")
+	var aliased_class: ClassStruct = ClassStruct.new("aliased class")
+	var implemented_trait := FooTraitImpl.Bar.new("implemented trait")
+
+	print(direct_trait.value)
+	print(direct_class.value)
+	print(aliased_trait.value)
+	print(aliased_class.value)
+	print(implemented_trait.value)

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_struct_access.out
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_struct_access.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+direct trait
+direct class
+aliased trait
+aliased class
+implemented trait


### PR DESCRIPTION
Fixes #1372 

## Root cause:
- The analyzer rejected all direct trait member access before checking whether the member was a nested struct type.
- Nested struct references were assigned the correct datatype but weren’t marked as constant expressions, breaking aliases for both trait and class structs.

## Solution:
- Allow direct trait access only for nested structs; existing restrictions on trait functions and other members remain intact.
- Mark resolved struct member references as constant expressions.
- Added runtime coverage for direct construction, class/trait aliases, typed aliases, and trait implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed GDScript access to nested structs declared through traits, including direct and aliased references.
  - Struct members referenced through class identifiers are now correctly treated as constants.
  - Nested structs declared in traits are now available to classes that use those traits.
  - Preserved validation rules that restrict access to other unsupported trait members.

- **Tests**
  - Added coverage for constructing nested structs through classes and traits and accessing their fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->