### PR TITLE
Fix nullable struct fields defaulting to zero instead of null.

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2912,7 +2912,7 @@ void GDScriptAnalyzer::resolve_struct(GDScriptParser::StructNode *p_struct) {
 
 		if (field->initializer != nullptr && field->initializer->is_constant) {
 			f.default_value = field->initializer->reduced_value;
-		} else if (f.is_typed && f.type != Variant::NIL && f.type != Variant::STRUCT) {
+		} else if (!field_type.is_nullable && f.is_typed && f.type != Variant::NIL && f.type != Variant::STRUCT) {
 			Callable::CallError err;
 			Variant zero;
 			Variant::construct(f.type, zero, nullptr, 0, err);

--- a/modules/gdscript/tests/scripts/runtime/features/struct_nullable_field_defaults.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/struct_nullable_field_defaults.gd
@@ -1,0 +1,14 @@
+struct NullDefBox:
+	var i: int?
+	var vec2: Vector2?
+	var vec3: Vector3?
+	var typed: int
+	var initialized: int? = 5
+
+func test():
+	var box := NullDefBox.new()
+	print(box.i)
+	print(box.vec2)
+	print(box.vec3)
+	print(box.typed)
+	print(box.initialized)

--- a/modules/gdscript/tests/scripts/runtime/features/struct_nullable_field_defaults.out
+++ b/modules/gdscript/tests/scripts/runtime/features/struct_nullable_field_defaults.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+<null>
+<null>
+<null>
+0
+5


### PR DESCRIPTION
Fixes #1379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nullable typed fields in GDScript structs now default to an uninitialized value rather than the type’s zero value.
  * Nullable fields with explicit defaults continue to use those specified values.

* **Tests**
  * Added runtime coverage for nullable fields across several supported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->