### PR TITLE
Expand environment variables in `FileDialog` folder/file path fields

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -43,6 +43,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/string/char_utils.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "drivers/unix/file_access_unix_pipe.h"
@@ -1359,6 +1360,45 @@ String OS_Unix::expand_path(const String &p_path) const {
 		String home = get_environment("HOME");
 		if (!home.is_empty()) {
 			path = home + path.substr(1);
+		}
+	}
+
+	int pos = 0;
+
+	while (pos < path.length()) {
+		int dollar = path.find_char('$', pos);
+		if (dollar == -1) {
+			break;
+		}
+
+		const int begin = dollar + 1;
+		if (begin >= path.length()) {
+			break;
+		}
+
+		if (!(is_ascii_alphabet_char(path[begin]) || is_underscore(path[begin]))) {
+			pos = dollar + 1;
+			continue;
+		}
+
+		int end = begin + 1;
+		while (end < path.length()) {
+			const char32_t c = path[end];
+
+			if (!(is_ascii_alphanumeric_char(c) || is_underscore(c))) {
+				break;
+			}
+			end++;
+		}
+
+		const String var_name = path.substr(begin, end - begin);
+		const String value = get_environment(var_name);
+
+		if (!value.is_empty()) {
+			path = path.substr(0, dollar) + value + path.substr(end);
+			pos = dollar + value.length();
+		} else {
+			pos = end;
 		}
 	}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2537,6 +2537,36 @@ String OS_Windows::expand_path(const String &p_path) const {
 		}
 	}
 
+	int pos = 0;
+
+	while (true) {
+		int left = path.find_char('%', pos);
+		if (left == -1) {
+			break;
+		}
+
+		int right = path.find_char('%', left + 1);
+		if (right == -1) {
+			break;
+		}
+
+		String var = path.substr(left + 1, right - left - 1);
+
+		if (var.is_empty()) {
+			pos = right + 1;
+			continue;
+		}
+
+		String value = get_environment(var);
+
+		if (!value.is_empty()) {
+			path = path.substr(0, left) + value + path.substr(right + 1);
+			pos = left + value.length();
+		} else {
+			pos = right + 1;
+		}
+	}
+
 	return path;
 }
 


### PR DESCRIPTION
Adds support for expanding environment variables in FileDialog folder/file path fields on Unix-like operating systems & Windows.

This PR has been tested on both Linux & Windows & seems to work as expected. If you find any issues, lemme know & I'll fix them.

### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unix paths now expand `$VARIABLE` references using matching environment values.
  - Windows paths now expand `%VARIABLE%` references using matching environment values.
  - Unset or invalid environment-variable references remain unchanged or are skipped appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->