### PR TITLE
Mode7 bugfix

### DIFF
--- a/doc/classes/Mode7Sprite2D.xml
+++ b/doc/classes/Mode7Sprite2D.xml
@@ -85,6 +85,9 @@
 			Path to a [Node2D] target. When set, the sprite's [member Sprite2D.region_rect] shifts each physics frame so the Mode 7 viewport "follows" the target node while preserving its size and aspect ratio.
 			This creates the illusion of a moving camera or scrolling background. Only active when region mode is enabled on the sprite ([member Sprite2D.region_enabled] must be [code]true[/code]).
 		</member>
+		<member name="mode7_saved_material" type="Material" setter="set_mode7_saved_material" getter="get_mode7_saved_material">
+			(Non-editor) Property to save the material the user had before enabling Mode 7.
+		</member>
 		<member name="mode7_scanline_overrides" type="Mode7ScanlineOverride[]" setter="set_mode7_scanline_overrides" getter="get_mode7_scanline_overrides" default="[]">
 			Array of [Mode7ScanlineOverride] resources acting as anchors across the sprite height. Each entry defines a 2x2 affine matrix (rotation, scale, skew), a translation offset, and a pivot point, and the shader interpolates between adjacent entries for every output row (UV.y band).
 			When Mode 7 is enabled, a single default identity override is created automatically. Add more entries to interpolate between different transforms across the sprite height.

--- a/scene/2d/mode7_sprite_2d.cpp
+++ b/scene/2d/mode7_sprite_2d.cpp
@@ -193,6 +193,28 @@ void fragment() {
 }
 )";
 
+PackedStringArray Mode7Sprite2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Sprite2D::get_configuration_warnings();
+
+	if (!mode7_region_follow_target.is_empty()) {
+		Node *target = has_node(mode7_region_follow_target) ? get_node(mode7_region_follow_target) : nullptr;
+		if (!target || !Object::cast_to<Node2D>(target)) {
+			warnings.push_back(RTR("Region follow target path must point to a valid Node2D node to work."));
+		} else if (target == this) {
+			warnings.push_back(RTR("Region follow target cannot be this node."));
+		}
+	}
+
+	return warnings;
+}
+
+void Mode7Sprite2D::set_mode7_saved_material(const Ref<Material> &p_material) {
+	_saved_material = p_material;
+}
+Ref<Material> Mode7Sprite2D::get_mode7_saved_material() const {
+	return _saved_material;
+}
+
 void Mode7Sprite2D::_mode7_rebuild_material() {
 	if (_mode7_material.is_null()) {
 		Ref<Shader> shader;
@@ -882,6 +904,8 @@ void Mode7Sprite2D::set_mode7_region_follow_target(const NodePath &p_path) {
 			set_physics_process(true);
 			mode7_follow_physics_active = true;
 		}
+
+		update_configuration_warnings();
 	} else if (!p_path.is_empty()) {
 		// Node not in tree yet — defer starting physics too, until we're ready.
 		callable_mp(this, &Mode7Sprite2D::_ensure_follow_physics).call_deferred();
@@ -972,6 +996,9 @@ void Mode7Sprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mode7_projection_pixel_aspect", "value"), &Mode7Sprite2D::set_mode7_projection_pixel_aspect);
 	ClassDB::bind_method(D_METHOD("get_mode7_projection_pixel_aspect"), &Mode7Sprite2D::get_mode7_projection_pixel_aspect);
 
+	ClassDB::bind_method(D_METHOD("set_mode7_saved_material", "material"), &Mode7Sprite2D::set_mode7_saved_material);
+	ClassDB::bind_method(D_METHOD("get_mode7_saved_material"), &Mode7Sprite2D::get_mode7_saved_material);
+
 	// Properties (exposed in the Inspector) -----------------------------------
 
 	// Global (un-grouped)
@@ -1028,6 +1055,9 @@ void Mode7Sprite2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mode7_projection_pixel_aspect",
 						 PROPERTY_HINT_RANGE, "0.875,1.125,0.001"),
 			"set_mode7_projection_pixel_aspect", "get_mode7_projection_pixel_aspect");
+
+	// Internal - for persistence
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mode7_saved_material", PROPERTY_HINT_RESOURCE_TYPE, "Material", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_NO_EDITOR), "set_mode7_saved_material", "get_mode7_saved_material");
 }
 
 Mode7Sprite2D::Mode7Sprite2D() {

--- a/scene/2d/mode7_sprite_2d.cpp
+++ b/scene/2d/mode7_sprite_2d.cpp
@@ -812,10 +812,17 @@ void Mode7Sprite2D::_notification(int p_what) {
 				set_physics_process(false);
 				mode7_follow_physics_active = false;
 				return;
-			} else if (!is_inside_tree() || !target_2d->is_inside_tree()) {
-				set_physics_process(false);
-				mode7_follow_physics_active = false;
-				return;
+			} else if (!is_inside_tree()) {
+			    // The sprite itself left the tree; NOTIFICATION_EXIT_TREE already
+			    // disables physics processing in this case, but bail out safely.
+			    set_physics_process(false);
+			    mode7_follow_physics_active = false;
+			    return;
+			} else if (!target_2d->is_inside_tree()) {
+			    // The target is only temporarily detached (e.g. mid-reparent).
+			    // Skip this update but keep physics processing active so follow
+			    // resumes automatically once the target re-enters the tree.
+			    return;
 			} else if (!is_region_enabled()) {
 				// Skip the update while the region is disabled, but keep
 				// physics processing so follow resumes automatically.

--- a/scene/2d/mode7_sprite_2d.cpp
+++ b/scene/2d/mode7_sprite_2d.cpp
@@ -638,6 +638,13 @@ real_t Mode7Sprite2D::get_mode7_projection_pixel_aspect() const {
 }
 
 void Mode7Sprite2D::_validate_property(PropertyInfo &p_property) const {
+ 	if (p_property.name == "material" && mode7_enabled) {
+        // The active material is always regenerated from mode7_* properties
+        // via _mode7_rebuild_material(); never persist the generated
+        // ShaderMaterial as if it were the user's original material.
+        p_property.usage &= ~PROPERTY_USAGE_STORAGE;
+    }
+
 	// The projection tuning parameters only affect the scanline-table math in
 	// INTERPOLATION_PROJECTION mode, so lock them when any other mode is active.
 	// (Mirrors the Mode7ScanlineOverride::_validate_property pattern for skew.)

--- a/scene/2d/mode7_sprite_2d.cpp
+++ b/scene/2d/mode7_sprite_2d.cpp
@@ -638,12 +638,12 @@ real_t Mode7Sprite2D::get_mode7_projection_pixel_aspect() const {
 }
 
 void Mode7Sprite2D::_validate_property(PropertyInfo &p_property) const {
- 	if (p_property.name == "material" && mode7_enabled) {
-        // The active material is always regenerated from mode7_* properties
-        // via _mode7_rebuild_material(); never persist the generated
-        // ShaderMaterial as if it were the user's original material.
-        p_property.usage &= ~PROPERTY_USAGE_STORAGE;
-    }
+	if (p_property.name == "material" && mode7_enabled) {
+		// The active material is always regenerated from mode7_* properties
+		// via _mode7_rebuild_material(); never persist the generated
+		// ShaderMaterial as if it were the user's original material.
+		p_property.usage &= ~PROPERTY_USAGE_STORAGE;
+	}
 
 	// The projection tuning parameters only affect the scanline-table math in
 	// INTERPOLATION_PROJECTION mode, so lock them when any other mode is active.
@@ -820,23 +820,22 @@ void Mode7Sprite2D::_notification(int p_what) {
 				mode7_follow_physics_active = false;
 				return;
 			} else if (!is_inside_tree()) {
-			    // The sprite itself left the tree; NOTIFICATION_EXIT_TREE already
-			    // disables physics processing in this case, but bail out safely.
-			    set_physics_process(false);
-			    mode7_follow_physics_active = false;
-			    return;
+				// This node itself is not in the tree. NOTIFICATION_EXIT_TREE already
+				// resets mode7_follow_cache/mode7_follow_initialized/mode7_follow_physics_active
+				// and disarms physics_process unconditionally, so don't duplicate or
+				// race with that logic here — just bail out for this frame.
+				return;
 			} else if (!target_2d->is_inside_tree()) {
-			    // The target is only temporarily detached (e.g. mid-reparent).
-			    // Skip this update but keep physics processing active so follow
-			    // resumes automatically once the target re-enters the tree.
-			    return;
+				// Only the target is temporarily out of the tree (e.g. being
+				// re-parented). This is recoverable, so keep polling instead of
+				// disarming physics processing — otherwise follow never resumes
+				// once the target re-enters the tree. Force a re-snap once it's
+				// back, so the region doesn't jump on resume.
+				mode7_follow_initialized = false;
+				return;
 			} else if (!is_region_enabled()) {
 				// Skip the update while the region is disabled, but keep
 				// physics processing so follow resumes automatically.
-				return;
-			}
-
-			if (!is_inside_tree()) {
 				return;
 			}
 
@@ -914,7 +913,7 @@ void Mode7Sprite2D::_update_follow_cache() {
 }
 
 void Mode7Sprite2D::force_update_follow_cache() {
-	_update_follow_cache();
+	_ensure_follow_physics();
 }
 
 void Mode7Sprite2D::_bind_methods() {

--- a/scene/2d/mode7_sprite_2d.h
+++ b/scene/2d/mode7_sprite_2d.h
@@ -172,6 +172,10 @@ private:
 	/// ensuring follow starts as soon as the tree is ready.
 	void _ensure_follow_physics();
 
+	/// Surfaces a warning icon in the Scene dock when mode7_region_follow_target is set
+	/// but does not currently resolve to a Node2D
+	PackedStringArray get_configuration_warnings() const override;
+
 	/// @name Horizon masks
 	real_t mode7_top_horizon_mask_amount = 0.0f; ///< 0..1 fraction to make transparent (from top down)
 	real_t mode7_top_horizon_tilt = 0.0f; ///< Stored internally in radians; the mode7_top_horizon_tilt property is exposed in degrees.
@@ -196,6 +200,8 @@ private:
 	/// @endGroup
 
 	Ref<Material> _saved_material;
+	void set_mode7_saved_material(const Ref<Material> &p_material);
+	Ref<Material> get_mode7_saved_material() const;
 };
 
 VARIANT_ENUM_CAST(Mode7Sprite2D::Mode7InterpolationMode);


### PR DESCRIPTION
Fixes a few issues where it was possible for the Mode 7 Enabled (save/load scene issue) & Follow Target properties to lose their state and require turning it off and then on again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented regenerated Mode7 shader materials from being saved unintentionally.
  * Preserved the original material across scene reloads when Mode7 is enabled.
  * Improved follow behavior when the target temporarily leaves the scene, allowing tracking to resume and re-align when it returns.
  * Improved follow updates initiated manually or outside the regular physics cycle.

* **Editor Improvements**
  * Added a configuration warning when the configured region follow target is missing or is not a valid 2D node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->