### PR TITLE
Fix spacing in REDOT_AUTHORS.md & clean up core_builders.py

### DIFF
--- a/REDOT_AUTHORS.md
+++ b/REDOT_AUTHORS.md
@@ -35,10 +35,10 @@ name is available.
     Andevrs (tindrew)
     Arctis Fireblight
     ChocolateChipAussie (Logan-ReXDev)
-	DaveTheEggman
+    DaveTheEggman
     DAShoe1
     decryptedchaos
-	GeneralProtectionFault
+    GeneralProtectionFault
     George L Albany (spartan322)
     Jon (JoltedJon)
     McDubh (mcdubhghlas)

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,5 +1,6 @@
 """Functions used to generate source files during build time"""
 
+import sys
 from collections import OrderedDict
 from io import TextIOWrapper
 
@@ -95,94 +96,6 @@ inline constexpr unsigned char _certs_compressed[] = {{
 	{methods.format_buffer(buffer, 1)}
 }};
 """)
-
-
-def make_redot_authors_header(target, source, env):
-    SECTIONS = {
-        "Project Founders": "REDOT_AUTHORS_FOUNDERS",
-        "Lead Developer": "REDOT_AUTHORS_LEAD_DEVELOPERS",
-        "Project Manager": "REDOT_AUTHORS_PROJECT_MANAGERS",
-        "Developers": "REDOT_AUTHORS_DEVELOPERS",
-    }
-    buffer = methods.get_buffer(str(source[0]))
-    reading = False
-
-    with methods.generated_wrapper(str(target[0])) as file:
-
-        def close_section():
-            file.write("\tnullptr,\n};\n\n")
-
-        for line in buffer.decode().splitlines():
-            if line.startswith("    ") and reading:
-                file.write(f'\t"{methods.to_escaped_cstring(line).strip()}",\n')
-            elif line.startswith("## "):
-                if reading:
-                    close_section()
-                    reading = False
-                section = SECTIONS[line[3:].strip()]
-                if section:
-                    file.write(f"inline constexpr const char *{section}[] = {{\n")
-                    reading = True
-
-        if reading:
-            close_section()
-
-
-def make_authors_header(target, source, env):
-    SECTIONS = {
-        "Project Founders": "AUTHORS_FOUNDERS",
-        "Lead Developer": "AUTHORS_LEAD_DEVELOPERS",
-        "Project Manager": "AUTHORS_PROJECT_MANAGERS",
-        "Developers": "AUTHORS_DEVELOPERS",
-    }
-    buffer = methods.get_buffer(str(source[0]))
-    reading = False
-
-    with methods.generated_wrapper(str(target[0])) as file:
-
-        def close_section():
-            file.write("\tnullptr,\n};\n\n")
-
-        for line in buffer.decode().splitlines():
-            if line.startswith("    ") and reading:
-                file.write(f'\t"{methods.to_escaped_cstring(line).strip()}",\n')
-            elif line.startswith("## "):
-                if reading:
-                    close_section()
-                    reading = False
-                section = SECTIONS[line[3:].strip()]
-                if section:
-                    file.write(f"inline constexpr const char *{section}[] = {{\n")
-                    reading = True
-
-        if reading:
-            close_section()
-
-
-def make_donors_header(target, source, env):
-    SECTIONS = {"Donors": "DONORS_LIST"}
-    buffer = methods.get_buffer(str(source[0]))
-    reading = False
-
-    with methods.generated_wrapper(str(target[0])) as file:
-
-        def close_section():
-            file.write("\tnullptr,\n};\n\n")
-
-        for line in buffer.decode().splitlines():
-            if line.startswith("    ") and reading:
-                file.write(f'\t"{methods.to_escaped_cstring(line).strip()}",\n')
-            elif line.startswith("## "):
-                if reading:
-                    close_section()
-                    reading = False
-                section = SECTIONS.get(line[3:].strip())
-                if section:
-                    file.write(f"inline constexpr const char *{section}[] = {{\n")
-                    reading = True
-
-        if reading:
-            close_section()
 
 
 def make_license_header(target, source, env):
@@ -316,3 +229,73 @@ struct ComponentCopyright {{
                     to_raw += [line]
             file.write(f"{methods.to_raw_cstring(to_raw)},\n\n")
         file.write("};\n\n")
+
+
+def _make_list_header(target, source, sections):
+    """!Parses a Markdown file with '## Section' headers and indented list
+    items into a C header of `nullptr`-terminated string arrays.
+
+    target/source: SCons target/source lists, as passed by env.Run().
+    sections: dict mapping each expected Markdown section title (str) to
+        the C array name (str) to emit for it. Unrecognized '## ' headings
+        are reported and skipped rather than silently ignored or crashing.
+    """
+    buffer = methods.get_buffer(str(source[0]))
+    reading = False
+
+    with methods.generated_wrapper(str(target[0])) as file:
+
+        def close_section():
+            file.write("\tnullptr,\n};\n\n")
+
+        for line in buffer.decode().splitlines():
+            if reading and line[:1] in (" ", "\t") and line.strip():
+                file.write(f'\t"{methods.to_escaped_cstring(line.strip())}",\n')
+            elif line.startswith("## "):
+                if reading:
+                    close_section()
+                    reading = False
+                title = line[3:].strip()
+                section = sections.get(title)
+                if section:
+                    file.write(f"inline constexpr const char *{section}[] = {{\n")
+                    reading = True
+                else:
+                    print(
+                        f'WARNING: "{source[0]}" has unrecognized section "{title}", '
+                        "no entries will be generated for it.",
+                        file=sys.stderr,
+                    )
+
+        if reading:
+            close_section()
+
+
+def make_redot_authors_header(target, source, env):
+    _make_list_header(
+        target,
+        source,
+        {
+            "Project Founders": "REDOT_AUTHORS_FOUNDERS",
+            "Lead Developer": "REDOT_AUTHORS_LEAD_DEVELOPERS",
+            "Project Manager": "REDOT_AUTHORS_PROJECT_MANAGERS",
+            "Developers": "REDOT_AUTHORS_DEVELOPERS",
+        },
+    )
+
+
+def make_authors_header(target, source, env):
+    _make_list_header(
+        target,
+        source,
+        {
+            "Project Founders": "AUTHORS_FOUNDERS",
+            "Lead Developer": "AUTHORS_LEAD_DEVELOPERS",
+            "Project Manager": "AUTHORS_PROJECT_MANAGERS",
+            "Developers": "AUTHORS_DEVELOPERS",
+        },
+    )
+
+
+def make_donors_header(target, source, env):
+    _make_list_header(target, source, {"Donors": "DONORS_LIST"})


### PR DESCRIPTION
Fixes #1381 

This fixes the tabbing/spacing issue in the authors file, and also cleans up the script that parses it for the build.
The script would look, specifically, for 4 spaces, which I believe is sensible enough for Markdown format, but this is just to get into the About dialog in the engine.  The updated code also DRYs it out, there were 3 methods doing basically the same thing, so I separated that out to a helper function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unrecognized sections in contributor and donor lists now generate a warning instead of being silently ignored.

- **Documentation**
  - Standardized indentation in contributor documentation for consistent formatting.

- **Refactor**
  - Unified list-header processing to provide more consistent behavior while preserving the existing public interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->