### PR TITLE
Fix Handling of `@export_group` in GDScript traits

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2062,6 +2062,9 @@ void GDScriptAnalyzer::resolve_class_uses(GDScriptParser::ClassNode *p_class, co
 			GDScriptParser::DataType class_base_type = p_class->base_type;
 			if (class_base_type.kind == GDScriptParser::DataType::NATIVE && class_base_type.native_type != SNAME("RefCounted")) {
 				for (const GDScriptParser::ClassNode::Member &member : trait->members) {
+					if (member.type == GDScriptParser::ClassNode::Member::GROUP) {
+						continue;
+					}
 					if (ClassDB::has_enum(class_base_type.native_type, member.get_name()) ||
 							ClassDB::has_signal(class_base_type.native_type, member.get_name()) ||
 							ClassDB::has_method(class_base_type.native_type, member.get_name()) ||
@@ -2074,6 +2077,9 @@ void GDScriptAnalyzer::resolve_class_uses(GDScriptParser::ClassNode *p_class, co
 				GDScriptParser::ClassNode *parent = class_base_type.class_type;
 				while (parent != nullptr && inheritance_match) {
 					for (const GDScriptParser::ClassNode::Member &member : trait->members) {
+						if (member.type == GDScriptParser::ClassNode::Member::GROUP) {
+							continue;
+						}
 						if (parent->has_member(member.get_name())) {
 							inheritance_match = false;
 							break;
@@ -7650,6 +7656,23 @@ void GDScriptAnalyzer::extend_class(GDScriptParser::ClassNode *p_class, const GD
 	for (int i = 0; i < p_trait->members.size(); i++) {
 		GDScriptParser::ClassNode::Member trait_member = p_trait->members[i];
 		if (trait_member.type == GDScriptParser::ClassNode::Member::TRAIT) {
+			continue;
+		}
+		if (trait_member.type == GDScriptParser::ClassNode::Member::GROUP) {
+			bool copied_over = trait_member.get_source_node()->trait_origin.has(p_class->fqcn);
+			for (const StringName &trait_fqcn : p_class->traits_fqtn) {
+				if (!copied_over && trait_member.get_source_node()->trait_origin.has(trait_fqcn)) {
+					copied_over = true;
+					break;
+				}
+			}
+			if (copied_over) {
+				continue;
+			}
+			p_class->add_member_group(trait_member.annotation);
+			if (!trait_member.get_source_node()->trait_origin.has(p_trait->fqcn)) {
+				trait_member.get_source_node()->trait_origin.append(p_trait->fqcn);
+			}
 			continue;
 		}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -880,9 +880,7 @@ public:
 			members.push_back(Member(p_enum_value));
 		}
 		void add_member_group(AnnotationNode *p_annotation_node) {
-			// Avoid name conflict. See GH-78252.
-			StringName name = vformat("@group_%d_%s", members.size(), p_annotation_node->export_info.name);
-			members_indices[name] = members.size();
+			// Groups are ordered Inspector metadata, not named class members.
 			members.push_back(Member(p_annotation_node));
 		}
 

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_export_groups.gd
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_export_groups.gd
@@ -1,0 +1,76 @@
+extends Node
+uses GroupTrait, CategoryTrait, SubgroupTrait, RepeatedGroupTrait
+
+# GH-1395
+@export var trait_group_name: int
+
+trait GroupTrait:
+	@export_group("trait_group_name")
+	@export var group_value: int
+
+trait CategoryTrait:
+	@export_category("queue_free")
+	@export var category_value: int
+
+trait SubgroupTrait:
+	@export_subgroup("First-position Subgroup")
+	@export var subgroup_value: int
+
+trait RepeatedGroupTrait:
+	@export_group("trait_group_name")
+	@export var repeated_group_value: int
+
+trait InheritedGroupTrait:
+	@export_group("inherited_group_name")
+	@export var inherited_group_value: int
+
+class ScriptBase:
+	var inherited_group_name: int
+
+class ScriptChild extends ScriptBase:
+	uses InheritedGroupTrait
+
+trait SharedTrait:
+	@export_group("Shared Trait")
+	@export var shared_value: int
+
+trait LeftTrait:
+	uses SharedTrait
+	@export var left_value: int
+
+trait RightTrait:
+	uses SharedTrait
+	@export var right_value: int
+
+class DiamondClass:
+	uses LeftTrait, RightTrait
+
+func get_export_signatures(object: Object, names: Array[String]) -> Array[String]:
+	var signatures: Array[String]
+	for property in object.get_property_list():
+		if property.name in names:
+			signatures.append(Utils.get_property_signature(property))
+	return signatures
+
+func test():
+	var export_signatures := get_export_signatures(self, [
+		"trait_group_name",
+		"group_value",
+		"queue_free",
+		"category_value",
+		"First-position Subgroup",
+		"subgroup_value",
+		"repeated_group_value",
+	])
+	for signature in export_signatures:
+		print(signature)
+
+	var inherited := ScriptChild.new()
+	var inherited_signatures := get_export_signatures(inherited, ["inherited_group_name", "inherited_group_value"])
+	for signature in inherited_signatures:
+		print(signature)
+
+	var diamond := DiamondClass.new()
+	var diamond_signatures := get_export_signatures(diamond, ["Shared Trait", "shared_value", "left_value", "right_value"])
+	for signature in diamond_signatures:
+		print(signature)

--- a/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_export_groups.out
+++ b/modules/gdscript/tests/scripts/Traits/analyzer/features/trait_export_groups.out
@@ -1,0 +1,17 @@
+GDTEST_OK
+var trait_group_name: int
+@export_group("trait_group_name")
+var group_value: int
+@export_category("queue_free")
+var category_value: int
+@export_subgroup("First-position Subgroup")
+var subgroup_value: int
+@export_group("trait_group_name")
+var repeated_group_value: int
+@export_group("inherited_group_name")
+var inherited_group_value: int
+var inherited_group_name: int
+var left_value: int
+@export_group("Shared Trait")
+var shared_value: int
+var right_value: int


### PR DESCRIPTION
- Add support for `@export_group` metadata in GDScript traits, enabling organized property grouping.
- Update analyzer to manage export group traits without processing them as class members.
- Extend tests to cover export group functionality, including inheritance and shared traits scenarios.
- Refactor `add_member_group` logic to avoid naming conflicts.

Fixes #1395 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed exported property groups when using traits and inherited scripts.
  - Group annotations now remain correctly associated with their originating traits.
  - Prevented duplicate groups from appearing when traits are combined or inherited, including complex shared-trait setups.
  - Improved handling of categories, subgroups, repeated groups, and inherited groups in the Inspector.
- **Tests**
  - Added coverage for exported groups across trait composition and script inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->