### PR TITLE
Switch to LLVM-MinGW for Windows  release builds

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -12,6 +12,8 @@ env:
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
   SCONS_CACHE_MSVC_CONFIG: true
   PYTHONIOENCODING: utf8
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
   build-windows:
@@ -88,7 +90,7 @@ jobs:
       - name: Download pre-built AccessKit
         uses: dsaltares/fetch-gh-release-asset@1.1.2
         with:
-          repo: AccessKit/accesskit-c
+          repo: godotengine/godot-accesskit-c-static
           version: tags/0.17.0
           file: accesskit-c-0.17.0.zip
           target: accesskit-c-0.17.0/accesskit_c.zip
@@ -125,3 +127,139 @@ jobs:
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help
           ${{ matrix.bin }} --test --force-colors
+
+  build-windows-mono:
+    runs-on: ubuntu-24.04
+    name: Editor w/ Mono (cross-compiled with LLVM)
+    timeout-minutes: 120
+    env:
+      LLVM_MINGW_VERSION: "20251118"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Restore Godot build cache
+        uses: ./.github/actions/godot-cache-restore
+        with:
+          cache-name: windows-editor-mono-llvm-${{ env.LLVM_MINGW_VERSION }}
+        continue-on-error: true
+
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
+      - name: Free disk space on runner
+        run: sudo rm -rf /usr/local/lib/android
+
+      - name: Setup LLVM-MinGW
+        shell: bash
+        run: |
+          archive="${RUNNER_TEMP}/llvm-mingw.tar.xz"
+          toolchain="${RUNNER_TEMP}/llvm-mingw"
+          curl --fail --location --retry 3 \
+            --output "${archive}" \
+            "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-22.04-x86_64.tar.xz"
+          mkdir -p "${toolchain}"
+          tar -xf "${archive}" --strip-components=1 -C "${toolchain}"
+          echo "${toolchain}/bin" >> "${GITHUB_PATH}"
+
+      - name: Download pre-built AccessKit
+        uses: dsaltares/fetch-gh-release-asset@1.1.2
+        with:
+          repo: godotengine/godot-accesskit-c-static
+          version: tags/0.17.0
+          file: accesskit-c-0.17.0.zip
+          target: accesskit-c-0.17.0/accesskit_c.zip
+
+      - name: Extract pre-built AccessKit
+        run: unzip -o accesskit-c-0.17.0/accesskit_c.zip
+
+      - name: Verify LLVM AccessKit static library
+        shell: bash
+        run: test -f accesskit-c-0.17.0/lib/windows/x86_64/mingw-llvm/static/libaccesskit.a
+
+      - name: Compilation
+        uses: ./.github/actions/godot-build
+        with:
+          scons-flags: >-
+            dev_mode=yes
+            module_text_server_fb_enabled=yes
+            debug_symbols=no
+            module_mono_enabled=yes
+            use_mingw=yes
+            use_llvm=yes
+            windows_subsystem=console
+            "mingw_prefix=${{ runner.temp }}/llvm-mingw"
+            "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
+          platform: windows
+          target: editor
+
+      - name: Save Godot build cache
+        uses: ./.github/actions/godot-cache-save
+        with:
+          cache-name: windows-editor-mono-llvm-${{ env.LLVM_MINGW_VERSION }}
+        continue-on-error: true
+
+      - name: Upload cross-compiled editor
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: windows-editor-mono-llvm-native
+          path: |
+            bin/redot.windows.editor.x86_64.llvm.mono.exe
+            bin/*.dll
+
+  test-windows-mono:
+    needs: build-windows-mono
+    runs-on: windows-latest
+    name: Editor w/ Mono (.NET glue and tests)
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Download cross-compiled editor
+        uses: ./.github/actions/download-artifact
+        with:
+          name: windows-editor-mono-llvm-native
+          path: bin
+
+      - name: Setup Python and SCons
+        uses: ./.github/actions/godot-deps
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.100
+
+      - name: Generate C# glue
+        shell: pwsh
+        run: |
+          ./bin/redot.windows.editor.x86_64.llvm.mono.exe --headless --generate-mono-glue ./modules/mono/glue
+
+      - name: Build RedotSharp and tools
+        shell: pwsh
+        run: |
+          dotnet --info
+          python ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows --werror
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: windows-editor-mono-llvm
+
+      - name: Unit tests
+        shell: pwsh
+        run: |
+          ./bin/redot.windows.editor.x86_64.llvm.mono.exe --version
+          ./bin/redot.windows.editor.x86_64.llvm.mono.exe --help
+          ./bin/redot.windows.editor.x86_64.llvm.mono.exe --headless --test --force-colors
+
+      - name: .NET source generators tests
+        shell: pwsh
+        run: |
+          dotnet test modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,8 +126,7 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
+    - export OPTIONS="production=yes use_mingw=yes use_llvm=yes mingw_prefix=$MINGW_PREFIX angle_libs=$WINDOWS_DEPS_ROOT/angle mesa_libs=$WINDOWS_DEPS_ROOT/mesa agility_sdk_path=$WINDOWS_DEPS_ROOT/agility_sdk d3d12=yes"
   variables:
     PLATFORM: "windows"
 
@@ -138,8 +137,7 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
+    - export OPTIONS="production=yes use_mingw=yes use_llvm=yes mingw_prefix=$MINGW_PREFIX angle_libs=$WINDOWS_DEPS_ROOT/angle mesa_libs=$WINDOWS_DEPS_ROOT/mesa agility_sdk_path=$WINDOWS_DEPS_ROOT/agility_sdk d3d12=yes"
   variables:
     PLATFORM: "windows"
 
@@ -150,20 +148,13 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
+    - export OPTIONS="production=yes use_mingw=yes use_llvm=yes mingw_prefix=$MINGW_PREFIX angle_libs=$WINDOWS_DEPS_ROOT/angle mesa_libs=$WINDOWS_DEPS_ROOT/mesa agility_sdk_path=$WINDOWS_DEPS_ROOT/agility_sdk d3d12=yes"
   script:
     - !reference [ .build-release-template, script ]
   after_script:
     - if [ "$TARGET" == "template_debug" ]; then export FRIENDLY_TARGET="debug"; else export FRIENDLY_TARGET="release"; fi
-    - |
-      if [ "$ARCH" == "arm64" ]; then
-      mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
-      mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.console.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
-      else
-      mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
-      mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.console.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
-      fi
+    - mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
+    - mv "out/templates/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.console.exe" "out/templates/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
   variables:
     PLATFORM: "windows"
   artifacts:
@@ -179,20 +170,13 @@ stages:
   image: $CI_REGISTRY/redot-engine/redot-production-containers/redot-windows:latest
   before_script:
     - !reference [.template-build, before_script]
-    - python3 ./misc/scripts/install_d3d12_sdk_windows.py
-    - export OPTIONS="production=yes use_mingw=yes angle_libs=$(pwd)/deps/angle mesa_libs=$(pwd)/deps/mesa d3d12=yes"
+    - export OPTIONS="production=yes use_mingw=yes use_llvm=yes mingw_prefix=$MINGW_PREFIX angle_libs=$WINDOWS_DEPS_ROOT/angle mesa_libs=$WINDOWS_DEPS_ROOT/mesa agility_sdk_path=$WINDOWS_DEPS_ROOT/agility_sdk d3d12=yes"
   script:
     - !reference [ .build-release-template-mono, script ]
   after_script:
     - if [ "$TARGET" == "template_debug" ]; then export FRIENDLY_TARGET="debug"; else export FRIENDLY_TARGET="release"; fi
-    - |
-      if [ "$ARCH" == "arm64" ]; then
-      mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.mono.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
-      mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.mono.console.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
-      else
-      mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.mono.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
-      mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.mono.console.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
-      fi
+    - mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.mono.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}.exe"
+    - mv "out/templates-mono/redot.${PLATFORM}.${TARGET}.${ARCH}.llvm.mono.console.exe" "out/templates-mono/windows_${FRIENDLY_TARGET}_${ARCH}_console.exe"
   variables:
     PLATFORM: "windows"
   artifacts:


### PR DESCRIPTION
## Purpose

Updated the release pipeline to use LLVM to compile Windows x64 builds, and updated the GitHub workflows to test cross compilation of a Windows editor through LLVM.

## Why

Cross compiling through standard MinGW tends to take forever which makes it not viable for for automated testing on GitHub Runners, taking up to an hour and a half when we tried.

LLVM does the job much faster and consistently.

I have already done initial testing on the internal GitLab pipeline for release builds, so those work.
Once I have confirmed that the new GHA that was added works, we should be ready for merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Windows Mono editor builds and artifact packaging.
  * Added automated validation for generated C# assemblies, unit tests, and source generator tests.

* **Build Improvements**
  * Standardized Windows builds across architectures using LLVM.
  * Updated release packaging to use consistent executable naming across supported Windows architectures.
  * Improved the reliability and consistency of Windows build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->