### PR TITLE
Optimize copyright header updates by skipping unchanged files and improving memory usage

### DIFF
--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -64,6 +64,13 @@ for f in sys.argv[1:]:
         text = header.replace("$filename", fsingle)
     text += "\n"
 
+    # Most files already have the expected header. We should avoid reading and rebuilding
+    # their entire contents, which can be especially expensive for large files.
+    header_bytes = text.encode("utf-8")
+    with open(fname.strip(), "rb") as fileread:
+        if fileread.read(len(header_bytes)) == header_bytes:
+            continue
+
     # We now have the proper header, so we want to ignore the one in the original file
     # and potentially empty lines and badly formatted lines, while keeping comments that
     # come after the header, and then keep everything non-header unchanged.
@@ -71,6 +78,7 @@ for f in sys.argv[1:]:
     # In a second pass, we skip all consecutive comment lines starting with "/*",
     # then we can append the rest (step 2).
 
+    body = []
     with open(fname.strip(), "r", encoding="utf-8") as fileread:
         line = fileread.readline()
         header_done = False
@@ -86,12 +94,14 @@ for f in sys.argv[1:]:
             if line.find("/*") != 0:  # No more starting with a comment
                 header_done = True
                 if line.strip() != "":
-                    text += line
+                    body.append(line)
             line = fileread.readline()
 
         while line != "":  # Dump everything until EOF
-            text += line
+            body.append(line)
             line = fileread.readline()
+
+    text += "".join(body)
 
     # Write
     with open(fname.strip(), "w", encoding="utf-8", newline="\n") as filewrite:


### PR DESCRIPTION
After merging Worldscape 3D, `pre-commit` takes forever. On my Ryzen 9950X3D it was taking 124.9s to parse through and verify the copyright headers.

After diagnosing the problem, the Python script responsible was simply reading in each entire file and then rewrote the entire file back to disk after correcting the header in memory. Additionally, it was reading the file line by line and then repeatedly concatenating each line to a string in memory causing tons of unnecessary garbage generation.

This PR adds an initial check to make sure that the copyright header is in place, and if so, early returns.
A secondary performance enhancement is added where instead of continuously concatenating and replacing the same string, we instead store each line and then do a single join at the end.

This cut the time on my machine to parse the copyright headers down from 124.9s all the way to 0.05s, or more than over 6,000× faster...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved copyright-header processing to avoid rewriting files that already contain the correct header.
- Preserved existing file content more reliably when adding or updating headers.
- Reduced unnecessary file changes during repeated header-processing runs.
- Ensured generated headers are applied without incrementally altering preserved content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->