### PR TITLE
Fix WorldScape3D terrain invalidation in editor plugin

### DIFF
--- a/modules/worldscape_3d/editor/worldscape_3d_editor.cpp
+++ b/modules/worldscape_3d/editor/worldscape_3d_editor.cpp
@@ -1064,9 +1064,9 @@ void WorldScape3DEditorPlugin::clear() {
 			}
 			terrain->clear_gizmos();
 		}
-		_editor->set_terrain(nullptr);
-		_ui->clear_picking();
 	}
+	_editor->set_terrain(nullptr);
+	_ui->clear_picking();
 	_region_gizmo->clear();
 }
 
@@ -1110,7 +1110,7 @@ EditorPlugin::AfterGUIInput WorldScape3DEditorPlugin::forward_3d_gui_input(Camer
 	}
 
 	auto terrain = _editor->get_terrain();
-	if (!terrain) {
+	if (!terrain || !ObjectDB::get_instance(terrain->get_instance_id())) {
 		return AfterGUIInput::AFTER_GUI_INPUT_PASS;
 	}
 


### PR DESCRIPTION
Fixes #1388 

The WorldScape3D invalidation done in the editor plugin clear() was incomplete, leaving behind dangling pointers that would allow 3D gui calls to be fowarded even if the node creation is undone.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when working with terrain in the 3D editor.
  - Prevented stale terrain references from being used after the terrain is no longer available.
  - Ensured terrain selection and picking state are properly reset when clearing the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->