### PR TITLE
wayland-protocols: Update to 1.45

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1185,7 +1185,7 @@ Files extracted from upstream source:
 # wayland-protocols
 
 - Upstream: https://gitlab.freedesktop.org/wayland/wayland-protocols
-- Version: 1.33 (54346071a5f211f2c482889f2c8ee3b5ecda63ab, 2024)
+- Version: 1.45 (0091197f5c1b1f2c131f1410e99f9c95d50646be, 2025)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/wayland-protocols/stable/tablet/README
+++ b/thirdparty/wayland-protocols/stable/tablet/README
@@ -1,4 +1,4 @@
 Tablet protocol
 
 Maintainers:
-Peter Hutterer <peter.hutterer@who-t.net>
+Peter Hutterer <peter.hutterer@who-t.net> (@whot)

--- a/thirdparty/wayland-protocols/stable/tablet/tablet-v2.xml
+++ b/thirdparty/wayland-protocols/stable/tablet/tablet-v2.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="tablet_unstable_v2">
+<protocol name="tablet_v2">
 
   <copyright>
     Copyright 2014 © Stephen "Lyude" Chandler Paul
-    Copyright 2015-2016 © Red Hat, Inc.
+    Copyright 2015-2024 © Red Hat, Inc.
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation files
@@ -104,18 +104,9 @@
     compositor-specific policy when a tool can be removed. Common approaches
     will likely include some form of removing a tool when all tablets the
     tool was used on are removed.
-
-    Warning! The protocol described in this file is experimental and
-    backward incompatible changes may be made. Backward compatible changes
-    may be added together with the corresponding interface version bump.
-    Backward incompatible changes are done by bumping the version number in
-    the protocol and interface names and resetting the interface version.
-    Once the protocol is to be declared stable, the 'z' prefix and the
-    version number in the protocol and interface names are removed and the
-    interface version number is reset.
   </description>
 
-  <interface name="zwp_tablet_manager_v2" version="1">
+  <interface name="zwp_tablet_manager_v2" version="2">
     <description summary="controller object for graphic tablet devices">
       An object that provides access to the graphics tablets available on this
       system. All tablets are associated with a seat, to get access to the
@@ -139,7 +130,7 @@
     </request>
   </interface>
 
-  <interface name="zwp_tablet_seat_v2" version="1">
+  <interface name="zwp_tablet_seat_v2" version="2">
     <description summary="controller object for graphic tablet devices of a seat">
       An object that provides access to the graphics tablets available on this
       seat. After binding to this interface, the compositor sends a set of
@@ -190,7 +181,7 @@
     </event>
   </interface>
 
-  <interface name="zwp_tablet_tool_v2" version="1">
+  <interface name="zwp_tablet_tool_v2" version="2">
     <description summary="a physical tablet tool">
       An object that represents a physical tool that has been, or is
       currently in use with a tablet in this seat. Each wp_tablet_tool
@@ -576,7 +567,7 @@
     </enum>
   </interface>
 
-  <interface name="zwp_tablet_v2" version="1">
+  <interface name="zwp_tablet_v2" version="2">
     <description summary="graphics tablet device">
       The wp_tablet interface represents one graphics tablet device. The
       tablet interface itself does not generate events; all events are
@@ -596,19 +587,33 @@
 
     <event name="name">
       <description summary="tablet device name">
+        A descriptive name for the tablet device.
+
+	If the device has no descriptive name, this event is not sent.
+
 	This event is sent in the initial burst of events before the
-	wp_tablet.done event.
+        wp_tablet.done event.
       </description>
       <arg name="name" type="string" summary="the device name"/>
     </event>
 
     <event name="id">
-      <description summary="tablet device USB vendor/product id">
+      <description summary="tablet device vendor/product id">
+	The vendor and product IDs for the tablet device.
+
+	The interpretation of the id depends on the wp_tablet.bustype.
+	Prior to version v2 of this protocol, the id was implied to be a USB
+	vendor and product ID. If no wp_tablet.bustype is sent, the ID
+	is to be interpreted as USB vendor and product ID.
+
+	If the device has no vendor/product ID, this event is not sent.
+	This can happen for virtual devices or non-USB devices, for instance.
+
 	This event is sent in the initial burst of events before the
 	wp_tablet.done event.
       </description>
-      <arg name="vid" type="uint" summary="USB vendor id"/>
-      <arg name="pid" type="uint" summary="USB product id"/>
+      <arg name="vid" type="uint" summary="vendor id"/>
+      <arg name="pid" type="uint" summary="product id"/>
     </event>
 
     <event name="path">
@@ -649,9 +654,36 @@
 	the object.
       </description>
     </event>
+
+    <!-- Version 2 additions -->
+
+    <enum name="bustype" since="2">
+      <description summary="bus type ">
+	Describes the bus types this tablet is connected to.
+      </description>
+      <entry name="usb" value="3" summary="USB"/>
+      <entry name="bluetooth" value="5" summary="Bluetooth"/>
+      <entry name="virtual" value="6" summary="Virtual"/>
+      <entry name="serial" value="17" summary="Serial"/>
+      <entry name="i2c" value="24" summary="I2C"/>
+    </enum>
+
+    <event name="bustype" since="2">
+      <description summary="tablet device bus type">
+	The bustype argument is one of the BUS_ defines in the Linux kernel's
+	linux/input.h
+
+	If the device has no known bustype or the bustype cannot be
+	queried, this event is not sent.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="bustype" type="uint" enum="bustype" summary="bus type"/>
+    </event>
   </interface>
 
-  <interface name="zwp_tablet_pad_ring_v2" version="1">
+  <interface name="zwp_tablet_pad_ring_v2" version="2">
     <description summary="pad ring">
       A circular interaction area, such as the touch ring on the Wacom Intuos
       Pro series tablets.
@@ -765,7 +797,7 @@
     </event>
   </interface>
 
-  <interface name="zwp_tablet_pad_strip_v2" version="1">
+  <interface name="zwp_tablet_pad_strip_v2" version="2">
     <description summary="pad strip">
       A linear interaction area, such as the strips found in Wacom Cintiq
       models.
@@ -881,7 +913,7 @@
     </event>
   </interface>
 
-  <interface name="zwp_tablet_pad_group_v2" version="1">
+  <interface name="zwp_tablet_pad_group_v2" version="2">
     <description summary="a set of buttons, rings and strips">
       A pad group describes a distinct (sub)set of buttons, rings and strips
       present in the tablet. The criteria of this grouping is usually positional,
@@ -984,14 +1016,14 @@
       <description summary="mode switch event">
 	Notification that the mode was switched.
 
-	A mode applies to all buttons, rings and strips in a group
+	A mode applies to all buttons, rings, strips and dials in a group
 	simultaneously, but a client is not required to assign different actions
 	for each mode. For example, a client may have mode-specific button
 	mappings but map the ring to vertical scrolling in all modes. Mode
 	indices start at 0.
 
 	Switching modes is compositor-dependent. The compositor may provide
-	visual cues to the client about the mode, e.g. by toggling LEDs on
+	visual cues to the user about the mode, e.g. by toggling LEDs on
 	the tablet device. Mode-switching may be software-controlled or
 	controlled by one or more physical buttons. For example, on a Wacom
 	Intuos Pro, the button inside the ring may be assigned to switch
@@ -1005,20 +1037,33 @@
 	previous mode, the client should immediately issue a
 	wp_tablet_pad.set_feedback request for each changed button.
 
-	If a ring or strip action in the new mode differs from the action
+	If a ring, strip or dial action in the new mode differs from the action
 	in the previous mode, the client should immediately issue a
-	wp_tablet_ring.set_feedback or wp_tablet_strip.set_feedback request
-	for each changed ring or strip.
+	wp_tablet_ring.set_feedback, wp_tablet_strip.set_feedback or
+	wp_tablet_dial.set_feedback request for each changed ring, strip or dial.
       </description>
       <arg name="time" type="uint" summary="the time of the event with millisecond granularity"/>
       <arg name="serial" type="uint"/>
       <arg name="mode" type="uint" summary="the new mode of the pad"/>
     </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="dial" since="2">
+      <description summary="dial announced">
+	Sent on wp_tablet_pad initialization to announce available dials.
+	One event is sent for each dial available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="dial" type="new_id" interface="zwp_tablet_pad_dial_v2"/>
+    </event>
   </interface>
 
-  <interface name="zwp_tablet_pad_v2" version="1">
-    <description summary="a set of buttons, rings and strips">
-      A pad device is a set of buttons, rings and strips
+  <interface name="zwp_tablet_pad_v2" version="2">
+    <description summary="a set of buttons, rings, strips and dials">
+      A pad device is a set of buttons, rings, strips and dials
       usually physically present on the tablet device itself. Some
       exceptions exist where the pad device is physically detached, e.g. the
       Wacom ExpressKey Remote.
@@ -1032,7 +1077,7 @@
       This initial event sequence is terminated by a wp_tablet_pad.done
       event.
 
-      All pad features (buttons, rings and strips) are logically divided into
+      All pad features (buttons, rings, strips and dials) are logically divided into
       groups and all pads have at least one group. The available groups are
       notified through the wp_tablet_pad.group event; the compositor will
       emit one event per group before emitting wp_tablet_pad.done.
@@ -1173,6 +1218,80 @@
 	and groups that were offered by this pad, and issue wp_tablet_pad.destroy
 	the pad itself.
       </description>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_dial_v2" version="2">
+    <description summary="pad dial">
+      A rotary control, e.g. a dial or a wheel.
+
+      Events on a dial are logically grouped by the wl_tablet_pad_dial.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this dial. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the dial is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the dial, and compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	dial. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="dial description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the dial object">
+	This destroys the client's resource for this dial object.
+      </description>
+    </request>
+
+    <event name="delta">
+      <description summary="delta movement">
+	Sent whenever the position on a dial changes.
+
+	This event carries the wheel delta as multiples or fractions
+	of 120 with each multiple of 120 representing one logical wheel detent.
+	For example, an axis_value120 of 30 is one quarter of
+	a logical wheel step in the positive direction, a value120 of
+	-240 are two logical wheel steps in the negative direction within the
+	same hardware event. See the wl_pointer.axis_value120 for more details.
+
+	The value120 must not be zero.
+      </description>
+      <arg name="value120" type="int" summary="rotation distance as fraction of 120"/>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a dial event sequence">
+	Indicates the end of a set of events that represent one logical
+	hardware dial event. A client is expected to accumulate the data
+	in all events within the frame before proceeding.
+
+	All wp_tablet_pad_dial events before a wp_tablet_pad_dial.frame event belong
+	logically together.
+
+	A wp_tablet_pad_dial.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_dial
+	event. Specifically, a client may get a sequence: delta, frame,
+	delta, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
     </event>
   </interface>
 </protocol>

--- a/thirdparty/wayland-protocols/stable/viewporter/README
+++ b/thirdparty/wayland-protocols/stable/viewporter/README
@@ -3,5 +3,5 @@ Viewporter: cropping and scaling extension for surface contents
 Previously known as wl_scaler.
 
 Maintainers:
-Pekka Paalanen <pekka.paalanen@collabora.co.uk>
+Pekka Paalanen <pekka.paalanen@collabora.co.uk> (@pq)
 

--- a/thirdparty/wayland-protocols/stable/viewporter/viewporter.xml
+++ b/thirdparty/wayland-protocols/stable/viewporter/viewporter.xml
@@ -71,8 +71,7 @@
       src_y, src_width, src_height), and the destination size (dst_width,
       dst_height). The contents of the source rectangle are scaled to the
       destination size, and content outside the source rectangle is ignored.
-      This state is double-buffered, and is applied on the next
-      wl_surface.commit.
+      This state is double-buffered, see wl_surface.commit.
 
       The two parts of crop and scale state are independent: the source
       rectangle, and the destination size. Initially both are unset, that
@@ -149,8 +148,7 @@
 	or negative, or x or y are negative, raise the bad_value protocol
 	error.
 
-	The crop and scale state is double-buffered state, and will be
-	applied on the next wl_surface.commit.
+	The crop and scale state is double-buffered, see wl_surface.commit.
       </description>
       <arg name="x" type="fixed" summary="source rectangle x"/>
       <arg name="y" type="fixed" summary="source rectangle y"/>
@@ -169,8 +167,7 @@
 	contains zero or negative values raises the bad_value protocol
 	error.
 
-	The crop and scale state is double-buffered state, and will be
-	applied on the next wl_surface.commit.
+	The crop and scale state is double-buffered, see wl_surface.commit.
       </description>
       <arg name="width" type="int" summary="surface width"/>
       <arg name="height" type="int" summary="surface height"/>

--- a/thirdparty/wayland-protocols/stable/xdg-shell/README
+++ b/thirdparty/wayland-protocols/stable/xdg-shell/README
@@ -1,5 +1,5 @@
 xdg shell protocol
 
 Maintainers:
-Jonas Ådahl <jadahl@gmail.com>
-Mike Blumenkrantz <michael.blumenkrantz@gmail.com>
+Jonas Ådahl <jadahl@gmail.com> (@jadahl)
+Mike Blumenkrantz <michael.blumenkrantz@gmail.com> (@zmike)

--- a/thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml
+++ b/thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml
@@ -29,7 +29,7 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="xdg_wm_base" version="6">
+  <interface name="xdg_wm_base" version="7">
     <description summary="create desktop-style surfaces">
       The xdg_wm_base interface is exposed as a global object enabling clients
       to turn their wl_surfaces into windows in a desktop environment. It
@@ -122,7 +122,7 @@
     </event>
   </interface>
 
-  <interface name="xdg_positioner" version="6">
+  <interface name="xdg_positioner" version="7">
     <description summary="child surface positioner">
       The xdg_positioner provides a collection of rules for the placement of a
       child surface relative to a parent surface. Rules can be defined to ensure
@@ -344,7 +344,7 @@
 
 	The default adjustment is none.
       </description>
-      <arg name="constraint_adjustment" type="uint"
+      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
 	   summary="bit mask of constraint adjustments"/>
     </request>
 
@@ -407,7 +407,7 @@
     </request>
   </interface>
 
-  <interface name="xdg_surface" version="6">
+  <interface name="xdg_surface" version="7">
     <description summary="desktop user interface surface base interface">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
@@ -434,7 +434,8 @@
       manipulate a buffer prior to the first xdg_surface.configure call must
       also be treated as errors.
 
-      After creating a role-specific object and setting it up, the client must
+      After creating a role-specific object and setting it up (e.g. by sending
+      the title, app ID, size constraints, parent, etc), the client must
       perform an initial commit without any buffer attached. The compositor
       will reply with initial wl_surface state such as
       wl_surface.preferred_buffer_scale followed by an xdg_surface.configure
@@ -515,8 +516,7 @@
 	portions like drop-shadows which should be ignored for the
 	purposes of aligning, placing and constraining windows.
 
-	The window geometry is double buffered, and will be applied at the
-	time wl_surface.commit of the corresponding wl_surface is called.
+	The window geometry is double-buffered state, see wl_surface.commit.
 
 	When maintaining a position, the compositor should treat the (x, y)
 	coordinate of the window geometry as the top left corner of the window.
@@ -617,7 +617,7 @@
 
   </interface>
 
-  <interface name="xdg_toplevel" version="6">
+  <interface name="xdg_toplevel" version="7">
     <description summary="toplevel surface">
       This interface defines an xdg_surface role which allows a surface to,
       among other things, set window-like properties such as maximize,
@@ -635,7 +635,7 @@
       attributes (e.g. title, state, stacking, ...) are discarded for
       an xdg_toplevel surface when it is unmapped. The xdg_toplevel returns to
       the state it had right after xdg_surface.get_toplevel. The client
-      can re-map the toplevel by perfoming a commit without any buffer
+      can re-map the toplevel by performing a commit without any buffer
       attached, waiting for a configure event and handling it as usual (see
       xdg_surface description).
 
@@ -832,8 +832,7 @@
 	configure event to ensure that both the client and the compositor
 	setting the state can be synchronized.
 
-	States set in this way are double-buffered. They will get applied on
-	the next commit.
+	States set in this way are double-buffered, see wl_surface.commit.
       </description>
       <entry name="maximized" value="1" summary="the surface is maximized">
 	<description summary="the surface is maximized">
@@ -873,24 +872,36 @@
 	<description summary="the surface’s left edge is tiled">
 	  The window is currently in a tiled layout and the left edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the left edge.
 	</description>
       </entry>
       <entry name="tiled_right" value="6" since="2">
 	<description summary="the surface’s right edge is tiled">
 	  The window is currently in a tiled layout and the right edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the right edge.
 	</description>
       </entry>
       <entry name="tiled_top" value="7" since="2">
 	<description summary="the surface’s top edge is tiled">
 	  The window is currently in a tiled layout and the top edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the top edge.
 	</description>
       </entry>
       <entry name="tiled_bottom" value="8" since="2">
 	<description summary="the surface’s bottom edge is tiled">
 	  The window is currently in a tiled layout and the bottom edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the bottom edge.
 	</description>
       </entry>
       <entry name="suspended" value="9" since="6">
@@ -898,6 +909,38 @@
 	  The surface is currently not ordinarily being repainted; for
 	  example because its content is occluded by another window, or its
 	  outputs are switched off due to screen locking.
+	</description>
+      </entry>
+      <entry name="constrained_left" value="10" since="7">
+	<description summary="the surface’s left edge is constrained">
+          The left edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_right" value="11" since="7">
+	<description summary="the surface’s right edge is constrained">
+          The right edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_top" value="12" since="7">
+	<description summary="the surface’s top edge is constrained">
+          The top edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
+	</description>
+      </entry>
+      <entry name="constrained_bottom" value="13" since="7">
+	<description summary="the surface’s bottom edge is tiled">
+          The bottom edge of the window is currently constrained, meaning it
+          shouldn't attempt to resize from that edge. It can for example mean
+          it's tiled next to a monitor edge on the constrained side of the
+          window.
 	</description>
       </entry>
     </enum>
@@ -912,8 +955,7 @@
 	The width and height arguments are in window geometry coordinates.
 	See xdg_surface.set_window_geometry.
 
-	Values set in this way are double-buffered. They will get applied
-	on the next commit.
+	Values set in this way are double-buffered, see wl_surface.commit.
 
 	The compositor can use this information to allow or disallow
 	different states like maximize or fullscreen and draw accurate
@@ -953,8 +995,7 @@
 	The width and height arguments are in window geometry coordinates.
 	See xdg_surface.set_window_geometry.
 
-	Values set in this way are double-buffered. They will get applied
-	on the next commit.
+	Values set in this way are double-buffered, see wl_surface.commit.
 
 	The compositor can use this information to allow or disallow
 	different states like maximize or fullscreen and draw accurate
@@ -1198,7 +1239,7 @@
     </event>
   </interface>
 
-  <interface name="xdg_popup" version="6">
+  <interface name="xdg_popup" version="7">
     <description summary="short-lived, popup surfaces for menus">
       A popup surface is a short-lived, temporary surface. It can be used to
       implement for example menus, popovers, tooltips and other similar user

--- a/thirdparty/wayland-protocols/staging/fractional-scale/README
+++ b/thirdparty/wayland-protocols/staging/fractional-scale/README
@@ -1,4 +1,4 @@
 wp fractional scale protocol
 
 Maintainers:
-Kenny Levinsen <kl@kl.wtf>
+Kenny Levinsen <kl@kl.wtf> (@kennylevinsen)

--- a/thirdparty/wayland-protocols/staging/xdg-activation/README
+++ b/thirdparty/wayland-protocols/staging/xdg-activation/README
@@ -1,4 +1,4 @@
 XDG Activation protocol
 
 Maintainers:
-Aleix Pol Gonzalez <aleixpol@kde.org>
+Aleix Pol Gonzalez <aleixpol@kde.org> (@apol)

--- a/thirdparty/wayland-protocols/unstable/pointer-constraints/README
+++ b/thirdparty/wayland-protocols/unstable/pointer-constraints/README
@@ -1,4 +1,4 @@
 Pointer constraints protocol
 
 Maintainers:
-Jonas Ådahl <jadahl@gmail.com>
+Jonas Ådahl <jadahl@gmail.com> (@jadahl)

--- a/thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
+++ b/thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
@@ -225,9 +225,8 @@
 	information to warp the pointer upon unlock in order to avoid pointer
 	jumps.
 
-	The cursor position hint is double buffered. The new hint will only take
-	effect when the associated surface gets it pending state applied. See
-	wl_surface.commit for details.
+	The cursor position hint is double-buffered state, see
+	wl_surface.commit.
       </description>
       <arg name="surface_x" type="fixed"
 	   summary="surface-local x coordinate"/>
@@ -239,9 +238,7 @@
       <description summary="set a new lock region">
 	Set a new region used to lock the pointer.
 
-	The new lock region is double-buffered. The new lock region will
-	only take effect when the associated surface gets its pending state
-	applied. See wl_surface.commit for details.
+	The new lock region is double-buffered, see wl_surface.commit.
 
 	For details about the lock region, see wp_locked_pointer.
       </description>
@@ -298,9 +295,7 @@
       <description summary="set a new confine region">
 	Set a new region used to confine the pointer.
 
-	The new confine region is double-buffered. The new confine region will
-	only take effect when the associated surface gets its pending state
-	applied. See wl_surface.commit for details.
+	The new confine region is double-buffered, see wl_surface.commit.
 
 	If the confinement is active when the new confinement region is applied
 	and the pointer ends up outside of newly applied region, the pointer may

--- a/thirdparty/wayland-protocols/unstable/pointer-gestures/README
+++ b/thirdparty/wayland-protocols/unstable/pointer-gestures/README
@@ -1,4 +1,4 @@
 Pointer gestures protocol
 
 Maintainers:
-Carlos Garnacho <carlosg@gnome.org>
+Carlos Garnacho <carlosg@gnome.org> (@carlosg)

--- a/thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml
+++ b/thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml
@@ -8,7 +8,7 @@
 
       Three gestures are currently supported: swipe, pinch, and hold.
       Pinch and swipe gestures follow a three-stage cycle: begin, update,
-      end, hold gestures follow a two-stage cycle: begin and end. All
+      end. Hold gestures follow a two-stage cycle: begin and end. All
       gestures are identified by a unique id.
 
       Warning! The protocol described in this file is experimental and

--- a/thirdparty/wayland-protocols/unstable/primary-selection/README
+++ b/thirdparty/wayland-protocols/unstable/primary-selection/README
@@ -1,4 +1,4 @@
 Primary selection protocol
 
 Maintainers:
-Simon Ser <contact@emersion.fr>
+Simon Ser <contact@emersion.fr> (@emersion)

--- a/thirdparty/wayland-protocols/unstable/relative-pointer/README
+++ b/thirdparty/wayland-protocols/unstable/relative-pointer/README
@@ -1,4 +1,4 @@
 Relative pointer protocol
 
 Maintainers:
-Jonas Ådahl <jadahl@gmail.com>
+Jonas Ådahl <jadahl@gmail.com> (@jadahl)

--- a/thirdparty/wayland-protocols/unstable/text-input/README
+++ b/thirdparty/wayland-protocols/unstable/text-input/README
@@ -1,4 +1,4 @@
 Text input protocol
 
 Maintainers:
-Jan Arne Petersen <janarne@gmail.com>
+Jan Arne Petersen <janarne@gmail.com> (@jpetersen)

--- a/thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml
+++ b/thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml
@@ -89,16 +89,15 @@
         Requests text input on the surface previously obtained from the enter
         event.
 
-        This request must be issued every time the active text input changes
+        This request must be issued every time the focused text input changes
         to a new one, including within the current surface. Use
         zwp_text_input_v3.disable when there is no longer any input focus on
         the current surface.
 
         Clients must not enable more than one text input on the single seat
         and should disable the current text input before enabling the new one.
-        At most one instance of text input may be in enabled state per instance,
-        Requests to enable the another text input when some text input is active
-        must be ignored by compositor.
+        Requests to enable a text input when another text input is enabled
+        on the same seat must be ignored by compositor.
 
         This request resets all state associated with previous enable, disable,
         set_surrounding_text, set_text_change_cause, set_content_type, and

--- a/thirdparty/wayland-protocols/unstable/xdg-decoration/README
+++ b/thirdparty/wayland-protocols/unstable/xdg-decoration/README
@@ -1,4 +1,4 @@
 xdg_decoration protocol
 
 Maintainers:
-Simon Ser <contact@emersion.fr>
+Simon Ser <contact@emersion.fr> (@emersion)

--- a/thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+++ b/thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
@@ -88,6 +88,7 @@
         summary="xdg_toplevel already has a decoration object"/>
       <entry name="orphaned" value="2"
         summary="xdg_toplevel destroyed before the decoration object"/>
+      <entry name="invalid_mode" value="3" summary="invalid mode"/>
     </enum>
 
     <request name="destroy" type="destructor">
@@ -127,6 +128,9 @@
         Such clients are responsible for preventing configure loops and must
         make sure not to send multiple successive set_mode requests with the
         same decoration mode.
+
+        If an invalid mode is supplied by the client, the invalid_mode protocol
+        error is raised by the compositor.
       </description>
       <arg name="mode" type="uint" enum="mode" summary="the decoration mode"/>
     </request>

--- a/thirdparty/wayland-protocols/unstable/xdg-foreign/README
+++ b/thirdparty/wayland-protocols/unstable/xdg-foreign/README
@@ -1,4 +1,4 @@
 xdg foreign protocol
 
 Maintainers:
-Jonas Ådahl <jadahl@gmail.com>
+Jonas Ådahl <jadahl@gmail.com> (@jadahl)


### PR DESCRIPTION
Cherry-picks https://github.com/godotengine/godot/pull/107693
This PR is needed for the PR mentioned in #1330 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Wayland protocols to version 1.45.
  - Added tablet bus-type reporting and support for tablet-pad dials, including events and feedback.
  - Added new xdg-shell constrained-edge states.
  - Added validation reporting for invalid window-decoration modes.

- **Documentation**
  - Clarified protocol state buffering, gesture behavior, text-input rules, and window-management guidance.
  - Updated protocol maintainer and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->