### PR TITLE
Remove "LTS" from version.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Redot Engine LTS
+# Redot Engine
 
 <p align="center">
   <a href="https://redotengine.org/">
@@ -10,7 +10,7 @@
 
 ## 2D and 3D cross-platform game engine
 
-**[Redot Engine LTS](https://redotengine.org) is a feature-packed, cross-platform
+**[Redot Engine](https://redotengine.org) is a feature-packed, cross-platform
 game engine to create 2D and 3D games from a unified interface.** It provides a
 comprehensive set of common tools, so that
 users can focus on making games without having to reinvent the wheel. Games can

--- a/REDOT_AUTHORS.md
+++ b/REDOT_AUTHORS.md
@@ -1,4 +1,4 @@
-# Redot Engine LTS authors
+# Redot Engine authors
 
 Redot is a Fork of the Godot Engine that is developed by a community of
 voluntary contributors who contribute code, bug reports, documentation,

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 short_name = "redot"
-name = "Redot Engine LTS"
+name = "Redot Engine"
 major = 26
 minor = 3
 patch = 0


### PR DESCRIPTION
Since the LTS will just be in 26.4, this will get "LTS" out of the title bar.
My 2 cents would be it might be easier not to have that in the title bar at all, but if we do want it, we could make it a flag instead of text to make it a little harder to forget :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the displayed product name from “Redot Engine LTS” to “Redot Engine.”
* **Documentation**
  * Updated README headings and introductory text to use “Redot Engine.”
  * Updated the authors document title to use “Redot Engine authors.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->