### PR TITLE
Add support for `trait super` calls in GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4529,7 +4529,28 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		return;
 	}
 
-	if (get_function_signature(p_call, is_constructor, base_type, p_call->function_name, return_type, par_types, default_arg_count, method_flags)) {
+	const GDScriptParser::FunctionNode *trait_super_function = nullptr;
+	if (p_call->is_super && p_call->callee == nullptr && parser->current_function != nullptr && parser->current_function->trait_super_function != nullptr) {
+		trait_super_function = parser->current_function->trait_super_function;
+		p_call->is_trait_super = true;
+		for (const GDScriptParser::ParameterNode *parameter : trait_super_function->parameters) {
+			par_types.push_back(parameter->get_datatype());
+			if (parameter->initializer != nullptr) {
+				default_arg_count++;
+			}
+		}
+		if (trait_super_function->is_vararg()) {
+			method_flags.set_flag(METHOD_FLAG_VARARG);
+		}
+		if (trait_super_function->is_static) {
+			method_flags.set_flag(METHOD_FLAG_STATIC);
+		}
+		return_type = trait_super_function->get_datatype();
+		return_type.is_meta_type = false;
+		return_type.is_coroutine = trait_super_function->is_coroutine;
+	}
+
+	if (trait_super_function != nullptr || get_function_signature(p_call, is_constructor, base_type, p_call->function_name, return_type, par_types, default_arg_count, method_flags)) {
 		p_call->is_static = method_flags.has_flag(METHOD_FLAG_STATIC);
 		// If the method is implemented in the class hierarchy, the virtual/abstract flag will not be set for that `MethodInfo` and the search stops there.
 		// Virtual/abstract check only possible for super calls because class hierarchy is known. Objects may have scripts attached we don't know of at compile-time.
@@ -7536,6 +7557,9 @@ bool GDScriptAnalyzer::class_exists(const StringName &p_class) const {
 
 void GDScriptAnalyzer::override_member_function(GDScriptParser::FunctionNode *p_target_function, const GDScriptParser::FunctionNode *p_source_function, const String &p_trait_name) {
 	resolve_function_signature(p_target_function);
+	if (!p_source_function->is_bodyless) {
+		p_target_function->trait_super_function = p_source_function;
+	}
 
 	// Check function signature.
 	String function_signature = p_source_function->identifier->name;

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1133,8 +1133,8 @@ void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Addres
 	ct.cleanup();
 }
 
-void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_SELF_BASE, 1 + p_arguments.size());
+void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments, bool p_is_trait_super) {
+	append_opcode_and_argcount(p_is_trait_super ? GDScriptFunction::OPCODE_CALL_SELF_TRAIT : GDScriptFunction::OPCODE_CALL_SELF_BASE, 1 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
 	}

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -532,7 +532,7 @@ public:
 	virtual void write_store_named_global(const Address &p_dst, const StringName &p_global) override;
 	virtual void write_cast(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) override;
 	virtual void write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
-	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments, bool p_is_trait_super) override;
 	virtual void write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_call_utility(const Address &p_target, const StringName &p_function, const Vector<Address> &p_arguments) override;
 	void write_call_builtin_type(const Address &p_target, const Address &p_base, Variant::Type p_type, const StringName &p_method, bool p_is_static, const Vector<Address> &p_arguments);

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -131,7 +131,7 @@ public:
 	virtual void write_store_named_global(const Address &p_dst, const StringName &p_global) = 0;
 	virtual void write_cast(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) = 0;
 	virtual void write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
-	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments, bool p_is_trait_super) = 0;
 	virtual void write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_utility(const Address &p_target, const StringName &p_function, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_gdscript_utility(const Address &p_target, const StringName &p_function, const Vector<Address> &p_arguments) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -672,7 +672,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 				if (call->is_super) {
 					// Super call.
-					gen->write_super_call(result, call->function_name, arguments);
+					gen->write_super_call(result, call->function_name, arguments, call->is_trait_super);
 				} else {
 					if (callee->type == GDScriptParser::Node::IDENTIFIER) {
 						// Self function call.
@@ -2329,7 +2329,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 	return OK;
 }
 
-GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready, bool p_for_lambda) {
+GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready, bool p_for_lambda, bool p_for_trait_super) {
 	r_error = OK;
 	CodeGen codegen;
 	codegen.generator = memnew(GDScriptByteCodeGenerator);
@@ -2547,7 +2547,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 
 	GDScriptFunction *gd_function = codegen.generator->write_end();
 
-	if (is_initializer) {
+	if (is_initializer && !p_for_trait_super) {
 		p_script->initializer = gd_function;
 	} else if (is_implicit_initializer) {
 		p_script->implicit_initializer = gd_function;
@@ -2574,7 +2574,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 
 	gd_function->method_info = method_info;
 
-	if (!is_implicit_initializer && !is_implicit_ready && !p_for_lambda) {
+	if (!is_implicit_initializer && !is_implicit_ready && !p_for_lambda && !p_for_trait_super) {
 		p_script->member_functions[func_name] = gd_function;
 	}
 
@@ -3044,10 +3044,21 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 		if (member.type == member.FUNCTION) {
 			const GDScriptParser::FunctionNode *function = member.function;
 			Error err = OK;
-			_parse_function(err, p_script, p_class, function);
+			GDScriptFunction *trait_super_function = nullptr;
+			if (function->trait_super_function != nullptr) {
+				trait_super_function = _parse_function(err, p_script, p_class, function->trait_super_function, false, false, true);
+				if (err) {
+					return err;
+				}
+			}
+			GDScriptFunction *compiled_function = _parse_function(err, p_script, p_class, function);
 			if (err) {
+				if (trait_super_function != nullptr) {
+					memdelete(trait_super_function);
+				}
 				return err;
 			}
+			compiled_function->_trait_super_function = trait_super_function;
 		} else if (member.type == member.VARIABLE) {
 			const GDScriptParser::VariableNode *variable = member.variable;
 			if (variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
@@ -3253,9 +3264,12 @@ GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement
 
 Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
 	Vector<FunctionLambdaInfo> result;
-	// Only scrape the lambdas inside p_func.
+	// Scrape nested functions owned by p_func.
 	for (int i = 0; i < p_func->lambdas.size(); ++i) {
 		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
+	}
+	if (p_func->_trait_super_function != nullptr) {
+		result.push_back(_get_function_replacement_info(p_func->_trait_super_function, p_func->lambdas.size(), p_depth + 1, p_func));
 	}
 	return result;
 }

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -165,7 +165,7 @@ class GDScriptCompiler {
 	/// Avoid keeping in the stack long-lived references to objects, which may prevent `RefCounted` objects from being freed.
 	void _clear_block_locals(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_locals);
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_clear_locals = true);
-	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
+	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false, bool p_for_trait_super = false);
 	GDScriptFunction *_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
 	/// Prepares given script, and inner class scripts, for compilation. It populates class members and

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -1023,6 +1023,27 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				incr = 4 + argc;
 			} break;
+			case OPCODE_CALL_SELF_TRAIT: {
+				int instr_var_args = _code_ptr[++ip];
+
+				text += "call-self-trait ";
+
+				int argc = _code_ptr[ip + 1 + instr_var_args];
+				text += DADDR(2 + argc) + " = ";
+
+				text += _global_names_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				text += "(";
+
+				for (int i = 0; i < argc; i++) {
+					if (i > 0) {
+						text += ", ";
+					}
+					text += DADDR(1 + i);
+				}
+				text += ")";
+
+				incr = 4 + argc;
+			} break;
 			case OPCODE_AWAIT: {
 				text += "await ";
 				text += DADDR(1);

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -273,6 +273,9 @@ GDScriptFunction::~GDScriptFunction() {
 	for (int i = 0; i < lambdas.size(); i++) {
 		memdelete(lambdas[i]);
 	}
+	if (_trait_super_function != nullptr) {
+		memdelete(_trait_super_function);
+	}
 
 	for (int i = 0; i < argument_types.size(); i++) {
 		argument_types.write[i].script_type_ref = Ref<Script>();

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -215,6 +215,7 @@ public:
 		OPCODE_CALL_GDSCRIPT_UTILITY,
 		OPCODE_CALL_BUILTIN_TYPE_VALIDATED,
 		OPCODE_CALL_SELF_BASE,
+		OPCODE_CALL_SELF_TRAIT,
 		OPCODE_CALL_METHOD_BIND,
 		OPCODE_CALL_METHOD_BIND_RET,
 		OPCODE_CALL_BUILTIN_STATIC,
@@ -398,6 +399,7 @@ private:
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
 	Vector<MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
+	GDScriptFunction *_trait_super_function = nullptr;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -534,6 +534,7 @@ public:
 		Vector<ExpressionNode *> arguments;
 		StringName function_name;
 		bool is_super = false;
+		bool is_trait_super = false;
 		bool is_static = false;
 
 		CallNode() {
@@ -949,6 +950,7 @@ public:
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
+		const FunctionNode *trait_super_function = nullptr;
 		Vector<Variant> default_arg_values;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -318,6 +318,7 @@ void (*type_init_function_table[])(Variant *) = {
 		&&OPCODE_CALL_GDSCRIPT_UTILITY,                  \
 		&&OPCODE_CALL_BUILTIN_TYPE_VALIDATED,            \
 		&&OPCODE_CALL_SELF_BASE,                         \
+		&&OPCODE_CALL_SELF_TRAIT,                        \
 		&&OPCODE_CALL_METHOD_BIND,                       \
 		&&OPCODE_CALL_METHOD_BIND_RET,                   \
 		&&OPCODE_CALL_BUILTIN_STATIC,                    \
@@ -2629,6 +2630,43 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					String methodstr = *methodname;
 					err_text = _get_call_error("function '" + methodstr + "'", (const Variant **)argptrs, argc, *dst, err);
 
+					OPCODE_BREAK;
+				}
+
+				ip += 3;
+			}
+			DISPATCH_OPCODE;
+
+			OPCODE(OPCODE_CALL_SELF_TRAIT) {
+				LOAD_INSTRUCTION_ARGS
+				CHECK_SPACE(3 + instr_arg_count);
+
+				ip += instr_arg_count;
+
+				int argc = _code_ptr[ip + 1];
+				GD_ERR_BREAK(argc < 0);
+				if (_trait_super_function == nullptr) {
+					err_text = "compiler bug, trait super function not found";
+					OPCODE_BREAK;
+				}
+
+				int self_fun = _code_ptr[ip + 2];
+#ifdef DEBUG_ENABLED
+				if (self_fun < 0 || self_fun >= _global_names_count) {
+					err_text = "compiler bug, function name not found";
+					OPCODE_BREAK;
+				}
+#endif
+				const StringName *methodname = &_global_names_ptr[self_fun];
+				Variant **argptrs = instruction_args;
+
+				GET_INSTRUCTION_ARG(dst, argc);
+
+				Callable::CallError err;
+				*dst = _trait_super_function->call(p_instance, (const Variant **)argptrs, argc, err);
+				if (err.error != Callable::CallError::CALL_OK) {
+					String methodstr = *methodname;
+					err_text = _get_call_error("trait function '" + methodstr + "'", (const Variant **)argptrs, argc, *dst, err);
 					OPCODE_BREAK;
 				}
 

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_super_call.gd
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_super_call.gd
@@ -1,0 +1,45 @@
+extends Node
+
+trait Greeter:
+	func greet(recipient: String = "world") -> String:
+		return "hello, " + recipient
+
+class DefaultGreeter:
+	uses Greeter
+
+class LoudGreeter:
+	uses Greeter
+
+	func greet(recipient: String = "world") -> String:
+		return super(recipient).to_upper()
+
+trait Incrementer:
+	static func increment(value: int) -> int:
+		return value + 1
+
+class DoubleIncrementer:
+	uses Incrementer
+
+	static func increment(value: int) -> int:
+		return super(value) * 2
+
+trait ReadyTrait extends Node:
+	func _ready() -> void:
+		print("trait ready")
+
+class ReadyOverride extends Node:
+	uses ReadyTrait
+
+	func _ready() -> void:
+		print("before ready")
+		super()
+		print("after ready")
+
+func test() -> void:
+	print(DefaultGreeter.new().greet())
+	print(LoudGreeter.new().greet("traits"))
+	print(DoubleIncrementer.increment(3))
+
+	var ready_override := ReadyOverride.new()
+	ready_override._ready()
+	ready_override.free()

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_super_call.out
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_super_call.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+hello, world
+HELLO, TRAITS
+8
+before ready
+trait ready
+after ready


### PR DESCRIPTION
Fixes #1390 
This PR adds support for calling `super()` when a trait's method is overridden by a concrete type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calling overridden trait methods with `super` in GDScript.
  * Trait `super` calls now support arguments, static methods, default parameters, and return values.

* **Bug Fixes**
  * Improved execution and error reporting for trait `super` calls.

* **Tests**
  * Added coverage for trait overrides, static methods, and lifecycle methods using `super`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->