### PR TITLE
Use read-only CI permissions

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,6 +1,9 @@
 name: 🔗 GHA
 on: [push, pull_request, merge_group]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}|${{ github.ref_name }}
   cancel-in-progress: true


### PR DESCRIPTION
Set normal CI permissions to `contents: read`. Release publishing permissions remain unchanged.

Validation: checkout, cache and artifact operations pass in [fork CI](https://github.com/dominicbytes/redot-engine/actions/runs/34080398867). Full platform builds were not rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted automated workflow access to read-only repository contents, improving the safety of routine automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->