### PR TITLE
Fix lint scope and filename handling

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -9,7 +9,7 @@ jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
-    if: ${{ !vars.DISABLE_GODOT_CI || github.run_attempt > 1 }}
+    if: ${{ (!vars.DISABLE_GODOT_CI || github.run_attempt > 1) && !(github.event_name == 'push' && github.event.deleted) }}
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,41 +8,37 @@ env:
 jobs:
   static-checks:
     name: Code style, file formatting, and docs
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
+          persist-credentials: false
 
       # This needs to happen before Python and npm execution; it must happen before any extra files are written.
       - name: .gitignore checks (gitignore_check.sh)
         run: |
           bash ./misc/scripts/gitignore_check.sh
 
-      - name: Get changed files
-        if: ${{ env.DISABLE_REDOT_GET_CHANGED_FILES != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
-          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
-          fi
-          files=$(echo "$files" | xargs -I {} sh -c 'echo "\"./{}\""' | tr '\n' ' ')
-          echo "CHANGED_FILES=$files" >> $GITHUB_ENV
-
-      - name: Style checks via pre-commit
-        if: ${{ env.DISABLE_REDOT_GET_CHANGED_FILES != 'true' }}
-        uses: pre-commit/action@v3.0.1
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          extra_args: --files ${{ env.CHANGED_FILES }}
+          python-version: "3.11"
+
+      - name: Install pre-commit
+        run: python -m pip install pre-commit==4.6.2
+
+      - name: Test lint scope selection
+        run: python tests/python_build/test_ci_lint.py
 
       - name: Style checks via pre-commit
-        if: ${{ env.DISABLE_REDOT_GET_CHANGED_FILES == 'true' }}
-        uses: pre-commit/action@v3.0.1
+        env:
+          LINT_ALL_FILES: ${{ env.DISABLE_REDOT_GET_CHANGED_FILES }}
+        run: python misc/scripts/ci_lint.py
 
       - name: Class reference schema checks
         run: |

--- a/misc/scripts/ci_lint.py
+++ b/misc/scripts/ci_lint.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True, stderr=subprocess.PIPE).rstrip("\n")
+
+
+def commit(sha: str) -> str:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", sha):
+        raise ValueError("Invalid commit ID")
+    try:
+        return git("rev-parse", "--verify", f"{sha}^{{commit}}")
+    except subprocess.CalledProcessError as error:
+        raise ValueError("Commit is unavailable") from error
+
+
+def lint_args(
+    event_name: str, event: dict[str, Any], expected_sha: str, all_files: bool = False
+) -> tuple[list[str], str]:
+    head = git("rev-parse", "HEAD")
+    if commit(expected_sha) != head:
+        raise ValueError("Checkout does not match the event commit")
+
+    base = ""
+    if event_name == "push":
+        if event.get("deleted"):
+            raise ValueError("Deleted refs must be excluded before checkout")
+        if commit(event.get("after", "")) != head:
+            raise ValueError("Checkout does not match the push head")
+        if event.get("created") or event.get("forced") or event.get("ref", "").startswith("refs/tags/"):
+            return ["--all-files"], "created-forced-or-tag-push"
+        base = event.get("before", "")
+    elif event_name == "pull_request":
+        base = event.get("pull_request", {}).get("base", {}).get("sha", "")
+    elif event_name == "merge_group":
+        group = event.get("merge_group", {})
+        if group and commit(group.get("head_sha", "")) != head:
+            raise ValueError("Checkout does not match the merge group head")
+        base = group.get("base_sha", "")
+
+    if all_files:
+        return ["--all-files"], "explicit-full-tree"
+    try:
+        base = commit(base or "")
+        git("merge-base", "--is-ancestor", base, head)
+    except (ValueError, subprocess.CalledProcessError):
+        return ["--all-files"], "no-verified-ancestor"
+
+    # Changes to lint inputs can affect files outside the commit range. Deleted
+    # documentation also needs validation even when no XML remains in the diff.
+    try:
+        paths = git("diff", "--name-only", "--no-ext-diff", "-z", base, head).split("\0")
+    except subprocess.CalledProcessError:
+        return ["--all-files"], "diff-unavailable"
+    for path in paths:
+        if (
+            path.startswith((".github/", "misc/scripts/", "misc/utility/", "doc/tools/"))
+            or path.endswith((".yaml", ".yml", ".toml", ".csproj", ".props", ".sln", ".slnx"))
+            or path in (".clang-format", ".editorconfig", "custom_dict.txt", "gles3_builders.py", "glsl_builders.py")
+            or path.startswith("platform/web/")
+            and ("eslint" in path or "jsdoc2rst/" in path or "package" in path)
+            or path.endswith(".xml")
+            and (path.startswith("doc/classes/") or "/doc_classes/" in path)
+        ):
+            return ["--all-files"], "lint-inputs-changed"
+    return ["--from-ref", base, "--to-ref", head], "verified-range"
+
+
+def main() -> int:
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as file:
+        event = json.load(file)
+    args, reason = lint_args(
+        os.environ["GITHUB_EVENT_NAME"], event, os.environ["GITHUB_SHA"], os.environ.get("LINT_ALL_FILES") == "true"
+    )
+    print(f"Lint scope: {reason}; {' '.join(args)}", flush=True)
+    return subprocess.call(
+        [sys.executable, "-m", "pre_commit", "run", "--show-diff-on-failure", "--color=always", *args]
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/misc/scripts/ci_lint.py
+++ b/misc/scripts/ci_lint.py
@@ -62,9 +62,10 @@ def lint_args(
         return ["--all-files"], "diff-unavailable"
     for path in paths:
         if (
-            path.startswith((".github/", "misc/scripts/", "misc/utility/", "doc/tools/"))
-            or path.endswith((".yaml", ".yml", ".toml", ".csproj", ".props", ".sln", ".slnx"))
-            or path in (".clang-format", ".editorconfig", "custom_dict.txt", "gles3_builders.py", "glsl_builders.py")
+            path.startswith((".github/", "misc/scripts/", "misc/utility/", "doc/tools/", "tests/python_build/"))
+            or path.endswith((".yaml", ".yml", ".toml", ".csproj", ".props", ".targets", ".sln", ".slnx"))
+            or path.rsplit("/", 1)[-1] in (".clang-format", ".editorconfig", "global.json")
+            or path in ("custom_dict.txt", "gles3_builders.py", "glsl_builders.py", "methods.py", "platform_methods.py")
             or path.startswith("platform/web/")
             and ("eslint" in path or "jsdoc2rst/" in path or "package" in path)
             or path.endswith(".xml")

--- a/misc/scripts/ci_lint.py
+++ b/misc/scripts/ci_lint.py
@@ -66,10 +66,8 @@ def lint_args(
             or path.endswith((".yaml", ".yml", ".toml", ".csproj", ".props", ".targets", ".sln", ".slnx"))
             or path.rsplit("/", 1)[-1] in (".clang-format", ".editorconfig", "global.json")
             or path in ("custom_dict.txt", "gles3_builders.py", "glsl_builders.py", "methods.py", "platform_methods.py")
-            or path.startswith("platform/web/")
-            and ("eslint" in path or "jsdoc2rst/" in path or "package" in path)
-            or path.endswith(".xml")
-            and (path.startswith("doc/classes/") or "/doc_classes/" in path)
+            or (path.startswith("platform/web/") and ("eslint" in path or "jsdoc2rst/" in path or "package" in path))
+            or (path.endswith(".xml") and (path.startswith("doc/classes/") or "/doc_classes/" in path))
         ):
             return ["--all-files"], "lint-inputs-changed"
     return ["--from-ref", base, "--to-ref", head], "verified-range"

--- a/tests/python_build/test_ci_lint.py
+++ b/tests/python_build/test_ci_lint.py
@@ -123,7 +123,14 @@ class LintScopeTests(unittest.TestCase):
             self.assertEqual(lint_args("push", self.push(), self.head)[0], ["--all-files"])
 
     def test_configuration_and_deleted_docs_use_all_files(self) -> None:
-        for filename in (".pre-commit-config.yaml", "misc/scripts/helper.py", "doc/classes/Example.xml"):
+        for filename in (
+            ".pre-commit-config.yaml",
+            "misc/scripts/helper.py",
+            "doc/classes/Example.xml",
+            "modules/mono/.editorconfig",
+            "methods.py",
+            "tests/python_build/fixtures/example.glsl",
+        ):
             with self.subTest(filename=filename):
                 self.git("checkout", "-q", self.head)
                 Path(filename).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/python_build/test_ci_lint.py
+++ b/tests/python_build/test_ci_lint.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "misc/scripts"))
+from ci_lint import lint_args, main
+
+
+class LintScopeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        original = os.getcwd()
+        os.chdir(directory.name)
+        self.addCleanup(os.chdir, original)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Lint Test")
+        self.git("config", "user.email", "lint@example.invalid")
+        self.git("config", "core.autocrlf", "false")
+        Path("old.txt").write_text("old\n")
+        self.base = self.commit()
+        Path("changed.txt").write_text("new\n")
+        self.head = self.commit()
+
+    def git(self, *args: str) -> str:
+        return subprocess.check_output(["git", *args], text=True, stderr=subprocess.PIPE).strip()
+
+    def commit(self) -> str:
+        self.git("add", ".")
+        self.git("commit", "-qm", "fixture")
+        return self.git("rev-parse", "HEAD")
+
+    def push(self, **kwargs: object) -> dict[str, object]:
+        return {"before": self.base, "after": self.head, "ref": "refs/heads/main", **kwargs}
+
+    def test_push_range(self) -> None:
+        self.assertEqual(lint_args("push", self.push(), self.head)[0], ["--from-ref", self.base, "--to-ref", self.head])
+
+    def test_multi_commit_push(self) -> None:
+        Path("another.txt").write_text("another\n")
+        self.head = self.commit()
+        self.test_push_range()
+
+    def test_pr_merge_and_merge_group(self) -> None:
+        self.git("checkout", "-qb", "target", self.base)
+        Path("target.txt").write_text("target\n")
+        target = self.commit()
+        self.git("merge", "--no-ff", "-qm", "merge", self.head)
+        merge = self.git("rev-parse", "HEAD")
+        events = {
+            "pull_request": {"pull_request": {"base": {"sha": target}, "head": {"sha": self.head}}},
+            "merge_group": {"merge_group": {"base_sha": target, "head_sha": merge}},
+        }
+        for name, event in events.items():
+            with self.subTest(name=name):
+                self.assertEqual(lint_args(name, event, merge)[0], ["--from-ref", target, "--to-ref", merge])
+
+    def test_uncertain_base_uses_all_files(self) -> None:
+        for base in (None, "", "0" * 40, "f" * 40, "$(not-a-sha)"):
+            with self.subTest(base=base):
+                self.assertEqual(lint_args("push", self.push(before=base), self.head)[0], ["--all-files"])
+
+    def test_created_forced_and_tag_pushes_use_all_files(self) -> None:
+        for change in ({"created": True}, {"forced": True}, {"ref": "refs/tags/v1"}):
+            with self.subTest(change=change):
+                self.assertEqual(lint_args("push", self.push(**change), self.head)[0], ["--all-files"])
+
+    def test_other_events_and_explicit_full_run(self) -> None:
+        for name in ("schedule", "workflow_dispatch", "unknown", "pull_request", "merge_group"):
+            with self.subTest(name=name):
+                self.assertEqual(lint_args(name, {}, self.head)[0], ["--all-files"])
+        self.assertEqual(lint_args("push", self.push(), self.head, True)[0], ["--all-files"])
+
+    def test_invalid_checkout_and_mismatched_event_head_fail(self) -> None:
+        for sha in ("", "invalid", "f" * 40, self.base):
+            with self.subTest(sha=sha), self.assertRaises(ValueError):
+                lint_args("push", self.push(), sha)
+        for name, event in (
+            ("push", self.push(after=self.base)),
+            ("push", self.push(deleted=True)),
+            ("merge_group", {"merge_group": {"base_sha": self.base, "head_sha": self.base}}),
+        ):
+            with self.subTest(event=event), self.assertRaises(ValueError):
+                lint_args(name, event, self.head)
+
+    def test_divergent_base_uses_all_files(self) -> None:
+        self.git("checkout", "-qb", "divergent", self.base)
+        Path("divergent.txt").write_text("divergent\n")
+        other = self.commit()
+        self.git("checkout", "-q", self.head)
+        self.assertEqual(lint_args("push", self.push(before=other), self.head)[0], ["--all-files"])
+
+    def test_shallow_checkout_uses_all_files(self) -> None:
+        source = Path.cwd()
+        self.git("clone", "--quiet", "--depth=1", source.as_uri(), "shallow")
+        os.chdir(source / "shallow")
+        try:
+            self.assertEqual(lint_args("push", self.push(), self.head)[0], ["--all-files"])
+        finally:
+            os.chdir(source)
+
+    def test_diff_error_uses_all_files(self) -> None:
+        import ci_lint
+
+        original: Callable[..., str] = ci_lint.git
+
+        def failing_diff(*args: str) -> str:
+            if args[0] == "diff":
+                raise subprocess.CalledProcessError(1, ["git", *args])
+            return original(*args)
+
+        with patch("ci_lint.git", side_effect=failing_diff):
+            self.assertEqual(lint_args("push", self.push(), self.head)[0], ["--all-files"])
+
+    def test_configuration_and_deleted_docs_use_all_files(self) -> None:
+        for filename in (".pre-commit-config.yaml", "misc/scripts/helper.py", "doc/classes/Example.xml"):
+            with self.subTest(filename=filename):
+                self.git("checkout", "-q", self.head)
+                Path(filename).parent.mkdir(parents=True, exist_ok=True)
+                Path(filename).write_text("fixture\n")
+                changed = self.commit()
+                self.assertEqual(lint_args("push", self.push(after=changed), changed)[0], ["--all-files"])
+                if filename.endswith(".xml"):
+                    Path(filename).unlink()
+                    deleted = self.commit()
+                    self.assertEqual(
+                        lint_args("push", self.push(before=changed, after=deleted), deleted)[0], ["--all-files"]
+                    )
+
+    def test_main_propagates_lint_status(self) -> None:
+        Path("event.json").write_text(json.dumps(self.push()))
+        with patch.dict(
+            os.environ, {"GITHUB_EVENT_PATH": "event.json", "GITHUB_EVENT_NAME": "push", "GITHUB_SHA": self.head}
+        ), patch("ci_lint.subprocess.call", return_value=9) as call:
+            self.assertEqual(main(), 9)
+        self.assertEqual(call.call_args.args[0][-4:], ["--from-ref", self.base, "--to-ref", self.head])
+
+    def test_pre_commit_receives_changed_paths_without_shell_evaluation(self) -> None:
+        names = [
+            "space name.txt",
+            "quote's.txt",
+            "$(touch sentinel).txt",
+            "`touch sentinel`.txt",
+            "-dash.txt",
+            "unicode-é.txt",
+        ]
+        if os.name != "nt":
+            names += ['double"quote.txt', "tab\tname.txt", "back\\slash.txt", "line\nname.txt"]
+        Path("record.py").write_text(
+            "import json, sys\nfrom pathlib import Path\nPath('record.json').write_text(json.dumps(sys.argv[1:]))\n"
+        )
+        # JSON is also YAML; using an argument-safe entry avoids fixture quoting assumptions.
+
+        Path(".pre-commit-config.yaml").write_text(
+            json.dumps(
+                {
+                    "repos": [
+                        {
+                            "repo": "local",
+                            "hooks": [
+                                {
+                                    "id": "record",
+                                    "name": "record",
+                                    "language": "system",
+                                    "entry": shlex.join([sys.executable.replace("\\", "/"), "record.py"]),
+                                    "files": "\\.txt$",
+                                    "require_serial": True,
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        base = self.commit()
+        for name in names:
+            Path(name).write_text("fixture\n")
+        self.git("mv", "changed.txt", "renamed.txt")
+        self.git("rm", "old.txt")
+        head = self.commit()
+        args, _ = lint_args("push", self.push(before=base, after=head), head)
+        subprocess.run(
+            [sys.executable, "-m", "pre_commit", "run", *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(set(json.loads(Path("record.json").read_text())), set(names + ["renamed.txt"]))
+        self.assertFalse(Path("sentinel").exists())
+
+    def test_range_and_all_files_detect_the_expected_failures(self) -> None:
+        Path("check.py").write_text(
+            "import sys\nfrom pathlib import Path\nsys.exit(any('BAD' in Path(p).read_text() for p in sys.argv[1:]))\n"
+        )
+        Path(".pre-commit-config.yaml").write_text(
+            json.dumps(
+                {
+                    "repos": [
+                        {
+                            "repo": "local",
+                            "hooks": [
+                                {
+                                    "id": "check",
+                                    "name": "check",
+                                    "language": "system",
+                                    "entry": shlex.join([sys.executable.replace("\\", "/"), "check.py"]),
+                                    "files": "\\.txt$",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        Path("old.txt").write_text("BAD\n")
+        base = self.commit()
+        Path("changed.txt").write_text("good\n")
+        head = self.commit()
+        args, _ = lint_args("push", self.push(before=base, after=head), head)
+        command = [sys.executable, "-m", "pre_commit", "run"]
+        for scope, status in ((args, 0), (["--all-files"], 1)):
+            with self.subTest(scope=scope):
+                result = subprocess.run([*command, *scope], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                self.assertEqual(result.returncode, status, result.stdout)
+        Path("changed.txt").write_text("BAD\n")
+        head = self.commit()
+        args, _ = lint_args("push", self.push(before=base, after=head), head)
+        result = subprocess.run([*command, *args], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.assertEqual(result.returncode, 1, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python_build/test_ci_lint.py
+++ b/tests/python_build/test_ci_lint.py
@@ -27,6 +27,9 @@ class LintScopeTests(unittest.TestCase):
         self.git("config", "user.name", "Lint Test")
         self.git("config", "user.email", "lint@example.invalid")
         self.git("config", "core.autocrlf", "false")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        self.git("config", "core.hooksPath", "")
         Path("old.txt").write_text("old\n")
         self.base = self.commit()
         Path("changed.txt").write_text("new\n")
@@ -237,12 +240,14 @@ class LintScopeTests(unittest.TestCase):
         command = [sys.executable, "-m", "pre_commit", "run"]
         for scope, status in ((args, 0), (["--all-files"], 1)):
             with self.subTest(scope=scope):
-                result = subprocess.run([*command, *scope], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                result = subprocess.run(
+                    [*command, *scope], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                )
                 self.assertEqual(result.returncode, status, result.stdout)
         Path("changed.txt").write_text("BAD\n")
         head = self.commit()
         args, _ = lint_args("push", self.push(before=base, after=head), head)
-        result = subprocess.run([*command, *args], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        result = subprocess.run([*command, *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         self.assertEqual(result.returncode, 1, result.stdout)
 
 


### PR DESCRIPTION
Fix lint scope selection for missing or unreliable refs and pass filenames without shell interpolation. Fall back to all files when required.

Validation: 14 Windows/Linux regression tests, applicable hooks and actionlint pass. [Linux integration](https://github.com/dominicbytes/redot-engine/actions/runs/34081768619) passes twice without tracked changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated validation for branch, tag, pull request, and merge-group events.
  - Linting now automatically selects the appropriate scope, checking the full repository when needed and limiting checks to relevant changes otherwise.
  - Added more reliable handling for deleted references, unusual filenames, shallow checkouts, and unavailable change history.
  - Updated CI checks to use a consistent linting process and supported Python environment.

- **Tests**
  - Expanded coverage for lint-scope selection, event types, and failure scenarios to improve confidence in continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->